### PR TITLE
✨ Tweak `kcp-kubeconfig` flag for the scheduler

### DIFF
--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -17,15 +17,10 @@ limitations under the License.
 package options
 
 import (
-	"errors"
-	"strings"
-
 	"github.com/spf13/pflag"
 
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
-
-	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 )
 
 type Options struct {
@@ -44,11 +39,7 @@ func NewOptions() *Options {
 }
 
 func (options *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&options.KcpKubeconfig, "kcp-kubeconfig", options.KcpKubeconfig, "Kubeconfig file for -from cluster.")
-	fs.Var(kcpfeatures.NewFlagValue(), "feature-gates", ""+
-		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n"+strings.Join(kcpfeatures.KnownFeatures(), "\n")) // hide kube-only gates
-
+	fs.StringVar(&options.KcpKubeconfig, "kcp-kubeconfig", options.KcpKubeconfig, "Kubeconfig file for kcp")
 	options.Logs.AddFlags(fs)
 }
 
@@ -57,8 +48,5 @@ func (options *Options) Complete() error {
 }
 
 func (options *Options) Validate() error {
-	if options.KcpKubeconfig == "" {
-		return errors.New("--kcp-kubeconfig is required")
-	}
 	return nil
 }

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/edge-scheduler.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/edge-scheduler.md
@@ -77,7 +77,7 @@ Go to `root:edge` workspace and run the edge scheduler.
 ```console
 kubectl ws root:edge
 cd ~/edge-mc
-go run cmd/scheduler/main.go --kcp-kubeconfig=~/kcp/.kcp/admin.kubeconfig -v 2
+go run cmd/scheduler/main.go -v 2
 ```
 
 The outputs from the edge scheduler should be similar to:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR handles #270. Now the scheduler doesn't need an explicit `kcp-kubeconfig` flag, as long as (and already documented) environment variable `$KUBECONFIG` is pointed to the kcp server.

This PR also cleans up some legacy code in response to @MikeSpreitzer 's previous review (Thanks!), for example, the scheduler doesn't really need kubeSharedInformerFactory and related stuff.

Closes #270.