### PR TITLE
🐛 Fix to support the case for namespace to be wildcard in upsync

### DIFF
--- a/pkg/syncer/controller/syncerconfigcontroller_test.go
+++ b/pkg/syncer/controller/syncerconfigcontroller_test.go
@@ -122,6 +122,7 @@ func TestSyncerConfig(t *testing.T) {
 					{Group: "cheese.testing.k8s.io", Version: "v1", Kind: "Gouda", Name: "*"},
 					{Group: "cheese.testing.k8s.io", Version: "v27alpha15", Kind: "Cheddar", Namespace: "*", Name: "*"},
 					{Group: "cheese.testing.k8s.io", Version: "v27alpha15", Kind: "Gouda", Name: "*"},
+					{Group: "", Version: "v1", Kind: "Namespace", Name: "*"},
 				},
 				conversions: []edgev1alpha1.EdgeSynConversion{{
 					Upstream:   upSyncedResource,

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -177,7 +177,7 @@ func runSync(ctx context.Context, cfg *SyncerConfig, syncConfigManager *controll
 				}
 			}
 			for _, resource := range syncConfigManager.GetUpSyncedResources() {
-				if resource.Name == "*" {
+				if resource.Name == "*" || resource.Namespace == "*" {
 					if err := upSyncer.SyncMany(resource, syncConfigManager.GetConversions()); err != nil {
 						logger.V(1).Info(fmt.Sprintf("failed to upsync-many %s.%s/%s (ns=%s)", resource.Kind, resource.Group, resource.Name, resource.Namespace))
 					}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
https://github.com/kcp-dev/edge-mc/blob/main/pkg/apis/edge/v1alpha1/edge-placement.go#L136
```
	// `namespaces` is a list of acceptable namespaces.
	// An entry of `"*"` means that all match.
	// Empty list means nothing matches (you probably do not want this
	// for namespaced resources).
	Namespaces []string `json:"namespaces,omitempty"`
```

UpsyncSet allows wildcard in `namespaces` field. I added its support. 

## Related issue(s)

Fixes #
