### PR TITLE
✨ Start drafting placement translator internal interfaces

### DIFF
--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -46,13 +46,13 @@ import (
 	"k8s.io/klog/v2"
 	utilflag "k8s.io/kubernetes/pkg/util/flag"
 
-	edgeclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
-	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 
+	edgeclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
+	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/edge-mc/pkg/placement"
 )
 

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Import of k8s.io/client-go/plugin/pkg/client/auth ensures
+// that all in-tree Kubernetes client auth plugins
+// (e.g. Azure, GCP, OIDC, etc.)  are available.
+//
+// Import of k8s.io/component-base/metrics/prometheus/clientgo
+// makes the k8s client library produce Prometheus metrics.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/apiserver/pkg/server/routes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/metrics/legacyregistry"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo"
+	"k8s.io/klog/v2"
+	utilflag "k8s.io/kubernetes/pkg/util/flag"
+
+	edgeclusterclientset "github.com/kcp-dev/edge-mc/pkg/client/clientset/versioned/cluster"
+	edgeinformers "github.com/kcp-dev/edge-mc/pkg/client/informers/externalversions"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+
+	"github.com/kcp-dev/edge-mc/pkg/placement"
+)
+
+type ClientOpts struct {
+	loadingRules *clientcmd.ClientConfigLoadingRules
+	overrides    clientcmd.ConfigOverrides
+}
+
+func NewClientOpts() *ClientOpts {
+	return &ClientOpts{
+		loadingRules: clientcmd.NewDefaultClientConfigLoadingRules(),
+		overrides:    clientcmd.ConfigOverrides{},
+	}
+}
+
+func (opts *ClientOpts) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&opts.loadingRules.ExplicitPath, "kubeconfig", opts.loadingRules.ExplicitPath, "Path to the kubeconfig file to use for CLI requests")
+	flags.StringVar(&opts.overrides.CurrentContext, "context", opts.overrides.CurrentContext, "The name of the kubeconfig context to use")
+}
+
+func (opts *ClientOpts) ToRESTConfig() (*rest.Config, error) {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(opts.loadingRules, &opts.overrides)
+	return clientConfig.ClientConfig()
+}
+
+func main() {
+	resyncPeriod := time.Duration(0)
+	var concurrency int = 4
+	serverBindAddress := ":10204"
+	fs := pflag.NewFlagSet("placement-translator", pflag.ExitOnError)
+	klog.InitFlags(flag.CommandLine)
+	fs.AddGoFlagSet(flag.CommandLine)
+	fs.Var(&utilflag.IPPortVar{Val: &serverBindAddress}, "server-bind-address", "The IP address with port at which to serve /metrics and /debug/pprof/")
+	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
+	cliOpts := NewClientOpts()
+	cliOpts.AddFlags(fs)
+	fs.Parse(os.Args[1:])
+
+	ctx := context.Background()
+	logger := klog.Background()
+	ctx = klog.NewContext(ctx, logger)
+
+	fs.VisitAll(func(flg *pflag.Flag) {
+		logger.V(1).Info("Command line flag", flg.Name, flg.Value)
+	})
+
+	inventoryLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	inventoryConfigOverrides := &clientcmd.ConfigOverrides{}
+
+	fs.StringVar(&inventoryLoadingRules.ExplicitPath, "inventory-kubeconfig", inventoryLoadingRules.ExplicitPath, "pathname of kubeconfig file for inventory service provider workspace")
+	fs.StringVar(&inventoryConfigOverrides.CurrentContext, "inventory-context", "root", "current-context override for inventory-kubeconfig")
+
+	workloadLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	workloadConfigOverrides := &clientcmd.ConfigOverrides{}
+
+	fs.StringVar(&workloadLoadingRules.ExplicitPath, "workload-kubeconfig", workloadLoadingRules.ExplicitPath, "pathname of kubeconfig file for edge workload service provider workspace")
+	fs.StringVar(&workloadConfigOverrides.CurrentContext, "workload-context", workloadConfigOverrides.CurrentContext, "current-context override for workload-kubeconfig")
+
+	mymux := mux.NewPathRecorderMux("placement-translator")
+	mymux.Handle("/metrics", legacyregistry.Handler())
+	routes.Profiling{}.Install(mymux)
+	go func() {
+		err := http.ListenAndServe(serverBindAddress, mymux)
+		if err != nil {
+			logger.Error(err, "Failure in web serving")
+			panic(err)
+		}
+	}()
+
+	restConfig, err := cliOpts.ToRESTConfig()
+	if err != nil {
+		logger.Error(err, "Failed to build config from flags")
+		os.Exit(10)
+	}
+
+	// create config for accessing TMC service provider workspace
+	inventoryClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(inventoryLoadingRules, inventoryConfigOverrides)
+	inventoryConfig, err := inventoryClientConfig.ClientConfig()
+	if err != nil {
+		logger.Error(err, "failed to make inventory config")
+		os.Exit(2)
+	}
+
+	inventoryConfig.UserAgent = "mailbox-controller"
+
+	// Get client config for view of SyncTarget objects
+	edgeViewConfig, err := configForViewOfExport(ctx, restConfig, "edge.kcp.io")
+	if err != nil {
+		logger.Error(err, "Failed to create client config for view of edge APIExport")
+		os.Exit(4)
+	}
+
+	edgelusterClientset, err := edgeclusterclientset.NewForConfig(edgeViewConfig)
+	if err != nil {
+		logger.Error(err, "Failed to create clientset for view of SyncTarget exports")
+		os.Exit(6)
+	}
+
+	edgeInformerFactory := edgeinformers.NewSharedInformerFactoryWithOptions(edgelusterClientset, resyncPeriod)
+	spsPreInformer := edgeInformerFactory.Edge().V1alpha1().SinglePlacementSlices()
+	spsClusterInformer := spsPreInformer.Informer()
+
+	workspacesScopedClientset, err := kcpscopedclientset.NewForConfig(restConfig)
+	if err != nil {
+		logger.Error(err, "Failed to create clientset for workspaces")
+	}
+
+	workspacesScopedInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(workspacesScopedClientset, resyncPeriod)
+	workspacesScopedPreInformer := workspacesScopedInformerFactory.Tenancy().V1alpha1().Workspaces()
+	workspacesScopedInformer := workspacesScopedPreInformer.Informer()
+
+	doneCh := ctx.Done()
+	edgeInformerFactory.Start(doneCh)
+	workspacesScopedInformerFactory.Start(doneCh)
+	if !cache.WaitForNamedCacheSync("mailbox-controller", doneCh, spsClusterInformer.HasSynced, workspacesScopedInformer.HasSynced) {
+		logger.Error(nil, "Informer syncs not achieved")
+		os.Exit(100)
+	}
+	// TODO: more
+	placement.NewPlacementTranslator(ctx, workspacesScopedInformer)
+	<-doneCh
+	logger.Info("Time to stop")
+}
+
+func configForViewOfExport(ctx context.Context, providerConfig *rest.Config, exportName string) (*rest.Config, error) {
+	providerScopedClient, err := kcpscopedclientset.NewForConfig(providerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating client for service provider workspace: %w", err)
+	}
+	apiExportClient := providerScopedClient.ApisV1alpha1().APIExports()
+	logger := klog.FromContext(ctx)
+	var apiExport *apisv1alpha1.APIExport
+	for {
+		apiExport, err = apiExportClient.Get(ctx, exportName, metav1.GetOptions{})
+		if err != nil {
+			if k8sapierrors.IsNotFound(err) {
+				logger.V(2).Info("Pause because APIExport not found", "exportName", exportName)
+				time.Sleep(time.Second * 15)
+				continue
+			}
+			return nil, fmt.Errorf("error reading APIExport %s: %w", exportName, err)
+		}
+		if isAPIExportReady(logger, apiExport) {
+			break
+		}
+		logger.V(2).Info("Pause because APIExport not ready", "exportName", exportName)
+		time.Sleep(time.Second * 15)
+	}
+	viewConfig := rest.CopyConfig(providerConfig)
+	serverURL := apiExport.Status.VirtualWorkspaces[0].URL
+	logger.V(2).Info("Found APIExport view", "exportName", exportName, "serverURL", serverURL)
+	viewConfig.Host = serverURL
+	return viewConfig, nil
+}
+
+func isAPIExportReady(logger klog.Logger, apiExport *apisv1alpha1.APIExport) bool {
+	if !conditions.IsTrue(apiExport, apisv1alpha1.APIExportVirtualWorkspaceURLsReady) {
+		logger.V(2).Info("APIExport virtual workspace URLs are not ready", "APIExport", apiExport.Name)
+		return false
+	}
+	if len(apiExport.Status.VirtualWorkspaces) == 0 {
+		logger.V(2).Info("APIExport does not have any virtual workspace URLs", "APIExport", apiExport.Name)
+		return false
+	}
+	return true
+}

--- a/cmd/placement-translator/main.go
+++ b/cmd/placement-translator/main.go
@@ -145,13 +145,13 @@ func main() {
 		os.Exit(4)
 	}
 
-	edgelusterClientset, err := edgeclusterclientset.NewForConfig(edgeViewConfig)
+	edgeClusterClientset, err := edgeclusterclientset.NewForConfig(edgeViewConfig)
 	if err != nil {
 		logger.Error(err, "Failed to create clientset for view of SyncTarget exports")
 		os.Exit(6)
 	}
 
-	edgeInformerFactory := edgeinformers.NewSharedInformerFactoryWithOptions(edgelusterClientset, resyncPeriod)
+	edgeInformerFactory := edgeinformers.NewSharedInformerFactoryWithOptions(edgeClusterClientset, resyncPeriod)
 	spsPreInformer := edgeInformerFactory.Edge().V1alpha1().SinglePlacementSlices()
 	spsClusterInformer := spsPreInformer.Informer()
 

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -1,3 +1,4 @@
 /cmd/cluster-watchall/main.go:101:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/kcp-watchall/main.go:103:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
 /cmd/mailbox-controller/main.go:102:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.
+/cmd/placement-translator/main.go:99:3: Key positional arguments are expected to be inlined constant strings. Please replace &{flg Name} provided with string value.

--- a/pkg/placement/client-tracker.go
+++ b/pkg/placement/client-tracker.go
@@ -24,8 +24,8 @@ type ClientTracker[Provider any] struct {
 	clients  map[Client[Provider]]Empty
 }
 
