### PR TITLE
🌱 Improve and use `make imports`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(OPENSHIFT_GOIMPORTS):
 
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS) verify-go-versions
-	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/edge-mc
+	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev
 
 $(TOOLS_DIR)/verify_boilerplate.py:
 	mkdir -p $(TOOLS_DIR)

--- a/cmd/placement/cmd/placement.go
+++ b/cmd/placement/cmd/placement.go
@@ -30,15 +30,14 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	placementoptions "github.com/kcp-dev/edge-mc/cmd/placement/options"
 	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	edgeindexers "github.com/kcp-dev/edge-mc/pkg/indexers"
 	edgeplacement "github.com/kcp-dev/edge-mc/pkg/reconciler/scheduling/placement"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 func NewPlacementCommand() *cobra.Command {

--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -17,13 +17,12 @@ limitations under the License.
 package indexers
 
 import (
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 const (

--- a/pkg/reconciler/scheduling/placement/controller.go
+++ b/pkg/reconciler/scheduling/placement/controller.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -41,13 +39,14 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	schedulinglisters "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/logging"
-
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 const (

--- a/pkg/reconciler/scheduling/placement/indexes.go
+++ b/pkg/reconciler/scheduling/placement/indexes.go
@@ -19,11 +19,10 @@ package placement
 import (
 	"fmt"
 
-	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
 )
 
 func indexByWorkspace(obj interface{}) ([]string, error) {

--- a/pkg/reconciler/scheduling/placement/reconcile.go
+++ b/pkg/reconciler/scheduling/placement/reconcile.go
@@ -19,12 +19,11 @@ package placement
 import (
 	"context"
 
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 type reconcileStatus int

--- a/pkg/reconciler/scheduling/placement/reconcile_namespace.go
+++ b/pkg/reconciler/scheduling/placement/reconcile_namespace.go
@@ -19,14 +19,13 @@ package placement
 import (
 	"context"
 
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // placementNamespaceReconciler checks the namespaces bound to this placement and set the phase.

--- a/pkg/reconciler/scheduling/placement/reconcile_placement.go
+++ b/pkg/reconciler/scheduling/placement/reconcile_placement.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"math/rand"
 
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kube-openapi/pkg/util/sets"
@@ -29,6 +27,7 @@ import (
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // placementReconciler watches namespaces within a cluster workspace and assigns those to location from


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Make everything under kcp-dev sort together in the last block of imports.

Because openshift-goimports is rather opinionated and does not have a way to separate kcp-dev/kcp from kcp-dev/edge-mc with both coming after kubernetes.

Actually invoked `make imports` --- whose effects have not appeared in earlier PRs and whose effects will appear in future PRs that include the effects of `make codegen`.

## Related issue(s)

Fixes #
