### PR TITLE
🌱 Separate edge-mc imports from other kcp-dev imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ YAML_PATCH_BIN := yaml-patch
 YAML_PATCH := $(TOOLS_DIR)/$(YAML_PATCH_BIN)-$(YAML_PATCH_VER)
 export YAML_PATCH # so hack scripts can use it
 
-OPENSHIFT_GOIMPORTS_VER := c72f1dc2e3aacfa00aece3391d938c9bc734e791
+OPENSHIFT_GOIMPORTS_VER := 4cd858e694d7dfa32a2e697e0e4bab245c215cf3
 OPENSHIFT_GOIMPORTS_BIN := openshift-goimports
 OPENSHIFT_GOIMPORTS := $(TOOLS_DIR)/$(OPENSHIFT_GOIMPORTS_BIN)-$(OPENSHIFT_GOIMPORTS_VER)
 export OPENSHIFT_GOIMPORTS # so hack scripts can use it
@@ -204,7 +204,7 @@ $(OPENSHIFT_GOIMPORTS):
 
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS) verify-go-versions
-	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev
+	$(OPENSHIFT_GOIMPORTS) -i github.com/kcp-dev -m github.com/kcp-dev/edge-mc
 
 $(TOOLS_DIR)/verify_boilerplate.py:
 	mkdir -p $(TOOLS_DIR)

--- a/cmd/placement/cmd/placement.go
+++ b/cmd/placement/cmd/placement.go
@@ -30,12 +30,13 @@ import (
 
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
-	placementoptions "github.com/kcp-dev/edge-mc/cmd/placement/options"
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
-	edgeplacement "github.com/kcp-dev/edge-mc/pkg/reconciler/scheduling/placement"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+
+	placementoptions "github.com/kcp-dev/edge-mc/cmd/placement/options"
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
+	edgeplacement "github.com/kcp-dev/edge-mc/pkg/reconciler/scheduling/placement"
 )
 
 func NewPlacementCommand() *cobra.Command {

--- a/pkg/client/clientset/versioned/cluster/clientset.go
+++ b/pkg/client/clientset/versioned/cluster/clientset.go
@@ -30,9 +30,10 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 
 	kcpclient "github.com/kcp-dev/apimachinery/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 type ClusterInterface interface {

--- a/pkg/client/clientset/versioned/cluster/fake/clientset.go
+++ b/pkg/client/clientset/versioned/cluster/fake/clientset.go
@@ -27,13 +27,14 @@ import (
 
 	kcpfakediscovery "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/discovery/fake"
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	kcpclient "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
 	kcpedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
 	fakeedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake"
 	clientscheme "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/scheme"
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edge_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edge_client.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/client-go/rest"
 
 	kcpclient "github.com/kcp-dev/apimachinery/pkg/client"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
 )
 
 type EdgeV1alpha1ClusterInterface interface {

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/edgeplacement.go
@@ -28,9 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	kcpclient "github.com/kcp-dev/apimachinery/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // EdgePlacementsClusterGetter has a method to return a EdgePlacementClusterInterface.

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edge_client.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edge_client.go
@@ -25,9 +25,10 @@ import (
 	"k8s.io/client-go/rest"
 
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	kcpedgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1"
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 var _ kcpedgev1alpha1.EdgeV1alpha1ClusterInterface = (*EdgeV1alpha1ClusterClient)(nil)

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgeplacement.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/edgeplacement.go
@@ -32,9 +32,10 @@ import (
 	"k8s.io/client-go/testing"
 
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 var edgePlacementsResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "edgeplacements"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/singleplacementslice.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/fake/singleplacementslice.go
@@ -32,9 +32,10 @@ import (
 	"k8s.io/client-go/testing"
 
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 var singlePlacementSlicesResource = schema.GroupVersionResource{Group: "edge.kcp.io", Version: "v1alpha1", Resource: "singleplacementslices"}

--- a/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/clientset/versioned/cluster/typed/edge/v1alpha1/singleplacementslice.go
@@ -28,9 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	kcpclient "github.com/kcp-dev/apimachinery/pkg/client"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	edgev1alpha1client "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/typed/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // SinglePlacementSlicesClusterGetter has a method to return a SinglePlacementSliceClusterInterface.

--- a/pkg/client/informers/externalversions/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/edgeplacement.go
@@ -32,12 +32,13 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	kcpinformers "github.com/kcp-dev/apimachinery/third_party/informers"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
 	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // EdgePlacementClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/informers/externalversions/edge/v1alpha1/singleplacementslice.go
@@ -32,12 +32,13 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	kcpinformers "github.com/kcp-dev/apimachinery/third_party/informers"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
 	edgev1alpha1listers "github.com/kcp-dev/edge-mc/pkg/client/listers/edge/v1alpha1"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // SinglePlacementSliceClusterInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -32,11 +32,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
 	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/edge"
 	"github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions/internalinterfaces"
-	"github.com/kcp-dev/logicalcluster/v2"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -28,8 +28,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 type GenericClusterInformer interface {

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	scopedclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned"
 	clientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
 )

--- a/pkg/client/listers/edge/v1alpha1/edgeplacement.go
+++ b/pkg/client/listers/edge/v1alpha1/edgeplacement.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 // EdgePlacementClusterLister can list EdgePlacements across all workspaces, or scope down to a EdgePlacementLister for one workspace.

--- a/pkg/client/listers/edge/v1alpha1/singleplacementslice.go
+++ b/pkg/client/listers/edge/v1alpha1/singleplacementslice.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgev1alpha1 "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 // SinglePlacementSliceClusterLister can list SinglePlacementSlices across all workspaces, or scope down to a SinglePlacementSliceLister for one workspace.

--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -21,8 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 )
 
 const (

--- a/pkg/reconciler/scheduling/placement/controller.go
+++ b/pkg/reconciler/scheduling/placement/controller.go
@@ -40,13 +40,14 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	kcpcorev1informers "github.com/kcp-dev/client-go/informers/core/v1"
 	corev1listers "github.com/kcp-dev/client-go/listers/core/v1"
-	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	schedulingv1alpha1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	schedulingv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/logicalcluster/v2"
+
+	edgeclient "github.com/kcp-dev/edge-mc/pkg/client"
 )
 
 const (


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR switches to using the latest version of https://github.com/openshift-eng/openshift-goimports --- which can support import groups between openshift and the module being organized --- and grouping the non-edge kcp imports together before the edge-mc imports.

## Related issue(s)

Fixes #
