### PR TITLE
✨ Short names for edgeplacements and singleplacementslices

### DIFF
--- a/config/crds/edge.kcp.io_edgeplacements.yaml
+++ b/config/crds/edge.kcp.io_edgeplacements.yaml
@@ -12,6 +12,8 @@ spec:
     kind: EdgePlacement
     listKind: EdgePlacementList
     plural: edgeplacements
+    shortNames:
+    - epl
     singular: edgeplacement
   scope: Cluster
   versions:

--- a/config/crds/edge.kcp.io_singleplacementslices.yaml
+++ b/config/crds/edge.kcp.io_singleplacementslices.yaml
@@ -12,6 +12,8 @@ spec:
     kind: SinglePlacementSlice
     listKind: SinglePlacementSliceList
     plural: singleplacementslices
+    shortNames:
+    - sps
     singular: singleplacementslice
   scope: Cluster
   versions:

--- a/config/exports/apiexport-edge.kcp.io.yaml
+++ b/config/exports/apiexport-edge.kcp.io.yaml
@@ -5,6 +5,6 @@ metadata:
   name: edge.kcp.io
 spec:
   latestResourceSchemas:
-  - v230126-0a8bf97.edgeplacements.edge.kcp.io
-  - v230221-fa5dc39.singleplacementslices.edge.kcp.io
+  - v230228-0f548e5.singleplacementslices.edge.kcp.io
+  - v230228-7fe2c02.edgeplacements.edge.kcp.io
 status: {}

--- a/config/exports/apiresourceschema-edgeplacements.edge.kcp.io.yaml
+++ b/config/exports/apiresourceschema-edgeplacements.edge.kcp.io.yaml
@@ -2,13 +2,15 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v230126-0a8bf97.edgeplacements.edge.kcp.io
+  name: v230228-7fe2c02.edgeplacements.edge.kcp.io
 spec:
   group: edge.kcp.io
   names:
     kind: EdgePlacement
     listKind: EdgePlacementList
     plural: edgeplacements
+    shortNames:
+    - epl
     singular: edgeplacement
   scope: Cluster
   versions:

--- a/config/exports/apiresourceschema-singleplacementslices.edge.kcp.io.yaml
+++ b/config/exports/apiresourceschema-singleplacementslices.edge.kcp.io.yaml
@@ -2,13 +2,15 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v230221-fa5dc39.singleplacementslices.edge.kcp.io
+  name: v230228-0f548e5.singleplacementslices.edge.kcp.io
 spec:
   group: edge.kcp.io
   names:
     kind: SinglePlacementSlice
     listKind: SinglePlacementSliceList
     plural: singleplacementslices
+    shortNames:
+    - sps
     singular: singleplacementslice
   scope: Cluster
   versions:

--- a/pkg/apis/edge/v1alpha1/edge-placement.go
+++ b/pkg/apis/edge/v1alpha1/edge-placement.go
@@ -41,7 +41,7 @@ import (
 // +crd
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=epl
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type EdgePlacement struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/apis/edge/v1alpha1/single-placement.go
+++ b/pkg/apis/edge/v1alpha1/single-placement.go
@@ -36,7 +36,7 @@ const SourcePlacementLabelKey string = "edge.kcp.io/source-placement"
 // +crd
 // +genclient
 // +genclient:nonNamespaced
-// +kubebuilder:resource:scope=Cluster,path=singleplacementslices
+// +kubebuilder:resource:scope=Cluster,shortName=sps,path=singleplacementslices
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type SinglePlacementSlice struct {
 	metav1.TypeMeta `json:",inline"`


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR saves a few keystrokes when we use kubectl, e.g. `get singleplacementslices` -> `get sps`.

Short name `ep` is taken by kube endpoints, so using `epl` for edgeplacements.
