### PR TITLE
:bug: added a reference to SIG KCP-Edge and linkedin keyword in the readme …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# edge-mc
+# edge-mc: code repository for SIG KCP-Edge
 
 ## Overview
 edge-mc is a subproject of kcp focusing on concerns arising from edge multicluster use cases:
@@ -49,3 +49,4 @@ There are several ways to communicate with us:
 - See [upcoming](https://github.com/kcp-dev/edge-mc/issues?q=is%3Aissue+is%3Aopen+label%3Acommunity-meeting) and [past](https://github.com/kcp-dev/edge-mc/issues?q=is%3Aissue+is%3Aclosed+label%3Acommunity-meeting) community meeting agendas and notes
 - Browse the [shared Google Drive](https://drive.google.com/drive/folders/1FN7AZ_Q1CQor6eK0gpuKwdGFNwYI517M?usp=sharing) to share design docs, notes, etc.
     - Members of the kcp-dev mailing list can view this drive
+- Follow us on LinkedIn - [#sigkcpedge](https://www.linkedin.com/feed/hashtag/?keywords=sigkcpedge)


### PR DESCRIPTION
…so that SEO has a chance to index our community name

added a reference to SIG KCP-Edge in the readme so that SEO has a chance to index our community name

added a reference to SIG KCP-Edge in the readme so that SEO has a chance to index our community name

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #
