### PR TITLE
🐛 Attempt to fix broken reference to example1

### DIFF
--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
@@ -46,7 +46,7 @@ command line parameters, then `$KUBECONFIG`, then `~/.kube/config`.
 ## Try It
 
 The nascent placement translator can be exercised following the
-scenario in [example1](example1).  You do not need the scheduler nor
+scenario in [example1](../example1).  You do not need the scheduler nor
 the mailbox controller.
 
 When you get to the step of "Populate the edge service provider


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR attempts to fix the reference from placement-translator.md to example1.md, in a way that works after it runs through the conversion to github pages.

## Related issue(s)

Fixes #
