### PR TITLE
✨ Make mailbox controller create APIBinding for edge

### DIFF
--- a/cmd/mailbox-controller/main.go
+++ b/cmd/mailbox-controller/main.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apiserver/pkg/server/routes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/metrics/legacyregistry"
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 	"k8s.io/klog/v2"
@@ -50,30 +49,30 @@ import (
 	kcpscopedclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclusterclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	clientopts "github.com/kcp-dev/edge-mc/pkg/client-options"
 )
 
 func main() {
 	resyncPeriod := time.Duration(0)
 	var concurrency int = 4
 	serverBindAddress := ":10203"
+	espwPath := logicalcluster.Name("root").Path().Join("espw").String()
 	fs := pflag.NewFlagSet("mailbox-controller", pflag.ExitOnError)
 	klog.InitFlags(flag.CommandLine)
 	fs.AddGoFlagSet(flag.CommandLine)
 	fs.Var(&utilflag.IPPortVar{Val: &serverBindAddress}, "server-bind-address", "The IP address with port at which to serve /metrics and /debug/pprof/")
 
 	fs.IntVar(&concurrency, "concurrency", concurrency, "number of syncs to run in parallel")
+	fs.StringVar(&espwPath, "espw-path", espwPath, "the pathname of the edge service provider workspace")
 
-	inventoryLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	inventoryConfigOverrides := &clientcmd.ConfigOverrides{}
+	inventoryClientOpts := clientopts.NewClientOpts("inventory", "access to inventory management workspace")
+	inventoryClientOpts.OverrideCurrentContext("root")
 
-	fs.StringVar(&inventoryLoadingRules.ExplicitPath, "inventory-kubeconfig", inventoryLoadingRules.ExplicitPath, "pathname of kubeconfig file for inventory service provider workspace")
-	fs.StringVar(&inventoryConfigOverrides.CurrentContext, "inventory-context", "root", "current-context override for inventory-kubeconfig")
-
-	workloadLoadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	workloadConfigOverrides := &clientcmd.ConfigOverrides{}
-
-	fs.StringVar(&workloadLoadingRules.ExplicitPath, "workload-kubeconfig", workloadLoadingRules.ExplicitPath, "pathname of kubeconfig file for edge workload service provider workspace")
-	fs.StringVar(&workloadConfigOverrides.CurrentContext, "workload-context", workloadConfigOverrides.CurrentContext, "current-context override for workload-kubeconfig")
+	workloadClientOpts := clientopts.NewClientOpts("workload", "access to edge service provider workspace")
+	mbwsClientOpts := clientopts.NewClientOpts("mbws", "access to mailbox workspaces (really all clusters)")
+	mbwsClientOpts.OverrideCurrentContext("base")
 
 	fs.Parse(os.Args[1:])
 
@@ -97,8 +96,7 @@ func main() {
 	}()
 
 	// create config for accessing TMC service provider workspace
-	inventoryClientConfigGen := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(inventoryLoadingRules, inventoryConfigOverrides)
-	inventoryClientConfig, err := inventoryClientConfigGen.ClientConfig()
+	inventoryClientConfig, err := inventoryClientOpts.ToRESTConfig()
 	if err != nil {
 		logger.Error(err, "failed to make inventory config")
 		os.Exit(2)
@@ -123,8 +121,7 @@ func main() {
 	syncTargetClusterPreInformer := stViewInformerFactory.Workload().V1alpha1().SyncTargets()
 
 	// create config for accessing edge service provider workspace
-	workspaceClientConfigGen := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(workloadLoadingRules, workloadConfigOverrides)
-	workspaceClientConfig, err := workspaceClientConfigGen.ClientConfig()
+	workspaceClientConfig, err := workloadClientOpts.ToRESTConfig()
 	if err != nil {
 		logger.Error(err, "failed to make workspaces config")
 		os.Exit(8)
@@ -140,7 +137,22 @@ func main() {
 	workspaceScopedInformerFactory := kcpinformers.NewSharedScopedInformerFactoryWithOptions(workspaceScopedClientset, resyncPeriod)
 	workspaceScopedPreInformer := workspaceScopedInformerFactory.Tenancy().V1alpha1().Workspaces()
 
-	ctl := newMailboxController(ctx, syncTargetClusterPreInformer, workspaceScopedPreInformer, workspaceScopedClientset.TenancyV1alpha1().Workspaces())
+	mbwsClientConfig, err := mbwsClientOpts.ToRESTConfig()
+	if err != nil {
+		logger.Error(err, "failed to make all-cluster config")
+		os.Exit(20)
+	}
+	mbwsClientConfig.UserAgent = "mailbox-controller"
+	mbwsClientset, err := kcpclusterclientset.NewForConfig(mbwsClientConfig)
+	if err != nil {
+		logger.Error(err, "Failed to create all-cluster clientset")
+		os.Exit(24)
+	}
+
+	ctl := newMailboxController(ctx, espwPath, syncTargetClusterPreInformer, workspaceScopedPreInformer,
+		workspaceScopedClientset.TenancyV1alpha1().Workspaces(),
+		mbwsClientset.ApisV1alpha1().APIBindings(),
+	)
 
 	doneCh := ctx.Done()
 	stViewInformerFactory.Start(doneCh)

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/mailbox-controller.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/mailbox-controller.md
@@ -30,6 +30,7 @@ The command line flags, beyond the basics, are as follows.
 
 ```console
       --concurrency int                  number of syncs to run in parallel (default 4)
+      --espw-path string                 the pathname of the edge service provider workspace (default "root:espw")
       --inventory-context string         current-context override for inventory-kubeconfig (default "root")
       --inventory-kubeconfig string      pathname of kubeconfig file for inventory service provider workspace
       --server-bind-address ipport       The IP address with port at which to serve /metrics and /debug/pprof/ (default :10203)
@@ -121,6 +122,12 @@ $ kubectl get workspaces
 NAME                                                       TYPE        REGION   PHASE   URL                                                     AGE
 niqdko2g2pwoadfb-mb-f99e773f-3db2-439e-8054-827c4ac55368   universal            Ready   https://192.168.58.123:6443/clusters/0ay27fcwuo2sv6ht   22s
 ```
+
+FYI, if you look inside that workspace you will see an `APIBinding`
+named `bind-edge` that binds to the `APIExport` named `edge.kcp.io`
+from the edge service provider workspace (and this is why the
+controller needs to know the pathname of that workspace), so that the
+edge API is available in the mailbox workspace.
 
 Next, `kubectl delete` that workspace, and watch the mailbox
 controller wait for it to be gone and then re-create it.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds missing functionality to the mailbox controller: creating an APIBinding in each mailbox workspace that binds to the edge API.

For now, this controller will tolerate other parties modifying the spec of this binding, in case we need to override what the controller says.  Probably we eventually want the controller to undo any conflicting changes to the spec.

## Related issue(s)

Fixes #

/cc @waltforme 
/cc @yana1205 
@yuji-watanabe-jp 
@dumb0002 