### PR TITLE
🌱 Work around comment drifting in openshift-goimports

### DIFF
--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package main
 
+// Import of k8s.io/client-go/plugin/pkg/client/auth ensures
+// that all in-tree Kubernetes client auth plugins
+// (e.g. Azure, GCP, OIDC, etc.)  are available.
+//
+// Import of k8s.io/component-base/metrics/prometheus/clientgo
+// makes the k8s client library produce Prometheus metrics.
+
 import (
 	"context"
 	"flag"
@@ -31,13 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
-
-	// Import of k8s.io/client-go/plugin/pkg/client/auth ensures
-	// that all in-tree Kubernetes client auth plugins
-	// (e.g. Azure, GCP, OIDC, etc.)  are available.
-	//
-	// Import of k8s.io/component-base/metrics/prometheus/clientgo
-	// makes the k8s client library produce Prometheus metrics.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR moves the comment on imports in the mailbox controller to someplace that openshift-goimports does not mess with, to avoid https://github.com/openshift-eng/openshift-goimports/issues/16 .

## Related issue(s)

Fixes #
