### PR TITLE
:book: Corrected doc on mailbox workspace name

### DIFF
--- a/docs/poc2023q1/mailbox-controller.md
+++ b/docs/poc2023q1/mailbox-controller.md
@@ -9,8 +9,8 @@ For a given SyncTarget T, the mailbox controller currently chooses the
 name of the corresponding workspace to be the concatenation of the
 following.
 
-- the name (_not_ ID) of the workspace containing T
-- "-w-"
+- the ID of the logical cluster containing T
+- the string "-w-"
 - T's name
 
 This is ambiguous and subject to name length overflows.  Later


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR corrects the documentation of how the mailbox controller constructs the name of mailbox workspaces

## Related issue(s)

Fixes #153
