### PR TITLE
✨ Make client options code in pkg and let the scheduler use it

### DIFF
--- a/cmd/scheduler/options/options.go
+++ b/cmd/scheduler/options/options.go
@@ -21,11 +21,15 @@ import (
 
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
+
+	"github.com/kcp-dev/edge-mc/pkg/client"
 )
 
 type Options struct {
-	KcpKubeconfig string
-	Logs          *logs.Options
+	EspwClientOpts   client.ClientOpts
+	RootClientOpts   client.ClientOpts
+	SysAdmClientOpts client.ClientOpts
+	Logs             *logs.Options
 }
 
 func NewOptions() *Options {
@@ -34,12 +38,19 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	return &Options{
-		Logs: logs,
+		EspwClientOpts:   *client.NewClientOpts("espw", "access to the edge service provider workspace"),
+		RootClientOpts:   *client.NewClientOpts("root", "access to all clusters"),
+		SysAdmClientOpts: *client.NewClientOpts("sysadm", "access to all clusters as system:admin"),
+		Logs:             logs,
 	}
 }
 
 func (options *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&options.KcpKubeconfig, "kcp-kubeconfig", options.KcpKubeconfig, "Kubeconfig file for kcp")
+	options.EspwClientOpts.AddFlags(fs)
+	options.RootClientOpts.OverrideUserAndCluster("kcp-admin", "root")
+	options.RootClientOpts.AddFlags(fs)
+	options.SysAdmClientOpts.OverrideCurrentContext("system:admin")
+	options.SysAdmClientOpts.AddFlags(fs)
 	options.Logs.AddFlags(fs)
 }
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type ClientOpts struct {
+	which        string
+	description  string
+	loadingRules *clientcmd.ClientConfigLoadingRules
+	overrides    clientcmd.ConfigOverrides
+}
+
+func NewClientOpts(which, description string) *ClientOpts {
+	return &ClientOpts{
+		which:        which,
+		description:  description,
+		loadingRules: clientcmd.NewDefaultClientConfigLoadingRules(),
+		overrides:    clientcmd.ConfigOverrides{},
+	}
+}
+
+func (opts *ClientOpts) OverrideCurrentContext(currCtx string) *ClientOpts {
+	opts.overrides.CurrentContext = currCtx
+	return opts
+}
+
+func (opts *ClientOpts) OverrideUserAndCluster(user, cluster string) *ClientOpts {
+	opts.overrides.Context = clientcmdapi.Context{
+		AuthInfo: user,
+		Cluster:  cluster,
+	}
+	return opts
+}
+
+func (opts *ClientOpts) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&opts.loadingRules.ExplicitPath, opts.which+"-kubeconfig", opts.loadingRules.ExplicitPath, "Path to the kubeconfig file to use for "+opts.description)
+	flags.StringVar(&opts.overrides.CurrentContext, opts.which+"-context", opts.overrides.CurrentContext, "The name of the kubeconfig context to use for "+opts.description)
+	flags.StringVar(&opts.overrides.Context.AuthInfo, opts.which+"-user", opts.overrides.Context.AuthInfo, "The name of the kubeconfig user to use for "+opts.description)
+	flags.StringVar(&opts.overrides.Context.Cluster, opts.which+"-cluster", opts.overrides.Context.Cluster, "The name of the kubeconfig cluster to use for "+opts.description)
+
+}
+
+func (opts *ClientOpts) ToRESTConfig() (*rest.Config, error) {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(opts.loadingRules, &opts.overrides)
+	return clientConfig.ClientConfig()
+}

--- a/pkg/scheduler/reconcile_on_location.go
+++ b/pkg/scheduler/reconcile_on_location.go
@@ -144,7 +144,7 @@ func (c *controller) reconcileOnLocation(ctx context.Context, locKey string) err
 			// 4a)
 			// an (obsolete) ep doesn't select loc anymore
 			// we need to remove all relevant sp(s) from the corresponding sps where 'relevant' means an sp has loc
-			logger.V(1).Info("stop to select Location", "edgePlacement", ep)
+			logger.V(1).Info("stop selecting Location", "edgePlacement", ep)
 			ws, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(ep)
 			if err != nil {
 				logger.Error(err, "invalid EdgePlacement key")

--- a/pkg/scheduler/reconcile_on_synctarget.go
+++ b/pkg/scheduler/reconcile_on_synctarget.go
@@ -122,7 +122,7 @@ func (c *controller) reconcileOnSyncTarget(ctx context.Context, stKey string) er
 			// for an (obsolite) ep in epsUsedSt but not in epsUsingSt
 			// remove all relevant sp(s) from that ep, so that that ep doesn't use st
 			// an obsolite ep doesn't use st anymore because its locs don't select the st anymore
-			logger.V(1).Info("stop to use SyncTarget", "edgePlacement", ep)
+			logger.V(1).Info("stop using SyncTarget", "edgePlacement", ep)
 			ws, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(ep)
 			if err != nil {
 				logger.Error(err, "invalid EdgePlacement key")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR
- puts (and tweaks) code for preparing client options into pkg (as suggested [here](https://github.com/kcp-dev/edge-mc/pull/271#issuecomment-1487603900), thanks to @MikeSpreitzer ) so that controllers can share them;
- use that part of code to allow more configurable flags for the scheduler @dumb0002 .

This PR also improves the English language in logs, thanks to @KPRoche the native speaker.