-func NewClientTracker[Provider any]() ClientTracker[Provider] {
-	return ClientTracker[Provider]{
+func NewClientTracker[Provider any]() *ClientTracker[Provider] {
+	return &ClientTracker[Provider]{
 		clients: map[Client[Provider]]Empty{},
 	}
 }

--- a/pkg/placement/client-tracker.go
+++ b/pkg/placement/client-tracker.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+// ClientTracker keeps track of a set of clients
+// and reports when RemoveClient removed the last of them.
+// NOT safe for concurrent use.
+type ClientTracker[Provider any] struct {
+	provider Provider
+	clients  map[Client[Provider]]Empty
+}
+
+func NewClientTracker[Provider any]() ClientTracker[Provider] {
+	return ClientTracker[Provider]{
+		clients: map[Client[Provider]]Empty{},
+	}
+}
+
+func (ct *ClientTracker[Provider]) IsEmpty() bool {
+	return len(ct.clients) == 0
+}
+
+func (ct *ClientTracker[Provider]) AddClient(client Client[Provider]) {
+	if _, found := ct.clients[client]; found {
+		return
+	}
+	ct.clients[client] = Empty{}
+	client.SetProvider(ct.provider)
+}
+
+func (ct *ClientTracker[Provider]) RemoveClient(client Client[Provider]) bool {
+	if _, found := ct.clients[client]; !found {
+		return false
+	}
+	delete(ct.clients, client)
+	return len(ct.clients) == 0
+}
+
+func (ct *ClientTracker[Provider]) SetProvider(provider Provider) {
+	ct.provider = provider
+	for client := range ct.clients {
+		client.SetProvider(provider)
+	}
+}

--- a/pkg/placement/cluster-name-and-path.go
+++ b/pkg/placement/cluster-name-and-path.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"k8s.io/klog/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8scache "k8s.io/client-go/tools/cache"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+type NameAndPathBinder struct {
+	logger     klog.Logger
+	nameToPath RelayMap[logicalcluster.Name, string]
+	pathToName RelayMap[string, logicalcluster.Name]
+}
+
+const PathKey = "kcp.io/path"
+
+func NewNameAndPath(logger klog.Logger, informer k8scache.SharedInformer, dedupConsumers bool) (
+	nameToPath DynamicMapProducer[logicalcluster.Name, string],
+	pathToName DynamicMapProducer[string, logicalcluster.Name]) {
+	nap := &NameAndPathBinder{
+		logger:     logger,
+		nameToPath: NewRelayMap[logicalcluster.Name, string](dedupConsumers),
+		pathToName: NewRelayMap[string, logicalcluster.Name](dedupConsumers),
+	}
+	informer.AddEventHandler(nap)
+	return nap.nameToPath, nap.pathToName
+}
+
+func (nap *NameAndPathBinder) OnAdd(obj any) {
+	mObj := obj.(metav1.Object)
+	name := logicalcluster.From(mObj)
+	if name == "" {
+		nap.logger.Error(nil, "No logicalcluster.Name", "obj", obj)
+		return
+	}
+	path := mObj.GetAnnotations()[PathKey]
+	if path == "" {
+		nap.logger.Error(nil, "No logicalcluster Path", "obj", obj)
+		return
+	}
+	nap.nameToPath.Set(name, path)
+	nap.pathToName.Set(path, name)
+}
+
+func (nap *NameAndPathBinder) OnUpdate(oldObj, newObj any) {
+	nap.OnAdd(newObj)
+}
+
+func (nap *NameAndPathBinder) OnDelete(obj any) {
+	if typed, ok := obj.(k8scache.DeletedFinalStateUnknown); ok {
+		obj = typed.Obj
+	}
+	mObj := obj.(metav1.Object)
+	name := logicalcluster.From(mObj)
+	if name == "" {
+		nap.logger.Error(nil, "No logicalcluster.Name", "obj", obj)
+		return
+	}
+	path := mObj.GetAnnotations()[PathKey]
+	if path == "" {
+		nap.logger.Error(nil, "No logicalcluster Path", "obj", obj)
+		return
+	}
+	nap.nameToPath.Remove(name)
+	nap.pathToName.Remove(path)
+}

--- a/pkg/placement/cluster-name-and-path.go
+++ b/pkg/placement/cluster-name-and-path.go
@@ -17,10 +17,9 @@ limitations under the License.
 package placement
 
 import (
-	"k8s.io/klog/v2"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 )

--- a/pkg/placement/cluster-name-and-path.go
+++ b/pkg/placement/cluster-name-and-path.go
@@ -33,8 +33,8 @@ type NameAndPathBinder struct {
 const PathKey = "kcp.io/path"
 
 func NewNameAndPath(logger klog.Logger, informer k8scache.SharedInformer, dedupConsumers bool) (
-	nameToPath DynamicMapProducer[logicalcluster.Name, string],
-	pathToName DynamicMapProducer[string, logicalcluster.Name]) {
+	nameToPath DynamicMapProvider[logicalcluster.Name, string],
+	pathToName DynamicMapProvider[string, logicalcluster.Name]) {
 	nap := &NameAndPathBinder{
 		logger:     logger,
 		nameToPath: NewRelayMap[logicalcluster.Name, string](dedupConsumers),

--- a/pkg/placement/cluster-name-and-path.go
+++ b/pkg/placement/cluster-name-and-path.go
@@ -32,13 +32,13 @@ type NameAndPathBinder struct {
 
 const PathKey = "kcp.io/path"
 
-func NewNameAndPath(logger klog.Logger, informer k8scache.SharedInformer, dedupConsumers bool) (
+func NewNameAndPath(logger klog.Logger, informer k8scache.SharedInformer, dedupReceivers bool) (
 	nameToPath DynamicMapProvider[logicalcluster.Name, string],
 	pathToName DynamicMapProvider[string, logicalcluster.Name]) {
 	nap := &NameAndPathBinder{
 		logger:     logger,
-		nameToPath: NewRelayMap[logicalcluster.Name, string](dedupConsumers),
-		pathToName: NewRelayMap[string, logicalcluster.Name](dedupConsumers),
+		nameToPath: NewRelayMap[logicalcluster.Name, string](dedupReceivers),
+		pathToName: NewRelayMap[string, logicalcluster.Name](dedupReceivers),
 	}
 	informer.AddEventHandler(nap)
 	return nap.nameToPath, nap.pathToName

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+	"strings"
+
+	k8sevents "k8s.io/api/events/v1"
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+// This file contains declarations of the interfaces between the main parts
+// of the placement translator.  Those are as follows.
+//
+// - a WhereResolver that monitors the "where" resolutions in the
+//   SinglePlacementSlice API objects.
+// - a WhatResolver that monitors the EdgePlacement objects and resolves
+//   their "what" predicates.
+// - a SetBinder that keeps track of the bindings between resolved where
+//   and resolved what.
+// - a WorkloadProjector that maintains the customized workload copies
+//   in the mailbox workspaces.
+// - a PlacementProjector that maintains the TMC Placement objects that
+//   correspond to the EdgePlacement objects.
+
+// WhereResolver is responsible for keeping given consumers eventually
+// consistent with the resolutions of the EdgePlacement "where" predicates.
+// This is done by a calls to the given consumers.
+// Calls to Get are not associated with any particular consumer.
+// Each `*edgeapi.SinglePlacementSlice` points to an immutable object.
+type WhereResolver interface {
+	AddConsumer(consume func(placementRef edgeapi.ExternalName, resolved ResolvedWhere))
+	Get(placementRef edgeapi.ExternalName) ResolvedWhere
+}
+
+// WhatResolver is responsible for resolving the "what" predicates of the EdgePlacement
+// objects and keeping given consumers eventually consistent with these resolutions.
+// This is done by a calls to the given consumers.
+// Calls to Get are not associated with any particular consumer.
+type WhatResolver interface {
+	AddConsumer(consume func(placementRef edgeapi.ExternalName, resolved WorkloadParts))
+	Get(placementRef edgeapi.ExternalName) WorkloadParts
+}
+
+// SetBinder is a component that keeps track of the mapping
+// from EdgePlacement to its pair of (resolved what, resolved where).
+// An implementation may be responsible, for example, for keeping a given
+// SingleBinder eventually consistent.
+// An implementation is likely going to use a SinglePlacementSliceSetReducer.
+// Each `*edgeapi.SinglePlacementSlice` points to an immutable object.
+type SetBinder interface {
+	NoteBinding(placementRef edgeapi.ExternalName, what WorkloadParts, where ResolvedWhere)
+	NoteUnbinding(placementRef edgeapi.ExternalName)
+}
+
+// WorkloadProjector is kept appraised of what goes where
+// and is responsible for maintaining the customized workload
+// copies in the mailbox workspaces.
+type WorkloadProjector interface {
+	SingleBinder
+}
+
+// PlacementProjector is responsible for maintaining the TMC Placement
+// objects corresponding to given EdgePlacement objects.
+// An implementation is likely going to use a SinglePlacementSliceSetReducer.
+type PlacementProjector interface {
+	SetBinder
+}
+
+// ResolvedWhere identifies the set of SyncTargets that match a certain
+// EdgePlacement's "where" predicate.
+// Each `*edgeapi.SinglePlacementSlice` points to an immutable object.
+type ResolvedWhere []*edgeapi.SinglePlacementSlice
+
+// WorkloadParts identifies a workload prescription and provides
+// ephemeral details of how to access it.
+// A workload prescription is the things that match the "what" predicate
+// of an EdgePlacement.
+//
+// Every WorkloadParts that appears in the interfaces here is immutable.
+//
+// In the case of a Namespace object, this implies that
+// all the objects in that namespace are included.
+//
+// A workload may include objects of kinds that are built into
+// the edge cluster.  By built-in we mean that these kinds are both
+// already known (regardless of whether it is via being built into
+// the apiserver or added to it by either form of aggregation) and
+// not managed by edge workload management.
+// It is the user's responsibility to make the "what" predicate
+// match the corresponding CRD when the workload includes an object
+// of a kind that is not built into the edge cluster.
+type WorkloadParts map[WorkloadPartID]WorkloadPartDetails
+
+// WorkloadPartID identifies part of a workload.
+type WorkloadPartID struct {
+	ClusterName logicalcluster.Name
+
+	APIGroup string
+
+	// Resource is the lowercase plural way of identifying the kind of object
+	Resource string
+
+	Name string
+}
+
+// WorkloadPartDetails provides additional details about how the WorkloadPart
+// is to be included.
+type WorkloadPartDetails struct {
+	// APIVersion is the one to use when reading from the source workspace.
+	APIVersion string
+
+	// IncludeNamespaceObject is only relevant for a Namespace part, and
+	// indicates whether to include the details of the Namespace object;
+	// the objects in the namespace are certainly included.
+	IncludeNamespaceObject bool
+}
+
+// SingleBinder is appraised of individual bindings and unbindings,
+// but they may come in batches.
+// AddBinding calls are ordered by API machinery dependencies.
+// RemoveBinding calls are ordered by the reverse of the API machinery dependencies.
+type SingleBinder interface {
+	// Transact does a collection of adds and removes.
+	Transact(func(SingleBindingOps))
+}
+
+type SingleBindingOps interface {
+	AddBinding(what WorkloadPart, where SinglePlacement)
+	RemoveBinding(what WorkloadPart, where SinglePlacement)
+}
+
+type WorkloadPart struct {
+	WorkloadPartID
+	WorkloadPartDetails
+}
+
+// SinglePlacement extends the API struct with the UID of the SyncTarget.
+type SinglePlacement struct {
+	edgeapi.SinglePlacement
+	SyncTargetUID apimachtypes.UID
+}
+
+func (sp SinglePlacement) SyncTargetRef() edgeapi.ExternalName {
+	return edgeapi.ExternalName{Workspace: sp.Location.Workspace, Name: sp.SyncTargetName}
+}
+
+// SinglePlacementSliceSetReducer keeps track of
+// a slice of `*edgeapi.SinglePlacementSlice`.
+// Typically one of these has a UIDer and
+// a SinglePlacementSetChangeConsumer that is kept
+// appraised of the set of values in those slices, extended by the
+// SyncTarget UIDs.
+// Each `*edgeapi.SinglePlacementSlice` points to an immutable object.
+type SinglePlacementSliceSetReducer interface {
+	Set(ResolvedWhere)
+}
+
+// SinglePlacementSetChangeConsumer is something that is kept
+// incrementally appraised of a set of SinglePlacement values.
+type SinglePlacementSetChangeConsumer interface {
+	Add(SinglePlacement)
+	Remove(SinglePlacement)
+}
+
+// UIDer is a source of mapping from object name to UID.
+// One of these is specific to one kind of object,
+// which is not namespaced.
+type UIDer interface {
+	AddConsumer(func(edgeapi.ExternalName, apimachtypes.UID))
+	GetUID(edgeapi.ExternalName) apimachtypes.UID
+}
+
+func (sp *SinglePlacement) MailboxWorkspaceName() string {
+	return sp.Location.Workspace + WSNameSep + string(sp.SyncTargetUID)
+}
+
+const WSNameSep = "-mb-"
+
+// EventHandler can be given Event objects.
+type EventHandler interface {
+	HandleEvent(*k8sevents.Event)
+}
+
+func (where ResolvedWhere) String() string {
+	var builder strings.Builder
+	builder.WriteRune('[')
+	for idx, slice := range where {
+		if idx > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(fmt.Sprintf("%v", slice))
+	}
+	builder.WriteRune(']')
+	return builder.String()
+}

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kcp-dev/logicalcluster/v3"
 	k8sevents "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachtypes "k8s.io/apimachinery/pkg/types"
 	k8ssets "k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kcp-dev/logicalcluster/v3"
 
 	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )

--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -56,14 +56,14 @@ import (
 // The particular locking order chosen here generally follows the pattern
 // that components that drive activity precede components that get driven,
 // so that this relationship can be synchronous.  For example, providers
-// of maps generally precede consumers of maps.
+// of maps generally precede clients of those maps.
 
-// WhereResolver is responsible for keeping given consumers eventually
+// WhereResolver is responsible for keeping given receivers eventually
 // consistent with the resolution of the "where" predicate for each EdgePlacement
 // (identified by cluster and name).
 type WhereResolver DynamicMapProvider[ExternalName, ResolvedWhere]
 
-// WhatResolver is responsible for keeping its consumers eventually consistent
+// WhatResolver is responsible for keeping its receivers eventually consistent
 // with the resolution of the "what" predicate of each EdgePlacement
 // (identified by cluster ane name).
 type WhatResolver DynamicMapProvider[ExternalName, WorkloadParts]
@@ -75,8 +75,8 @@ type WhatResolver DynamicMapProvider[ExternalName, WorkloadParts]
 // The implementation may use a BindingOrganizer to get from the atomized
 // "what" and "where" to the ProjectionMapProvider behavior.
 type SetBinder interface {
-	AsWhatConsumer() MappingReceiver[ExternalName, WorkloadParts]
-	AsWhereConsumer() MappingReceiver[ExternalName, ResolvedWhere]
+	AsWhatReceiver() MappingReceiver[ExternalName, WorkloadParts]
+	AsWhereReceiver() MappingReceiver[ExternalName, ResolvedWhere]
 	ProjectionMapProvider
 }
 
@@ -107,8 +107,8 @@ func AssemplePlacementTranslator(
 	workloadProjector WorkloadProjector,
 	placementProjector PlacementProjector,
 ) {
-	whatResolver.AddReceiver(setBinder.AsWhatConsumer(), true)
-	whereResolver.AddReceiver(setBinder.AsWhereConsumer(), true)
+	whatResolver.AddReceiver(setBinder.AsWhatReceiver(), true)
+	whereResolver.AddReceiver(setBinder.AsWhereReceiver(), true)
 	workloadProjector.SetProvider(setBinder)
 	placementProjector.SetProvider(setBinder)
 }
@@ -166,7 +166,7 @@ type WorkloadPart struct {
 	WorkloadPartDetails
 }
 
-// ProjectionMapProvider tells the consumers what to project,
+// ProjectionMapProvider tells the clients what to project,
 // organized into three levels.
 type ProjectionMapProvider DynamicMapProvider[ProjectionKey, *ProjectionPerCluster]
 
@@ -186,8 +186,8 @@ type ProjectionPerCluster struct {
 
 	// PerSourceCluster drives awareness of the relevant logical clusters
 	// and the work to do for each.
-	// This provider (a) requires consumers to be comparable and (b) deduplicates
-	// additions of consumers.
+	// This provider (a) requires receivers to be comparable and (b) deduplicates
+	// additions of receivers.
 	PerSourceCluster DynamicMapProvider[logicalcluster.Name, ProjectionDetails]
 }
 
@@ -228,7 +228,7 @@ type SingleBindingOps interface {
 }
 
 // SinglePlacementSliceSetReducer keeps track of a ResolvedWhere.
-// Typically one of these has a SinglePlacementSetChangeConsumer that is kept
+// Typically one of these has a SinglePlacementSetChangeReceiver that is kept
 // appraised of the set of values in those slices, extended by the
 // SyncTarget UIDs.
 // A SetBinder will likely use a SinglePlacementSliceSetReducer
@@ -237,9 +237,9 @@ type SinglePlacementSliceSetReducer interface {
 	Set(ResolvedWhere)
 }
 
-// SinglePlacementSetChangeConsumer is something that is kept
+// SinglePlacementSetChangeReceiver is something that is kept
 // incrementally appraised of a set of edgeapi.SinglePlacement values.
-type SinglePlacementSetChangeConsumer interface {
+type SinglePlacementSetChangeReceiver interface {
 	Add(edgeapi.SinglePlacement)
 	Remove(edgeapi.SinglePlacement)
 }

--- a/pkg/placement/dummies.go
+++ b/pkg/placement/dummies.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+func RelayWhatResolver() RelayMap[edgeapi.ExternalName, WorkloadParts] {
+	return NewRelayMap[edgeapi.ExternalName, WorkloadParts](true)
+}
+
+func RelayWhereResolver() RelayMap[edgeapi.ExternalName, ResolvedWhere] {
+	return NewRelayMap[edgeapi.ExternalName, ResolvedWhere](true)
+}
+
+func NewDummySetBinder() SetBinder {
+	return dummySetBinder{NewRelayMap[ProjectionKey, *ProjectionPerCluster](true)}
+}
+
+type dummySetBinder struct {
+	DynamicMapProducer[ProjectionKey, *ProjectionPerCluster]
+}
+
+func (dummySetBinder) AsWhatConsumer() DynamicMapConsumer[edgeapi.ExternalName, WorkloadParts] {
+	return RelayWhatResolver()
+}
+
+func (dummySetBinder) AsWhereConsumer() DynamicMapConsumer[edgeapi.ExternalName, ResolvedWhere] {
+	return RelayWhereResolver()
+}
+
+type dummyClient[Producer any] struct{}
+
+var _ Client[float64] = dummyClient[float64]{}
+
+func (dummyClient[Producer]) SetProvider(prod Producer) {}
+
+func NewDummyWorkloadProjector(mailboxPathToName DynamicMapProducer[string, logicalcluster.Name]) WorkloadProjector {
+	return dummyClient[ProjectionMapProducer]{}
+}

--- a/pkg/placement/dummies.go
+++ b/pkg/placement/dummies.go
@@ -33,14 +33,14 @@ func NewDummySetBinder() SetBinder {
 }
 
 type dummySetBinder struct {
-	DynamicMapProducer[ProjectionKey, *ProjectionPerCluster]
+	DynamicMapProvider[ProjectionKey, *ProjectionPerCluster]
 }
 
-func (dummySetBinder) AsWhatConsumer() DynamicMapConsumer[ExternalName, WorkloadParts] {
+func (dummySetBinder) AsWhatConsumer() MappingReceiver[ExternalName, WorkloadParts] {
 	return RelayWhatResolver()
 }
 
-func (dummySetBinder) AsWhereConsumer() DynamicMapConsumer[ExternalName, ResolvedWhere] {
+func (dummySetBinder) AsWhereConsumer() MappingReceiver[ExternalName, ResolvedWhere] {
 	return RelayWhereResolver()
 }
 
@@ -50,6 +50,6 @@ var _ Client[float64] = dummyClient[float64]{}
 
 func (dummyClient[Producer]) SetProvider(prod Producer) {}
 
-func NewDummyWorkloadProjector(mailboxPathToName DynamicMapProducer[string, logicalcluster.Name]) WorkloadProjector {
-	return dummyClient[ProjectionMapProducer]{}
+func NewDummyWorkloadProjector(mailboxPathToName DynamicMapProvider[string, logicalcluster.Name]) WorkloadProjector {
+	return dummyClient[ProjectionMapProvider]{}
 }

--- a/pkg/placement/dummies.go
+++ b/pkg/placement/dummies.go
@@ -18,16 +18,14 @@ package placement
 
 import (
 	"github.com/kcp-dev/logicalcluster/v3"
-
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
-func RelayWhatResolver() RelayMap[edgeapi.ExternalName, WorkloadParts] {
-	return NewRelayMap[edgeapi.ExternalName, WorkloadParts](true)
+func RelayWhatResolver() RelayMap[ExternalName, WorkloadParts] {
+	return NewRelayMap[ExternalName, WorkloadParts](true)
 }
 
-func RelayWhereResolver() RelayMap[edgeapi.ExternalName, ResolvedWhere] {
-	return NewRelayMap[edgeapi.ExternalName, ResolvedWhere](true)
+func RelayWhereResolver() RelayMap[ExternalName, ResolvedWhere] {
+	return NewRelayMap[ExternalName, ResolvedWhere](true)
 }
 
 func NewDummySetBinder() SetBinder {
@@ -38,11 +36,11 @@ type dummySetBinder struct {
 	DynamicMapProducer[ProjectionKey, *ProjectionPerCluster]
 }
 
-func (dummySetBinder) AsWhatConsumer() DynamicMapConsumer[edgeapi.ExternalName, WorkloadParts] {
+func (dummySetBinder) AsWhatConsumer() DynamicMapConsumer[ExternalName, WorkloadParts] {
 	return RelayWhatResolver()
 }
 
-func (dummySetBinder) AsWhereConsumer() DynamicMapConsumer[edgeapi.ExternalName, ResolvedWhere] {
+func (dummySetBinder) AsWhereConsumer() DynamicMapConsumer[ExternalName, ResolvedWhere] {
 	return RelayWhereResolver()
 }
 

--- a/pkg/placement/dummies.go
+++ b/pkg/placement/dummies.go
@@ -17,8 +17,9 @@ limitations under the License.
 package placement
 
 import (
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 func RelayWhatResolver() RelayMap[edgeapi.ExternalName, WorkloadParts] {

--- a/pkg/placement/dummies.go
+++ b/pkg/placement/dummies.go
@@ -36,11 +36,11 @@ type dummySetBinder struct {
 	DynamicMapProvider[ProjectionKey, *ProjectionPerCluster]
 }
 
-func (dummySetBinder) AsWhatConsumer() MappingReceiver[ExternalName, WorkloadParts] {
+func (dummySetBinder) AsWhatReceiver() MappingReceiver[ExternalName, WorkloadParts] {
 	return RelayWhatResolver()
 }
 
-func (dummySetBinder) AsWhereConsumer() MappingReceiver[ExternalName, ResolvedWhere] {
+func (dummySetBinder) AsWhereReceiver() MappingReceiver[ExternalName, ResolvedWhere] {
 	return RelayWhereResolver()
 }
 

--- a/pkg/placement/external-name.go
+++ b/pkg/placement/external-name.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+// ExternalName identifies a cluster-scoped object of some implicit kind
+type ExternalName struct {
+	// Cluster identifies the cluster.  It is the one-part ID, not a path.
+	Cluster logicalcluster.Name
+
+	Name string
+}
+
+// NewExternalName assumes the given cluster identifier is proper
+func NewExternalName(cluster, name string) ExternalName {
+	return ExternalName{Cluster: logicalcluster.Name(cluster), Name: name}
+}
+
+func (ExternalName) OfSPLocation(sp edgeapi.SinglePlacement) ExternalName {
+	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: sp.LocationName}
+}
+
+func (ExternalName) OfSPTarget(sp edgeapi.SinglePlacement) ExternalName {
+	return ExternalName{Cluster: logicalcluster.Name(sp.Cluster), Name: sp.SyncTargetName}
+}
+
+func (en ExternalName) String() string {
+	return en.Cluster.String() + ":" + en.Name
+}

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+
+	k8scache "k8s.io/client-go/tools/cache"
+)
+
+func NewPlacementTranslator(
+	ctx context.Context,
+	mailboxWorkspaceInformer k8scache.SharedInformer,
+	// TODO: add the other needed arguments
+) {
+	logger := klog.FromContext(ctx)
+	_, mbPathToName := NewNameAndPath(logger, mailboxWorkspaceInformer, true)
+	// TODO: make all the other needed infrastructure
+
+	// TODO: replace all these dummies
+	whatResolver := RelayWhatResolver()
+	whereResolver := RelayWhereResolver()
+	setBinder := NewDummySetBinder()
+	workloadProjector := NewDummyWorkloadProjector(mbPathToName)
+	placementProjector := NewDummyWorkloadProjector(mbPathToName)
+	AssemplePlacementTranslator(whatResolver, whereResolver, setBinder, workloadProjector, placementProjector)
+}

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -19,9 +19,8 @@ package placement
 import (
 	"context"
 
-	"k8s.io/klog/v2"
-
 	k8scache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 func NewPlacementTranslator(

--- a/pkg/placement/map-types.go
+++ b/pkg/placement/map-types.go
@@ -22,13 +22,13 @@ package placement
 //
 // "ThingProducer" actively produces a series of Things.
 // "ThingSupplier" passively produces a series of Things.
-// "ThingProvider" passively provides the service of a Thing.
 // "ThingConsumer" actively pulls for things.
 // "ThingReceiver" passively receives Things.
+// "ThingProvider" provides the Thing service, which may have active and/or passive aspects.
 // "Mapping" is a single key-value pair or other such association
 // "Map" is a complete set of pairs
 
-// DynamicMapProvider holds a mutable map and keeps consumers appraised of it.
+// DynamicMapProvider holds a mutable map and keeps clients appraised of it.
 // The zero value of Val signals a missing entry in the map.
 type DynamicMapProvider[Key comparable, Val any] interface {
 	// AddReceiver causes the given receiver to be notified of following
@@ -40,13 +40,13 @@ type DynamicMapProvider[Key comparable, Val any] interface {
 	AddReceiver(receiver MappingReceiver[Key, Val], notifyCurrent bool)
 
 	// Get invokes the given function on the value corresponding to the key.
-	// This does not count as informing any particular consumer.
+	// This does not count as informing any particular receiver.
 	// The producer precedes the function in the locking order.
 	Get(Key, func(Val))
 }
 
 // DynamicMapProviderGet does a non-CPS Get.
-// In situations with concurrency, regular consumers (as in AddReceiver)
+// In situations with concurrency, regular clients (as in AddReceiver)
 // get timing splinters if they use this.
 func DynamicMapProviderGet[Key comparable, Val any](prod DynamicMapProvider[Key, Val], key Key) Val {
 	var ans Val
@@ -69,7 +69,7 @@ func DynamicMapProviderRelease[Key comparable, Val any](prod DynamicMapProviderW
 }
 
 // MappingReceiver is given map entries by a DynamicMapProvider.
-// Some DynamicMapProvider implementations require consumers to be comparable.
+// Some DynamicMapProvider implementations require receivers to be comparable.
 type MappingReceiver[Key comparable, Val any] interface {
 	Set(Key, Val)
 }

--- a/pkg/placement/map-types.go
+++ b/pkg/placement/map-types.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+// DynamicMapProducer holds a mutable map and keeps consumers appraised of it.
+// The zero value of Val signals a missing entry in the map.
+type DynamicMapProducer[Key comparable, Val any] interface {
+	// AddConsumer notifies the consumer of the current contents
+	// of the map and following changes.
+	// Note that if this producer is safe for concurrent use then
+	// the consumer can not expect to be able to call Get.
+	AddConsumer(func(Key, Val))
+
+	// Get queries the current map state, and does not count
+	// as notifying any consumer.
+	Get(Key) Val
+}
+
+type DynamicMapConsumer[Key comparable, Val any] interface {
+	Set(Key, Val)
+}
+
+type Client[T any] interface {
+	SetProvider(T)
+}

--- a/pkg/placement/map-types.go
+++ b/pkg/placement/map-types.go
@@ -52,6 +52,10 @@ type DynamicMapProducerWithRelease[Key comparable, Val any] interface {
 	MaybeRelease(Key, func(Val) bool)
 }
 
+func DynamicMapProducerRelease[Key comparable, Val any](prod DynamicMapProducerWithRelease[Key, Val], key Key) {
+	prod.MaybeRelease(key, func(Val) bool { return true })
+}
+
 // DynamicMapConsumer is given map entries by a DynamicMapProducer.
 // Some DynamicMapProducer implementations require consumers to be comparable.
 type DynamicMapConsumer[Key comparable, Val any] interface {

--- a/pkg/placement/map-types.go
+++ b/pkg/placement/map-types.go
@@ -37,3 +37,8 @@ type DynamicMapConsumer[Key comparable, Val any] interface {
 type Client[T any] interface {
 	SetProvider(T)
 }
+
+type DynamicValueProducer[Val any] interface {
+	AddConsumer(func(Val))
+	Get() Val
+}

--- a/pkg/placement/reducer_test.go
+++ b/pkg/placement/reducer_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -120,7 +120,7 @@ func TestSimplePlacementSliceSetReducer(t *testing.T) {
 	locRef1 := edgeapi.ExternalName{Workspace: "ws-a", Name: "loc-a"}
 	asp1 := edgeapi.SinglePlacement{Location: locRef1, SyncTargetName: "st-a"}
 	sp1 := SinglePlacement{asp1, "u-a"}
-	testUIDer.SetUID(sp1.SyncTargetRef(), sp1.SyncTargetUID)
+	testUIDer.Set(sp1.SyncTargetRef(), sp1.SyncTargetUID)
 	rw1 := ResolvedWhere{&edgeapi.SinglePlacementSlice{
 		Destinations: []edgeapi.SinglePlacement{asp1},
 	}}
@@ -132,7 +132,7 @@ func TestSimplePlacementSliceSetReducer(t *testing.T) {
 		t.Errorf("Wrong details after first Set: actual=%#v, expected=%#v", actual, expected)
 	}
 	sp1a := SinglePlacement{asp1, "u-aa"}
-	testUIDer.SetUID(sp1.SyncTargetRef(), sp1a.SyncTargetUID)
+	testUIDer.Set(sp1.SyncTargetRef(), sp1a.SyncTargetUID)
 	wg.Wait()
 	if actual, expected := len(testConsumer), 1; actual != expected {
 		t.Errorf("Wrong size after first tweak: actual=%d, expected=%d", actual, expected)

--- a/pkg/placement/reducer_test.go
+++ b/pkg/placement/reducer_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+func exerciseSinglePlacementSliceSetReducer(rng *rand.Rand, initialWhere ResolvedWhere, iterations int, changesPerIteration int, extraPerIteration func(), reducer SinglePlacementSliceSetReducer, uider UIDer, consumer SinglePlacementSet) func(*testing.T) {
+	return func(t *testing.T) {
+		input := initialWhere
+		for iteration := 1; iteration <= iterations; iteration++ {
+			prevInput := input
+			for change := 1; change <= changesPerIteration; change++ {
+				input = reviseSinglePlacementSliceSlice(rng, input)
+			}
+			reducer.Set(input)
+			extraPerIteration()
+			checker := NewSinglePlacementSet()
+			reference := NewSimplePlacementSliceSetReducer(uider, checker)
+			reference.Set(input)
+			if consumer.Equals(checker) {
+				continue
+			}
+			t.Errorf("Unexpected result: excess=%v, missing=%v, iteration=%d, prevInput=%v, input=%v", consumer.Sub(checker), checker.Sub(consumer), iteration, prevInput, input)
+		}
+	}
+}
+
+func reviseSinglePlacementSliceSlice(rng *rand.Rand, slices ResolvedWhere) ResolvedWhere {
+	ans := make(ResolvedWhere, 0, len(slices))
+	copy(ans, slices)
+	if len(ans) == 0 || rng.Intn(20) == 1 {
+		// Add a new slice
+		sliceLen := (rng.Intn(12) + 2) / 3
+		slice := edgeapi.SinglePlacementSlice{Destinations: []edgeapi.SinglePlacement{}}
+		for dest := 1; dest <= sliceLen; dest++ {
+			slice.Destinations = append(slice.Destinations, genSinglePlacement(rng))
+		}
+		sliceIdx := rng.Intn(len(ans) + 1)
+		ans = append(ans[:sliceIdx], append([]*edgeapi.SinglePlacementSlice{&slice}, ans[sliceIdx:]...)...)
+	} else if rng.Intn(20) != 1 {
+		// modify an existing slice
+		sliceIdx := rng.Intn(len(ans))
+		slice := *ans[sliceIdx]
+		newDestinations := make([]edgeapi.SinglePlacement, 0, len(slice.Destinations))
+		copy(newDestinations, slice.Destinations)
+		if len(slice.Destinations) == 0 || rng.Intn(20) == 1 {
+			// Add a new entry
+			destIdx := rng.Intn(len(newDestinations) + 1)
+			dest := genSinglePlacement(rng)
+			newDestinations = append(newDestinations[:destIdx], append([]edgeapi.SinglePlacement{dest}, newDestinations[destIdx:]...)...)
+		} else if rng.Intn(20) != 1 {
+			// modify an existing SinglePlacement
+			destIdx := rng.Intn(len(newDestinations))
+			newDestinations[destIdx] = reviseSinglePlacement(rng, newDestinations[destIdx])
+		} else {
+			// delete an existing entry
+			destIdx := rng.Intn(len(newDestinations))
+			newDestinations = append(newDestinations[:destIdx], newDestinations[destIdx+1:]...)
+		}
+		slice.Destinations = newDestinations
+	} else {
+		// Delete an existing slice
+		sliceIdx := rng.Intn(len(ans))
+		ans = append(ans[:sliceIdx], ans[sliceIdx+1:]...)
+	}
+	return ans
+}
+
+func reviseSinglePlacement(rng *rand.Rand, sp edgeapi.SinglePlacement) edgeapi.SinglePlacement {
+	switch rng.Intn(3) {
+	case 0:
+		sp.Location.Workspace = fmt.Sprintf("ws%d", rng.Intn(1000))
+	case 1:
+		sp.Location.Name = fmt.Sprintf("loc%d", rng.Intn(1000))
+	default:
+		sp.SyncTargetName = fmt.Sprintf("st%d", rng.Intn(1000))
+	}
+	return sp
+}
+
+func genSinglePlacement(rng *rand.Rand) edgeapi.SinglePlacement {
+	return edgeapi.SinglePlacement{
+		Location: edgeapi.ExternalName{
+			Workspace: fmt.Sprintf("ws%d", rng.Intn(1000)),
+			Name:      fmt.Sprintf("loc%d", rng.Intn(1000)),
+		},
+		SyncTargetName: fmt.Sprintf("st%d", rng.Intn(1000)),
+	}
+}
+
+func TestSimplePlacementSliceSetReducer(t *testing.T) {
+	rs := rand.NewSource(time.Now().UnixNano())
+	rng := rand.New(rs)
+	var wg sync.WaitGroup
+	testUIDer := NewTestUIDer(rng, &wg)
+	testConsumer := NewSinglePlacementSet()
+	testReducer := NewSimplePlacementSliceSetReducer(testUIDer, testConsumer)
+	locRef1 := edgeapi.ExternalName{Workspace: "ws-a", Name: "loc-a"}
+	asp1 := edgeapi.SinglePlacement{Location: locRef1, SyncTargetName: "st-a"}
+	sp1 := SinglePlacement{asp1, "u-a"}
+	testUIDer.SetUID(sp1.SyncTargetRef(), sp1.SyncTargetUID)
+	rw1 := ResolvedWhere{&edgeapi.SinglePlacementSlice{
+		Destinations: []edgeapi.SinglePlacement{asp1},
+	}}
+	testReducer.Set(rw1)
+	if actual, expected := len(testConsumer), 1; actual != expected {
+		t.Errorf("Wrong size after first Set: actual=%d, expected=%d", actual, expected)
+	}
+	if actual, expected := testConsumer[sp1.SyncTargetRef()], sp1.Details(); actual != expected {
+		t.Errorf("Wrong details after first Set: actual=%#v, expected=%#v", actual, expected)
+	}
+	sp1a := SinglePlacement{asp1, "u-aa"}
+	testUIDer.SetUID(sp1.SyncTargetRef(), sp1a.SyncTargetUID)
+	wg.Wait()
+	if actual, expected := len(testConsumer), 1; actual != expected {
+		t.Errorf("Wrong size after first tweak: actual=%d, expected=%d", actual, expected)
+	}
+	if actual, expected := testConsumer[sp1.SyncTargetRef()], sp1a.Details(); actual != expected {
+		t.Errorf("Wrong details after first tweak: actual=%#v, expected=%#v", actual, expected)
+	}
+	exerciseSinglePlacementSliceSetReducer(rng, rw1, 20, 10, testUIDer.TweakNAndWait(rng, 4), testReducer, testUIDer, testConsumer)(t)
+}

--- a/pkg/placement/reducer_test.go
+++ b/pkg/placement/reducer_test.go
@@ -19,7 +19,6 @@ package placement
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 
@@ -120,7 +119,6 @@ func genSinglePlacement(rng *rand.Rand) edgeapi.SinglePlacement {
 func TestSimplePlacementSliceSetReducer(t *testing.T) {
 	rs := rand.NewSource(time.Now().UnixNano())
 	rng := rand.New(rs)
-	var wg sync.WaitGroup
 	testConsumer := NewSinglePlacementSet()
 	testReducer := NewSimplePlacementSliceSetReducer(testConsumer)
 	sp1 := edgeapi.SinglePlacement{Cluster: "ws-a", LocationName: "loc-a",
@@ -137,7 +135,10 @@ func TestSimplePlacementSliceSetReducer(t *testing.T) {
 	}
 	sp1a := sp1
 	sp1a.SyncTargetUID = "u-aa"
-	wg.Wait()
+	rw1a := ResolvedWhere{&edgeapi.SinglePlacementSlice{
+		Destinations: []edgeapi.SinglePlacement{sp1a},
+	}}
+	testReducer.Set(rw1a)
 	if actual, expected := len(testConsumer), 1; actual != expected {
 		t.Errorf("Wrong size after first tweak: actual=%d, expected=%d", actual, expected)
 	}

--- a/pkg/placement/reducer_test.go
+++ b/pkg/placement/reducer_test.go
@@ -26,6 +26,11 @@ import (
 	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
+// exerciseSinglePlacementSliceSetReducer tests a given SinglePlacementSliceSetReducer.
+// For a given SinglePlacementSliceSetReducer implementation Foo,
+// do the following in TestFoo (or whatever you call it):
+// - construct a Foo using a SinglePlacementSet as the consumer
+// - call exerciseSinglePlacementSliceSetReducer on the Foo, its UIDer, and that consumer.
 func exerciseSinglePlacementSliceSetReducer(rng *rand.Rand, initialWhere ResolvedWhere, iterations int, changesPerIteration int, extraPerIteration func(), reducer SinglePlacementSliceSetReducer, uider UIDer, consumer SinglePlacementSet) func(*testing.T) {
 	return func(t *testing.T) {
 		input := initialWhere

--- a/pkg/placement/relay-map.go
+++ b/pkg/placement/relay-map.go
@@ -30,19 +30,19 @@ type relayMap[Key comparable, OuterVal any, InnerVal any] struct {
 	transform      func(OuterVal) InnerVal
 	sync.Mutex
 	theMap    map[Key]OuterVal
-	consumers []DynamicMapConsumer[Key, InnerVal]
+	consumers []MappingReceiver[Key, InnerVal]
 }
 
 type TransformingRelayMap[Key comparable, OuterVal any, InnerVal any] interface {
-	DynamicMapConsumer[Key, OuterVal]
-	DynamicMapProducerWithRelease[Key, InnerVal]
+	MappingReceiver[Key, OuterVal]
+	DynamicMapProviderWithRelease[Key, InnerVal]
 	Len() int
 	Remove(Key)
 }
 
 type RelayMap[Key comparable, Val any] TransformingRelayMap[Key, Val, Val]
 
-var _ DynamicMapProducerWithRelease[string, func()] = &relayMap[string, int64, func()]{}
+var _ DynamicMapProviderWithRelease[string, func()] = &relayMap[string, int64, func()]{}
 
 func NewRelayMap[Key comparable, Val any](dedupConsumers bool) RelayMap[Key, Val] {
 	return NewRelayAndProjectMap[Key, Val, Val](dedupConsumers, func(x Val) Val { return x })
@@ -77,7 +77,7 @@ func (rm *relayMap[Key, OuterVal, InnerVal]) MaybeRelease(key Key, shouldRelease
 	}
 }
 
-func (rm *relayMap[Key, OuterVal, InnerVal]) AddConsumer(consumer DynamicMapConsumer[Key, InnerVal], notifyCurrent bool) {
+func (rm *relayMap[Key, OuterVal, InnerVal]) AddReceiver(consumer MappingReceiver[Key, InnerVal], notifyCurrent bool) {
 	rm.Lock()
 	defer rm.Unlock()
 	if rm.dedupConsumers {

--- a/pkg/placement/relay-map.go
+++ b/pkg/placement/relay-map.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"sync"
+)
+
+// This file defines an implementation of DynamicMapProducer that is simply
+// told what to put in the map.  It allows the values returned to the client
+// to contain a projection of the values in the map.
+
+type relayMap[Key comparable, OuterVal any, InnerVal any] struct {
+	project func(OuterVal) InnerVal
+	sync.Mutex
+	theMap    map[Key]OuterVal
+	consumers []func(Key, InnerVal)
+}
+
+func NewRelayMap[Key comparable, Val any]() DynamicMapProducerWithDelete[Key, Val] {
+	return NewRelayAndProjectMap[Key, Val, Val](func(x Val) Val { return x })
+}
+
+func NewRelayAndProjectMap[Key comparable, OuterVal any, InnerVal any](project func(OuterVal) InnerVal) DynamicMapProducerWithDelete[Key, InnerVal] {
+	return &relayMap[Key, OuterVal, InnerVal]{
+		project: project,
+		theMap:  map[Key]OuterVal{},
+	}
+}
+
+func (rm *relayMap[Key, OuterVal, InnerVal]) Get(key Key, kont func(InnerVal)) {
+	rm.Lock()
+	defer rm.Unlock()
+	kont(rm.project(rm.theMap[key]))
+}
+
+func (rm *relayMap[Key, OuterVal, InnerVal]) MaybeDelete(key Key, shouldDelete func(InnerVal) bool) {
+	rm.Lock()
+	defer rm.Unlock()
+	innerVal := rm.project(rm.theMap[key])
+	if shouldDelete(innerVal) {
+		delete(rm.theMap, key)
+	}
+	for _, consumer := range rm.consumers {
+		consumer(key, innerVal)
+	}
+}
+
+func (rm *relayMap[Key, OuterVal, InnerVal]) AddConsumer(consumer func(Key, InnerVal)) {
+	rm.Lock()
+	defer rm.Unlock()
+	rm.consumers = append(rm.consumers, consumer)
+	for key, outerVal := range rm.theMap {
+		consumer(key, rm.project(outerVal))
+	}
+}
+
+func (rm *relayMap[Key, OuterVal, InnerVal]) Set(key Key, outerVal OuterVal) {
+	innerVal := rm.project(outerVal)
+	rm.Lock()
+	defer rm.Unlock()
+	rm.theMap[key] = outerVal
+	for _, consumer := range rm.consumers {
+		consumer(key, innerVal)
+	}
+}
+
+func (rm *relayMap[Key, OuterVal, InnerVal]) Remove(key Key) {
+	rm.MaybeDelete(key, func(InnerVal) bool { return true })
+}

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+	k8ssets "k8s.io/apimachinery/pkg/util/sets"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// exerciseSetBinder tests a given SetBinder.
+// For a particular SetBinder implementation Foo,
+// invoke this from TestFoo (or whatever).
+// At the current state of development, the test is utterly simple.
+// TODO: make this test harder.
+func exerciseSetBinder(t *testing.T, binder SetBinder) {
+	gr1 := metav1.GroupResource{
+		Group:    "group1.test",
+		Resource: "customresourcedefinitions"}
+	gvr1 := metav1.GroupVersionResource{
+		Group:    gr1.Group,
+		Version:  "v1",
+		Resource: gr1.Resource}
+	workloadPart1 := WorkloadPart{
+		WorkloadPartID{
+			APIGroup: gvr1.Group,
+			Resource: gvr1.Resource,
+			Name:     "crd1",
+		},
+		WorkloadPartDetails{APIVersion: "v1"},
+	}
+	what1 := WorkloadParts{workloadPart1.WorkloadPartID: workloadPart1.WorkloadPartDetails}
+	whatProvider := NewRelayMap[edgeapi.ExternalName, WorkloadParts](false)
+	sc1 := logicalcluster.Name("wm1")
+	ep1Ref := edgeapi.ExternalName{Workspace: sc1.String(), Name: "ep1"}
+	whatProvider.Set(ep1Ref, what1)
+	sp1 := SinglePlacement{
+		edgeapi.SinglePlacement{
+			Location:       edgeapi.ExternalName{Workspace: "inv1", Name: "loc1"},
+			SyncTargetName: "st1",
+		},
+		apimachtypes.UID("uid1"),
+	}
+	sps1 := &edgeapi.SinglePlacementSlice{
+		Destinations: []edgeapi.SinglePlacement{sp1.SinglePlacement},
+	}
+	where1 := ResolvedWhere{sps1}
+	whereProvider := NewRelayMap[edgeapi.ExternalName, ResolvedWhere](false)
+	whereProvider.Set(ep1Ref, where1)
+	whatProvider.AddConsumer(binder.AsWhatConsumer(), true)
+	whereProvider.AddConsumer(binder.AsWhereConsumer(), true)
+	projectionTracker := NewRelayMap[ProjectionKey, *ProjectionPerCluster](false)
+	binder.AddConsumer(projectionTracker, true)
+	if len(projectionTracker.theMap) != 1 {
+		t.Errorf("Wrong amount of stuff in projectionTracker.theMap: %#+v", projectionTracker.theMap)
+	}
+	pk1 := ProjectionKey{gr1, sp1}
+	ppc1 := DynamicMapProducerGet[ProjectionKey, *ProjectionPerCluster](projectionTracker, pk1)
+	if ppc1 == nil {
+		t.Errorf("Missing ProjectionPerCluster")
+		return // to stop linter from complaining about possible nil pointer below
+	}
+	if ppc1.APIVersion != gvr1.Version {
+		t.Errorf("Wrong API version: got %q, expected %q", ppc1.APIVersion, gvr1.Version)
+	}
+	pcTracker := NewRelayMap[logicalcluster.Name, ProjectionDetails](false)
+	ppc1.PerSourceCluster.AddConsumer(pcTracker, true)
+	if len(pcTracker.theMap) != 1 {
+		t.Errorf("Wrong amount of stuff in pcTracker.theMap: %#+v", pcTracker.theMap)
+	}
+	pd1 := DynamicMapProducerGet[logicalcluster.Name, ProjectionDetails](pcTracker, sc1)
+	if pd1.Namespaces != nil {
+		t.Errorf("Expected no namespaces but got %#+v", *pd1.Namespaces)
+	}
+	if pd1.Names == nil {
+		t.Error("Expected one name but got none")
+	} else {
+		expectedNames := k8ssets.NewString(workloadPart1.Name)
+		if !expectedNames.Equal(*pd1.Names) {
+			t.Errorf("Got wrong set of names: expected %v, got %v", expectedNames, *pd1.Names)
+		}
+	}
+}

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -66,8 +66,8 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 	where1 := ResolvedWhere{sps1}
 	whereProvider := NewRelayMap[ExternalName, ResolvedWhere](false)
 	whereProvider.Set(ep1Ref, where1)
-	whatProvider.AddReceiver(binder.AsWhatConsumer(), true)
-	whereProvider.AddReceiver(binder.AsWhereConsumer(), true)
+	whatProvider.AddReceiver(binder.AsWhatReceiver(), true)
+	whereProvider.AddReceiver(binder.AsWhereReceiver(), true)
 	projectionTracker := NewRelayMap[ProjectionKey, *ProjectionPerCluster](false)
 	binder.AddReceiver(projectionTracker, true)
 	if projectionTracker.Len() != 1 {

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -66,15 +66,15 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 	where1 := ResolvedWhere{sps1}
 	whereProvider := NewRelayMap[ExternalName, ResolvedWhere](false)
 	whereProvider.Set(ep1Ref, where1)
-	whatProvider.AddConsumer(binder.AsWhatConsumer(), true)
-	whereProvider.AddConsumer(binder.AsWhereConsumer(), true)
+	whatProvider.AddReceiver(binder.AsWhatConsumer(), true)
+	whereProvider.AddReceiver(binder.AsWhereConsumer(), true)
 	projectionTracker := NewRelayMap[ProjectionKey, *ProjectionPerCluster](false)
-	binder.AddConsumer(projectionTracker, true)
+	binder.AddReceiver(projectionTracker, true)
 	if projectionTracker.Len() != 1 {
 		t.Errorf("Wrong amount of stuff in projectionTracker.theMap: %#+v", projectionTracker)
 	}
 	pk1 := ProjectionKey{gr1, sp1}
-	ppc1 := DynamicMapProducerGet[ProjectionKey, *ProjectionPerCluster](projectionTracker, pk1)
+	ppc1 := DynamicMapProviderGet[ProjectionKey, *ProjectionPerCluster](projectionTracker, pk1)
 	if ppc1 == nil {
 		t.Errorf("Missing ProjectionPerCluster")
 		return // to stop linter from complaining about possible nil pointer below
@@ -83,11 +83,11 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 		t.Errorf("Wrong API version: got %q, expected %q", ppc1.APIVersion, gvr1.Version)
 	}
 	pcTracker := NewRelayMap[logicalcluster.Name, ProjectionDetails](false)
-	ppc1.PerSourceCluster.AddConsumer(pcTracker, true)
+	ppc1.PerSourceCluster.AddReceiver(pcTracker, true)
 	if pcTracker.Len() != 1 {
 		t.Errorf("Wrong amount of stuff in pcTracker.theMap: %#+v", pcTracker)
 	}
-	pd1 := DynamicMapProducerGet[logicalcluster.Name, ProjectionDetails](pcTracker, sc1)
+	pd1 := DynamicMapProviderGet[logicalcluster.Name, ProjectionDetails](pcTracker, sc1)
 	if pd1.Namespaces != nil {
 		t.Errorf("Expected no namespaces but got %#+v", *pd1.Namespaces)
 	}

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -23,8 +23,9 @@ import (
 	apimachtypes "k8s.io/apimachinery/pkg/types"
 	k8ssets "k8s.io/apimachinery/pkg/util/sets"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v3"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 // exerciseSetBinder tests a given SetBinder.

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -70,8 +70,8 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 	whereProvider.AddConsumer(binder.AsWhereConsumer(), true)
 	projectionTracker := NewRelayMap[ProjectionKey, *ProjectionPerCluster](false)
 	binder.AddConsumer(projectionTracker, true)
-	if len(projectionTracker.theMap) != 1 {
-		t.Errorf("Wrong amount of stuff in projectionTracker.theMap: %#+v", projectionTracker.theMap)
+	if projectionTracker.Len() != 1 {
+		t.Errorf("Wrong amount of stuff in projectionTracker.theMap: %#+v", projectionTracker)
 	}
 	pk1 := ProjectionKey{gr1, sp1}
 	ppc1 := DynamicMapProducerGet[ProjectionKey, *ProjectionPerCluster](projectionTracker, pk1)
@@ -84,8 +84,8 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 	}
 	pcTracker := NewRelayMap[logicalcluster.Name, ProjectionDetails](false)
 	ppc1.PerSourceCluster.AddConsumer(pcTracker, true)
-	if len(pcTracker.theMap) != 1 {
-		t.Errorf("Wrong amount of stuff in pcTracker.theMap: %#+v", pcTracker.theMap)
+	if pcTracker.Len() != 1 {
+		t.Errorf("Wrong amount of stuff in pcTracker.theMap: %#+v", pcTracker)
 	}
 	pd1 := DynamicMapProducerGet[logicalcluster.Name, ProjectionDetails](pcTracker, sc1)
 	if pd1.Namespaces != nil {

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -50,22 +50,21 @@ func exerciseSetBinder(t *testing.T, binder SetBinder) {
 		WorkloadPartDetails{APIVersion: "v1"},
 	}
 	what1 := WorkloadParts{workloadPart1.WorkloadPartID: workloadPart1.WorkloadPartDetails}
-	whatProvider := NewRelayMap[edgeapi.ExternalName, WorkloadParts](false)
+	whatProvider := NewRelayMap[ExternalName, WorkloadParts](false)
 	sc1 := logicalcluster.Name("wm1")
-	ep1Ref := edgeapi.ExternalName{Workspace: sc1.String(), Name: "ep1"}
+	ep1Ref := ExternalName{Cluster: sc1, Name: "ep1"}
 	whatProvider.Set(ep1Ref, what1)
-	sp1 := SinglePlacement{
-		edgeapi.SinglePlacement{
-			Location:       edgeapi.ExternalName{Workspace: "inv1", Name: "loc1"},
-			SyncTargetName: "st1",
-		},
-		apimachtypes.UID("uid1"),
+	sp1 := edgeapi.SinglePlacement{
+		Cluster:        "inv1",
+		LocationName:   "loc1",
+		SyncTargetName: "st1",
+		SyncTargetUID:  apimachtypes.UID("uid1"),
 	}
 	sps1 := &edgeapi.SinglePlacementSlice{
-		Destinations: []edgeapi.SinglePlacement{sp1.SinglePlacement},
+		Destinations: []edgeapi.SinglePlacement{sp1},
 	}
 	where1 := ResolvedWhere{sps1}
-	whereProvider := NewRelayMap[edgeapi.ExternalName, ResolvedWhere](false)
+	whereProvider := NewRelayMap[ExternalName, ResolvedWhere](false)
 	whereProvider.Set(ep1Ref, where1)
 	whatProvider.AddConsumer(binder.AsWhatConsumer(), true)
 	whereProvider.AddConsumer(binder.AsWhereConsumer(), true)

--- a/pkg/placement/simple-reducer.go
+++ b/pkg/placement/simple-reducer.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"sync"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+)
+
+// SimplePlacementSliceSetReducer is the simplest possible
+// implementation of SinglePlacementSliceSetReducer.
+type SimplePlacementSliceSetReducer struct {
+	uider UIDer
+	sync.Mutex
+	consumers []SinglePlacementSetChangeConsumer
+	enhanced  SinglePlacementSet
+}
+
+var _ SinglePlacementSliceSetReducer = &SimplePlacementSliceSetReducer{}
+
+func NewSimplePlacementSliceSetReducer(uider UIDer, consumers ...SinglePlacementSetChangeConsumer) *SimplePlacementSliceSetReducer {
+	ans := &SimplePlacementSliceSetReducer{
+		uider:     uider,
+		consumers: consumers,
+		enhanced:  NewSinglePlacementSet(),
+	}
+	uider.AddConsumer(ans.noteUID)
+	return ans
+}
+
+func (spsr *SimplePlacementSliceSetReducer) Set(newSlices ResolvedWhere) {
+	spsr.Lock()
+	defer spsr.Unlock()
+	for key, val := range spsr.enhanced {
+		sp := val.Complete(key)
+		for _, consumer := range spsr.consumers {
+			consumer.Remove(sp)
+		}
+	}
+	spsr.setLocked(newSlices)
+}
+
+func (spsr *SimplePlacementSliceSetReducer) setLocked(newSlices ResolvedWhere) {
+	spsr.enhanced = NewSinglePlacementSet()
+	enumerateSinglePlacementSlices(newSlices, func(apiSP edgeapi.SinglePlacement) {
+		syncTargetID := edgeapi.ExternalName{Workspace: apiSP.Location.Workspace, Name: apiSP.SyncTargetName}
+		syncTargetUID := spsr.uider.GetUID(syncTargetID)
+		syncTargetDetails := SinglePlacementDetails{
+			LocationName:  apiSP.Location.Name,
+			SyncTargetUID: syncTargetUID,
+		}
+		spsr.enhanced[syncTargetID] = syncTargetDetails
+		fullSP := SinglePlacement{SinglePlacement: apiSP, SyncTargetUID: syncTargetUID}
+		for _, consumer := range spsr.consumers {
+			consumer.Add(fullSP)
+		}
+	})
+}
+
+func (spsr *SimplePlacementSliceSetReducer) noteUID(en edgeapi.ExternalName, uid apimachtypes.UID) {
+	spsr.Lock()
+	defer spsr.Unlock()
+	if details, ok := spsr.enhanced[en]; ok {
+		details.SyncTargetUID = uid
+		spsr.enhanced[en] = details
+		fullSP := details.Complete(en)
+		for _, consumer := range spsr.consumers {
+			consumer.Add(fullSP)
+		}
+
+	}
+}
+
+func enumerateSinglePlacementSlices(slices []*edgeapi.SinglePlacementSlice, consumer func(edgeapi.SinglePlacement)) {
+	for _, slice := range slices {
+		if slice != nil {
+			for _, sp := range slice.Destinations {
+				consumer(sp)
+			}
+		}
+	}
+}

--- a/pkg/placement/simple-reducer.go
+++ b/pkg/placement/simple-reducer.go
@@ -60,7 +60,7 @@ func (spsr *SimplePlacementSliceSetReducer) setLocked(newSlices ResolvedWhere) {
 	spsr.enhanced = NewSinglePlacementSet()
 	enumerateSinglePlacementSlices(newSlices, func(apiSP edgeapi.SinglePlacement) {
 		syncTargetID := edgeapi.ExternalName{Workspace: apiSP.Location.Workspace, Name: apiSP.SyncTargetName}
-		syncTargetUID := spsr.uider.GetUID(syncTargetID)
+		syncTargetUID := spsr.uider.Get(syncTargetID)
 		syncTargetDetails := SinglePlacementDetails{
 			LocationName:  apiSP.Location.Name,
 			SyncTargetUID: syncTargetUID,

--- a/pkg/placement/simple-reducer.go
+++ b/pkg/placement/simple-reducer.go
@@ -60,7 +60,7 @@ func (spsr *SimplePlacementSliceSetReducer) setLocked(newSlices ResolvedWhere) {
 	spsr.enhanced = NewSinglePlacementSet()
 	enumerateSinglePlacementSlices(newSlices, func(apiSP edgeapi.SinglePlacement) {
 		syncTargetID := edgeapi.ExternalName{Workspace: apiSP.Location.Workspace, Name: apiSP.SyncTargetName}
-		syncTargetUID := spsr.uider.Get(syncTargetID)
+		syncTargetUID := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](spsr.uider, syncTargetID)
 		syncTargetDetails := SinglePlacementDetails{
 			LocationName:  apiSP.Location.Name,
 			SyncTargetUID: syncTargetUID,

--- a/pkg/placement/simple-reducer.go
+++ b/pkg/placement/simple-reducer.go
@@ -44,7 +44,7 @@ func NewSimplePlacementSliceSetReducer(consumers ...SinglePlacementSetChangeCons
 
 // SimplePlacementSliceSetReducerAsUIDConsumer adds the Set method that
 // SimplePlacementSliceSetReducer needs in order to implement
-// DynamicMapConsumer to receive UID information.
+// MappingReceiver to receive UID information.
 type SimplePlacementSliceSetReducerAsUIDConsumer struct {
 	*SimplePlacementSliceSetReducer
 }

--- a/pkg/placement/simple-reducer.go
+++ b/pkg/placement/simple-reducer.go
@@ -19,8 +19,9 @@ package placement
 import (
 	"sync"
 
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 	apimachtypes "k8s.io/apimachinery/pkg/types"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 // SimplePlacementSliceSetReducer is the simplest possible

--- a/pkg/placement/single-placement-set.go
+++ b/pkg/placement/single-placement-set.go
@@ -27,29 +27,22 @@ type SinglePlacementDetails struct {
 	SyncTargetUID apimachtypes.UID
 }
 
-func (sp SinglePlacement) Details() SinglePlacementDetails {
-	return SinglePlacementDetails{LocationName: sp.Location.Name, SyncTargetUID: sp.SyncTargetUID}
+func SPDetails(sp edgeapi.SinglePlacement) SinglePlacementDetails {
+	return SinglePlacementDetails{LocationName: sp.LocationName, SyncTargetUID: sp.SyncTargetUID}
 }
 
-func (spd SinglePlacementDetails) Complete(en edgeapi.ExternalName) SinglePlacement {
-	return SinglePlacement{
-		SinglePlacement: spd.ToAPI(en),
-		SyncTargetUID:   spd.SyncTargetUID,
-	}
-}
-
-func (spd SinglePlacementDetails) ToAPI(en edgeapi.ExternalName) edgeapi.SinglePlacement {
+func (spd SinglePlacementDetails) Complete(en ExternalName) edgeapi.SinglePlacement {
 	return edgeapi.SinglePlacement{
-		Location: edgeapi.ExternalName{
-			Workspace: en.Workspace,
-			Name:      spd.LocationName},
+		Cluster:        en.Cluster.String(),
+		LocationName:   spd.LocationName,
 		SyncTargetName: en.Name,
+		SyncTargetUID:  spd.SyncTargetUID,
 	}
 }
 
 // SinglePlacementSet maps ID of SyncTarget to the rest of the information
-// in each SinglePlacement.
-type SinglePlacementSet map[edgeapi.ExternalName]SinglePlacementDetails
+// in each edgeapi.SinglePlacement.
+type SinglePlacementSet map[ExternalName]SinglePlacementDetails
 
 var _ SinglePlacementSetChangeConsumer = NewSinglePlacementSet()
 
@@ -57,13 +50,13 @@ func NewSinglePlacementSet() SinglePlacementSet {
 	return SinglePlacementSet{}
 }
 
-func (sps SinglePlacementSet) Add(sp SinglePlacement) {
-	key := sp.SyncTargetRef()
-	sps[key] = sp.Details()
+func (sps SinglePlacementSet) Add(sp edgeapi.SinglePlacement) {
+	key := ExternalName{}.OfSPTarget(sp)
+	sps[key] = SPDetails(sp)
 }
 
-func (sps SinglePlacementSet) Remove(sp SinglePlacement) {
-	key := sp.SyncTargetRef()
+func (sps SinglePlacementSet) Remove(sp edgeapi.SinglePlacement) {
+	key := ExternalName{}.OfSPTarget(sp)
 	delete(sps, key)
 }
 

--- a/pkg/placement/single-placement-set.go
+++ b/pkg/placement/single-placement-set.go
@@ -44,7 +44,7 @@ func (spd SinglePlacementDetails) Complete(en ExternalName) edgeapi.SinglePlacem
 // in each edgeapi.SinglePlacement.
 type SinglePlacementSet map[ExternalName]SinglePlacementDetails
 
-var _ SinglePlacementSetChangeConsumer = NewSinglePlacementSet()
+var _ SinglePlacementSetChangeReceiver = NewSinglePlacementSet()
 
 func NewSinglePlacementSet() SinglePlacementSet {
 	return SinglePlacementSet{}

--- a/pkg/placement/single-placement-set.go
+++ b/pkg/placement/single-placement-set.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+type SinglePlacementDetails struct {
+	LocationName  string
+	SyncTargetUID apimachtypes.UID
+}
+
+func (sp SinglePlacement) Details() SinglePlacementDetails {
+	return SinglePlacementDetails{LocationName: sp.Location.Name, SyncTargetUID: sp.SyncTargetUID}
+}
+
+func (spd SinglePlacementDetails) Complete(en edgeapi.ExternalName) SinglePlacement {
+	return SinglePlacement{
+		SinglePlacement: spd.ToAPI(en),
+		SyncTargetUID:   spd.SyncTargetUID,
+	}
+}
+
+func (spd SinglePlacementDetails) ToAPI(en edgeapi.ExternalName) edgeapi.SinglePlacement {
+	return edgeapi.SinglePlacement{
+		Location: edgeapi.ExternalName{
+			Workspace: en.Workspace,
+			Name:      spd.LocationName},
+		SyncTargetName: en.Name,
+	}
+}
+
+// SinglePlacementSet maps ID of SyncTarget to the rest of the information
+// in each SinglePlacement.
+type SinglePlacementSet map[edgeapi.ExternalName]SinglePlacementDetails
+
+var _ SinglePlacementSetChangeConsumer = NewSinglePlacementSet()
+
+func NewSinglePlacementSet() SinglePlacementSet {
+	return SinglePlacementSet{}
+}
+
+func (sps SinglePlacementSet) Add(sp SinglePlacement) {
+	key := sp.SyncTargetRef()
+	sps[key] = sp.Details()
+}
+
+func (sps SinglePlacementSet) Remove(sp SinglePlacement) {
+	key := sp.SyncTargetRef()
+	delete(sps, key)
+}
+
+func (sps SinglePlacementSet) Equals(other SinglePlacementSet) bool {
+	if len(sps) != len(other) {
+		return false
+	}
+	for key, val := range sps {
+		if val != other[key] {
+			return false
+		}
+	}
+	return true
+}
+
+func (sps SinglePlacementSet) Sub(other SinglePlacementSet) SinglePlacementSet {
+	ans := NewSinglePlacementSet()
+	for key, val := range sps {
+		if other[key] != val {
+			ans[key] = val
+		}
+	}
+	return ans
+}

--- a/pkg/placement/test-apimap-provider.go
+++ b/pkg/placement/test-apimap-provider.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"sync"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+)
+
+// TestAPIMapProducer is a simple implementation of APIMapProvider.
+// It relies on a base map provider and caches the mappings,
+// and deletes unneeded entries from the base map provider.
+// In the locking order:
+// - callers of the TestAPIMapProducer methods precede the baseProducer
+// - callers of NewTestAPIMapProducer precede the baseProducer
+// - the baseProducer precedes this TestAPIMapProducer
+// - this TestAPIMapProducer precedes each of its Clients
+type TestAPIMapProducer struct {
+	// baseProducer precedes this TestAPIMapProducer in the locking order
+	baseProducer BaseAPIMapProducer
+
+	sync.Mutex
+
+	clusters map[logicalcluster.Name]ClientTracker[ScopedAPIProducer]
+}
+
+type BaseAPIMapProducer DynamicMapProducerWithDelete[logicalcluster.Name, ScopedAPIProducer]
+
+var _ APIMapProvider = &TestAPIMapProducer{}
+
+func (tamp *TestAPIMapProducer) noteProducer(cluster logicalcluster.Name, producer ScopedAPIProducer) {
+	tamp.Lock()
+	defer tamp.Unlock()
+	clusterData, found := tamp.clusters[cluster]
+	if !found {
+		return
+	}
+	clusterData.SetProvider(producer)
+	tamp.clusters[cluster] = clusterData
+}
+
+func NewTestAPIMapProducer(baseProducer BaseAPIMapProducer) *TestAPIMapProducer {
+	ans := &TestAPIMapProducer{
+		baseProducer: baseProducer,
+		clusters:     map[logicalcluster.Name]ClientTracker[ScopedAPIProducer]{},
+	}
+	baseProducer.AddConsumer(ans.noteProducer)
+	return ans
+}
+
+func (tamp *TestAPIMapProducer) AddClient(cluster logicalcluster.Name, client Client[ScopedAPIProducer]) {
+	tamp.baseProducer.Get(cluster, func(producer ScopedAPIProducer) {
+		tamp.Lock()
+		defer tamp.Unlock()
+		clusterData, found := tamp.clusters[cluster]
+		if !found {
+			clusterData = NewClientTracker[ScopedAPIProducer]()
+		}
+		clusterData.AddClient(client)
+		client.SetProvider(producer)
+		tamp.clusters[cluster] = clusterData
+	})
+}
+
+func (tamp *TestAPIMapProducer) RemoveClient(cluster logicalcluster.Name, client Client[ScopedAPIProducer]) {
+	tamp.baseProducer.MaybeDelete(cluster, func(ScopedAPIProducer) bool {
+		tamp.Lock()
+		defer tamp.Unlock()
+		clusterData, found := tamp.clusters[cluster]
+		if !found {
+			return true
+		}
+		release := clusterData.RemoveClient(client)
+		if release {
+			delete(tamp.clusters, cluster)
+		}
+		return release
+	})
+}

--- a/pkg/placement/test_uider.go
+++ b/pkg/placement/test_uider.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+// testUIDer is a UIDer that makes up an association whenever asked
+// for one it has not already made up.
+// The WaitGroup is so that tests can know when all the asynchronous processing is done.
+type testUIDer struct {
+	wg *sync.WaitGroup
+	sync.Mutex
+	rng       *rand.Rand
+	current   []UIDPair
+	consumers []func(edgeapi.ExternalName, apimachtypes.UID)
+}
+
+type UIDPair struct {
+	en  edgeapi.ExternalName
+	uid apimachtypes.UID
+}
+
+var _ UIDer = &testUIDer{}
+
+func NewTestUIDer(rng *rand.Rand, wg *sync.WaitGroup) *testUIDer {
+	return &testUIDer{
+		wg:      wg,
+		rng:     rng,
+		current: []UIDPair{},
+	}
+}
+
+func (tu *testUIDer) AddConsumer(consumer func(edgeapi.ExternalName, apimachtypes.UID)) {
+	tu.Lock()
+	defer tu.Unlock()
+	tu.consumers = append(tu.consumers, consumer)
+}
+
+func (tu *testUIDer) TweakOne(rng *rand.Rand) {
+	tu.Lock()
+	defer tu.Unlock()
+	var en edgeapi.ExternalName
+	newUID := apimachtypes.UID(fmt.Sprintf("u%d", tu.rng.Intn(1000000000)))
+	if len(tu.current) == 0 || rng.Intn(3) == 0 { // add a new one
+		en = edgeapi.ExternalName{
+			Workspace: fmt.Sprintf("ws%d", tu.rng.Intn(1000)),
+			Name:      fmt.Sprintf("n%d", tu.rng.Intn(1000)),
+		}
+		tu.current = append(tu.current, UIDPair{en, newUID})
+	} else { // modify an existing one
+		which := rng.Intn(len(tu.current))
+		tu.current[which].uid = newUID
+		en = tu.current[which].en
+	}
+	for _, consumer := range tu.consumers {
+		consumer(en, newUID)
+	}
+}
+
+func (tu *testUIDer) TweakNAndWait(rng *rand.Rand, n int) func() {
+	return func() {
+		for iter := 1; iter <= n; iter++ {
+			tu.TweakOne(rng)
+		}
+		tu.wg.Wait()
+	}
+}
+
+func (tu *testUIDer) GetUID(en edgeapi.ExternalName) apimachtypes.UID {
+	tu.Lock()
+	defer tu.Unlock()
+	if uid, ok := tu.lookupLocked(en); ok {
+		return uid
+	}
+	ans := apimachtypes.UID(fmt.Sprintf("u%d", tu.rng.Intn(1000000000)))
+	tu.current = append(tu.current, UIDPair{en, ans})
+	// Notify asynchronously in case GetUID was called while some consumer is locked
+	tu.wg.Add(1)
+	go func() {
+		defer tu.wg.Add(-1)
+		tu.Lock()
+		defer tu.Unlock()
+		uid, ok := tu.lookupLocked(en)
+		if !ok {
+			panic(tu)
+		}
+		for _, consumer := range tu.consumers {
+			consumer(en, uid)
+		}
+	}()
+	return ans
+}
+
+func (tu *testUIDer) lookupLocked(en edgeapi.ExternalName) (apimachtypes.UID, bool) {
+	for _, pair := range tu.current {
+		if pair.en == en {
+			return pair.uid, true
+		}
+	}
+	return "", false
+}
+
+func (tu *testUIDer) SetUID(en edgeapi.ExternalName, uid apimachtypes.UID) {
+	tu.Lock()
+	defer tu.Unlock()
+	found := false
+	for idx, pair := range tu.current {
+		if pair.en == en {
+			tu.current[idx].uid = uid
+			found = true
+			break
+		}
+	}
+	if !found {
+		tu.current = append(tu.current, UIDPair{en, uid})
+	}
+	for _, consumer := range tu.consumers {
+		consumer(en, uid)
+	}
+}

--- a/pkg/placement/test_uider.go
+++ b/pkg/placement/test_uider.go
@@ -33,7 +33,7 @@ type testUIDer struct {
 	sync.Mutex
 	rng       *rand.Rand
 	current   []UIDPair
-	consumers []DynamicMapConsumer[ExternalName, apimachtypes.UID]
+	consumers []MappingReceiver[ExternalName, apimachtypes.UID]
 }
 
 type UIDPair struct {
@@ -51,7 +51,7 @@ func NewTestUIDer(rng *rand.Rand, wg *sync.WaitGroup) *testUIDer {
 	}
 }
 
-func (tu *testUIDer) AddConsumer(consumer DynamicMapConsumer[ExternalName, apimachtypes.UID], notifyCurrent bool) {
+func (tu *testUIDer) AddReceiver(consumer MappingReceiver[ExternalName, apimachtypes.UID], notifyCurrent bool) {
 	tu.Lock()
 	defer tu.Unlock()
 	tu.consumers = append(tu.consumers, consumer)

--- a/pkg/placement/test_uider.go
+++ b/pkg/placement/test_uider.go
@@ -88,7 +88,7 @@ func (tu *testUIDer) TweakNAndWait(rng *rand.Rand, n int) func() {
 	}
 }
 
-func (tu *testUIDer) GetUID(en edgeapi.ExternalName) apimachtypes.UID {
+func (tu *testUIDer) Get(en edgeapi.ExternalName) apimachtypes.UID {
 	tu.Lock()
 	defer tu.Unlock()
 	if uid, ok := tu.lookupLocked(en); ok {
@@ -122,7 +122,7 @@ func (tu *testUIDer) lookupLocked(en edgeapi.ExternalName) (apimachtypes.UID, bo
 	return "", false
 }
 
-func (tu *testUIDer) SetUID(en edgeapi.ExternalName, uid apimachtypes.UID) {
+func (tu *testUIDer) Set(en edgeapi.ExternalName, uid apimachtypes.UID) {
 	tu.Lock()
 	defer tu.Unlock()
 	found := false

--- a/pkg/placement/test_uider.go
+++ b/pkg/placement/test_uider.go
@@ -88,11 +88,12 @@ func (tu *testUIDer) TweakNAndWait(rng *rand.Rand, n int) func() {
 	}
 }
 
-func (tu *testUIDer) Get(en edgeapi.ExternalName) apimachtypes.UID {
+func (tu *testUIDer) Get(en edgeapi.ExternalName, kont func(apimachtypes.UID)) {
 	tu.Lock()
 	defer tu.Unlock()
 	if uid, ok := tu.lookupLocked(en); ok {
-		return uid
+		kont(uid)
+		return
 	}
 	ans := apimachtypes.UID(fmt.Sprintf("u%d", tu.rng.Intn(1000000000)))
 	tu.current = append(tu.current, UIDPair{en, ans})
@@ -110,7 +111,7 @@ func (tu *testUIDer) Get(en edgeapi.ExternalName) apimachtypes.UID {
 			consumer(en, uid)
 		}
 	}()
-	return ans
+	kont(ans)
 }
 
 func (tu *testUIDer) lookupLocked(en edgeapi.ExternalName) (apimachtypes.UID, bool) {

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -29,17 +29,17 @@ func TestTestUIDer(t *testing.T) {
 	var wg sync.WaitGroup
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	uider := NewTestUIDer(rng, &wg)
-	testConsumer := &testUIDConsumer{
+	testReceiver := &testUIDReceiver{
 		current: map[ExternalName]apimachtypes.UID{},
 	}
-	uider.AddReceiver(testConsumer, false)
+	uider.AddReceiver(testReceiver, false)
 	en1 := ExternalName{Cluster: "ws1", Name: "n1"}
 	en2 := ExternalName{Cluster: "ws1", Name: "n2"}
 	uid1 := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en1)
 	uid2 := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en2)
 	wg.Wait()
-	if len(testConsumer.current) != 2 {
-		t.Errorf("Insufficient mappings: %v", testConsumer.current)
+	if len(testReceiver.current) != 2 {
+		t.Errorf("Insufficient mappings: %v", testReceiver.current)
 	}
 	if actual, expected := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
@@ -49,12 +49,12 @@ func TestTestUIDer(t *testing.T) {
 	}
 }
 
-type testUIDConsumer struct {
+type testUIDReceiver struct {
 	sync.Mutex
 	current map[ExternalName]apimachtypes.UID
 }
 
-func (tc *testUIDConsumer) Set(en ExternalName, uid apimachtypes.UID) {
+func (tc *testUIDReceiver) Set(en ExternalName, uid apimachtypes.UID) {
 	tc.Lock()
 	defer tc.Unlock()
 	tc.current[en] = uid

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	apimachtypes "k8s.io/apimachinery/pkg/types"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+)
+
+func TestTestUIDer(t *testing.T) {
+	var wg sync.WaitGroup
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	uider := NewTestUIDer(rng, &wg)
+	testConsumer := &testUIDConsumer{
+		current: map[edgeapi.ExternalName]apimachtypes.UID{},
+	}
+	uider.AddConsumer(testConsumer.Note)
+	en1 := edgeapi.ExternalName{Workspace: "ws1", Name: "n1"}
+	en2 := edgeapi.ExternalName{Workspace: "ws1", Name: "n2"}
+	uid1 := uider.GetUID(en1)
+	uid2 := uider.GetUID(en2)
+	wg.Wait()
+	if len(testConsumer.current) != 2 {
+		t.Errorf("Insufficient mappings: %v", testConsumer.current)
+	}
+	if actual, expected := uider.GetUID(en1), uid1; actual != expected {
+		t.Errorf("Got %q instead of %q", actual, expected)
+	}
+	if actual, expected := uider.GetUID(en2), uid2; actual != expected {
+		t.Errorf("Got %q instead of %q", actual, expected)
+	}
+}
+
+type testUIDConsumer struct {
+	sync.Mutex
+	current map[edgeapi.ExternalName]apimachtypes.UID
+}
+
+func (tc *testUIDConsumer) Note(en edgeapi.ExternalName, uid apimachtypes.UID) {
+	tc.Lock()
+	defer tc.Unlock()
+	tc.current[en] = uid
+}

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -37,16 +37,16 @@ func TestTestUIDer(t *testing.T) {
 	uider.AddConsumer(testConsumer.Note)
 	en1 := edgeapi.ExternalName{Workspace: "ws1", Name: "n1"}
 	en2 := edgeapi.ExternalName{Workspace: "ws1", Name: "n2"}
-	uid1 := uider.Get(en1)
-	uid2 := uider.Get(en2)
+	uid1 := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en1)
+	uid2 := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en2)
 	wg.Wait()
 	if len(testConsumer.current) != 2 {
 		t.Errorf("Insufficient mappings: %v", testConsumer.current)
 	}
-	if actual, expected := uider.Get(en1), uid1; actual != expected {
+	if actual, expected := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
-	if actual, expected := uider.Get(en2), uid2; actual != expected {
+	if actual, expected := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en2), uid2; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
 }

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	apimachtypes "k8s.io/apimachinery/pkg/types"
-
-	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
 )
 
 func TestTestUIDer(t *testing.T) {
@@ -32,31 +30,31 @@ func TestTestUIDer(t *testing.T) {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	uider := NewTestUIDer(rng, &wg)
 	testConsumer := &testUIDConsumer{
-		current: map[edgeapi.ExternalName]apimachtypes.UID{},
+		current: map[ExternalName]apimachtypes.UID{},
 	}
 	uider.AddConsumer(testConsumer, false)
-	en1 := edgeapi.ExternalName{Workspace: "ws1", Name: "n1"}
-	en2 := edgeapi.ExternalName{Workspace: "ws1", Name: "n2"}
-	uid1 := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en1)
-	uid2 := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en2)
+	en1 := ExternalName{Cluster: "ws1", Name: "n1"}
+	en2 := ExternalName{Cluster: "ws1", Name: "n2"}
+	uid1 := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en1)
+	uid2 := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en2)
 	wg.Wait()
 	if len(testConsumer.current) != 2 {
 		t.Errorf("Insufficient mappings: %v", testConsumer.current)
 	}
-	if actual, expected := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
+	if actual, expected := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
-	if actual, expected := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en2), uid2; actual != expected {
+	if actual, expected := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en2), uid2; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
 }
 
 type testUIDConsumer struct {
 	sync.Mutex
-	current map[edgeapi.ExternalName]apimachtypes.UID
+	current map[ExternalName]apimachtypes.UID
 }
 
-func (tc *testUIDConsumer) Set(en edgeapi.ExternalName, uid apimachtypes.UID) {
+func (tc *testUIDConsumer) Set(en ExternalName, uid apimachtypes.UID) {
 	tc.Lock()
 	defer tc.Unlock()
 	tc.current[en] = uid

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -34,7 +34,7 @@ func TestTestUIDer(t *testing.T) {
 	testConsumer := &testUIDConsumer{
 		current: map[edgeapi.ExternalName]apimachtypes.UID{},
 	}
-	uider.AddConsumer(testConsumer.Note)
+	uider.AddConsumer(testConsumer, false)
 	en1 := edgeapi.ExternalName{Workspace: "ws1", Name: "n1"}
 	en2 := edgeapi.ExternalName{Workspace: "ws1", Name: "n2"}
 	uid1 := DynamicMapProducerGet[edgeapi.ExternalName, apimachtypes.UID](uider, en1)
@@ -56,7 +56,7 @@ type testUIDConsumer struct {
 	current map[edgeapi.ExternalName]apimachtypes.UID
 }
 
-func (tc *testUIDConsumer) Note(en edgeapi.ExternalName, uid apimachtypes.UID) {
+func (tc *testUIDConsumer) Set(en edgeapi.ExternalName, uid apimachtypes.UID) {
 	tc.Lock()
 	defer tc.Unlock()
 	tc.current[en] = uid

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -32,19 +32,19 @@ func TestTestUIDer(t *testing.T) {
 	testConsumer := &testUIDConsumer{
 		current: map[ExternalName]apimachtypes.UID{},
 	}
-	uider.AddConsumer(testConsumer, false)
+	uider.AddReceiver(testConsumer, false)
 	en1 := ExternalName{Cluster: "ws1", Name: "n1"}
 	en2 := ExternalName{Cluster: "ws1", Name: "n2"}
-	uid1 := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en1)
-	uid2 := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en2)
+	uid1 := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en1)
+	uid2 := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en2)
 	wg.Wait()
 	if len(testConsumer.current) != 2 {
 		t.Errorf("Insufficient mappings: %v", testConsumer.current)
 	}
-	if actual, expected := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
+	if actual, expected := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en1), uid1; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
-	if actual, expected := DynamicMapProducerGet[ExternalName, apimachtypes.UID](uider, en2), uid2; actual != expected {
+	if actual, expected := DynamicMapProviderGet[ExternalName, apimachtypes.UID](uider, en2), uid2; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
 }

--- a/pkg/placement/test_uider_test.go
+++ b/pkg/placement/test_uider_test.go
@@ -37,16 +37,16 @@ func TestTestUIDer(t *testing.T) {
 	uider.AddConsumer(testConsumer.Note)
 	en1 := edgeapi.ExternalName{Workspace: "ws1", Name: "n1"}
 	en2 := edgeapi.ExternalName{Workspace: "ws1", Name: "n2"}
-	uid1 := uider.GetUID(en1)
-	uid2 := uider.GetUID(en2)
+	uid1 := uider.Get(en1)
+	uid2 := uider.Get(en2)
 	wg.Wait()
 	if len(testConsumer.current) != 2 {
 		t.Errorf("Insufficient mappings: %v", testConsumer.current)
 	}
-	if actual, expected := uider.GetUID(en1), uid1; actual != expected {
+	if actual, expected := uider.Get(en1), uid1; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
-	if actual, expected := uider.GetUID(en2), uid2; actual != expected {
+	if actual, expected := uider.Get(en2), uid2; actual != expected {
 		t.Errorf("Got %q instead of %q", actual, expected)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR is the first draft of the internal interfaces among the parts of the placement translator process of the 2023q1 PoC.

This draft assumes that #155 will be resolved by switching to using the SyncTarget UID instead of its name in the construction of the mailbox workspace name.

## Related issue(s)

Fixes #
