### PR TITLE
:bug: Differentiate logcheck output

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -1,1 +1,1 @@
-logcheck: ./... matched no packages
+APIs: logcheck: ./... matched no packages

--- a/hack/verify-contextual-logging.sh
+++ b/hack/verify-contextual-logging.sh
@@ -26,13 +26,13 @@ LOGCHECK=${LOGCHECK:-logcheck}
 cd "$REPO_ROOT"
 
 set +o errexit
-${LOGCHECK} -check-contextual ./... > "${work_file}" 2>&1
+${LOGCHECK} -check-contextual ./... 2>&1 | sed 's/^/Root: /' > "${work_file}" 
 set -o errexit
 
 # pkg/apis is a separate module, so check that in addition to our root packages
 cd "${REPO_ROOT}"/pkg/apis
 set +o errexit
-${LOGCHECK} -check-contextual ./... >> "${work_file}" 2>&1
+${LOGCHECK} -check-contextual ./... 2>&1 | sed 's/^/APIs: /' >> "${work_file}" 
 set -o errexit
 
 is_gnu_sed() { sed --version >/dev/null 2>&1; }
@@ -57,7 +57,7 @@ work_cleaned="$( sed -e 's/[0-9]*//g' "${work_file}" )"
 log_cleaned="$( sed -e 's/[0-9]*//g' "${LOG_FILE}" )"
 
 if ! changes="$(diff <(echo "${work_cleaned}")  <(echo "${log_cleaned}") )"; then
-    echo "[ERROR] Current logging errors and saved logging errors do not match."
+    echo "[ERROR] Current logging errors and saved logging errors do not match.  Current are in ${work_file}"
     echo "${changes}"
     echo
     echo "[INFO] If you need to update the saved list, run \`make update-contextual-logging\` and commit \`hack/logcheck.out\`'"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Make hack/verify-contextual-logging.sh keep track of which logcheck output is from which invocation.

Also make it note the location of the new output, to help developers debug problems.

## Related issue(s)

Fixes #70 
