### PR TITLE
🐛 mailbox name should be composed of clustername-mb-UID

### DIFF
--- a/pkg/mailboxwatch/impl_test.go
+++ b/pkg/mailboxwatch/impl_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	upstreamcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"github.com/kcp-dev/edge-mc/pkg/placement"
 
 	kcpk8sfake "github.com/kcp-dev/client-go/kubernetes/fake"
 	tenancyv1a1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
@@ -162,7 +163,7 @@ func TestMailboxInformer(t *testing.T) {
 					t.Logf("Removed from tracker: ReplicaSet %+v", gonerRS)
 				}
 			} else {
-				clusterS := fmt.Sprintf("c%d", rand.Intn(int(math.Sqrt(float64(iteration)))))
+				clusterS := fmt.Sprintf("c%d%stesting", rand.Intn(int(math.Sqrt(float64(iteration)))), placement.WSNameSep)
 				clusterN := logicalcluster.Name(clusterS)
 				wsObjName := objectName{cluster: espwCluster, name: clusterS}
 				workspace := workspaces[wsObjName]


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Hey @MikeSpreitzer shouldn't the mailbox name be composed of two parts separated by "-mb-"?  The current unit test fails to add the mailbox because it fails the `if len(mbwsNameParts) != 2 {` check in setInclusion().

## Related issue(s)

Fixes #
