### PR TITLE
:bug: reverted order of imports in indexers.go, main.go, and controller.go

### DIFF
--- a/cmd/placement/main.go
+++ b/cmd/placement/main.go
@@ -21,11 +21,6 @@ import (
 	"os"
 	"time"
 
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
-	edgeindexers "github.com/kcp-dev/edge-mc/pkg/indexers"
-	edgeplacement "github.com/kcp-dev/edge-mc/pkg/reconciler/scheduling/placement"
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	kcpkubernetesinformers "k8s.io/client-go/informers"
 	kcpkubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -35,6 +30,11 @@ import (
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
+	edgeindexers "github.com/kcp-dev/edge-mc/pkg/indexers"
+	edgeplacement "github.com/kcp-dev/edge-mc/pkg/reconciler/scheduling/placement"
 )
 
 func main() {

--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -17,12 +17,13 @@ limitations under the License.
 package indexers
 
 import (
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
+
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 )
 
 const (

--- a/pkg/reconciler/scheduling/placement/controller.go
+++ b/pkg/reconciler/scheduling/placement/controller.go
@@ -25,7 +25,6 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -47,6 +46,8 @@ import (
 	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	schedulinglisters "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/logging"
+
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 )
 
 const (


### PR DESCRIPTION
reverted order of imports in indexers.go, main.go, and controller.go
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
reverted order of imports in indexers.go, main.go, and controller.go

## Related issue(s)

Fixes #
