### PR TITLE
🐛 Fix typo

### DIFF
--- a/pkg/placement/what-resolver.go
+++ b/pkg/placement/what-resolver.go
@@ -618,7 +618,7 @@ outer:
 		if !(len(objSet.Resources) == 1 && objSet.Resources[0] == "*" || SliceContains(objSet.Resources, whatResource)) {
 			continue
 		}
-		if len(objSet.ResourceNames) == 1 && objSet.ResourceNames[9] == "*" || SliceContains(objSet.ResourceNames, objName) {
+		if len(objSet.ResourceNames) == 1 && objSet.ResourceNames[0] == "*" || SliceContains(objSet.ResourceNames, objName) {
 			matches = true
 			break outer
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a bug that will cause the placement translator to crash IFF an EdgePlacement has a NonNamespacedObjectReferenceSet with exactly one entry in its ResourceNames.

## Related issue(s)

Fixes #

/cc @yana1205 
/cc @waltforme 
