### PR TITLE
:book: Improve punctuation for list items in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ edge-mc is a subproject of kcp focusing on concerns arising from edge multiclust
 
 - Collaboratively design a component set similar to those found in current KCP TMC implementation (dedicated Workspace type, scheduler, syncer-like mechanism, edge placement object definition, status collection strategy, and etc.)
 - Specify a multi-phased proof-of-concept inclusive of component architecture, interfaces, and example workloads
-- Validate phases of proof-of-concept with KCP, Kube SIG-Multicluster, and CNCF community members interested in Edge
+- Validate phases of proof-of-concept with KCP, Kube SIG-Multicluster, and CNCF community members interested in Edge.
 
 ## Areas of exploration
 
@@ -20,8 +20,8 @@ edge-mc is a subproject of kcp focusing on concerns arising from edge multiclust
 - Scheduling/syncing interface​: Need something that scales to large number of destinations​
 - Rollout control​: Client needs programmatic control of rollout, possibly including domain-specific logic​
 - Customization: Need a way for one pattern in the center to express how to customize for all the desired destinations​
-- Status from many destinations​: Center clients may need a way to access status from individual edge copies.​
-- Status summarization​: Client needs a way to say how statuses from edge copies are processed/reduced along the way from edge to center​
+- Status from many destinations​: Center clients may need a way to access status from individual edge copies
+- Status summarization​: Client needs a way to say how statuses from edge copies are processed/reduced along the way from edge to center​.
 
 ## Quickstart
 
@@ -37,4 +37,4 @@ We ❤️ our contributors! If you're interested in helping us out, please head 
 
 ## Getting in touch
 
-You may get in touch with us with the channels availabke in the [kcp-dev community](https://github.com/kcp-dev/kcp#getting-in-touch).
+You may get in touch with us with the channels available in the [kcp-dev community](https://github.com/kcp-dev/kcp#getting-in-touch).


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

No matter which convention we use, at least there should be a full stop at the end of a list.

## Related issue(s)

Fixes #23
