### PR TITLE
🐛 Do not ask syncer to downsync resources that do not go

### DIFF
--- a/pkg/placement/declarations.go
+++ b/pkg/placement/declarations.go
@@ -388,6 +388,18 @@ func (rscMode ResourceMode) GoesToMailbox() bool {
 	}
 }
 
+// GoesToEdge tells whether objects of this sort can downsync all the way to the edge cluster
+func (rscMode ResourceMode) GoesToEdge() bool {
+	switch rscMode.PropagationMode {
+	case ErrorInCenter, TolerateInCenter, GoesToMailbox:
+		return false
+	case GoesToEdge:
+		return true
+	default:
+		panic(rscMode)
+	}
+}
+
 func SPMailboxWorkspaceName(sp SinglePlacement) string {
 	return sp.Cluster + WSNameSep + string(sp.SyncTargetUID)
 }

--- a/pkg/placement/main.go
+++ b/pkg/placement/main.go
@@ -116,7 +116,7 @@ func NewPlacementTranslator(
 			crdClusterPreInformer, bindingClusterPreInformer, dynamicClusterClient, numThreads),
 		whereResolver: NewWhereResolver(ctx, spsClusterPreInformer, numThreads),
 	}
-	pt.workloadProjector = NewWorkloadProjector(ctx, numThreads, pt.mbwsInformer, pt.mbwsLister,
+	pt.workloadProjector = NewWorkloadProjector(ctx, numThreads, DefaultResourceModes, pt.mbwsInformer, pt.mbwsLister,
 		pt.syncfgClusterInformer, pt.syncfgClusterLister, edgeClusterClientset, dynamicClusterClient,
 		nsClusterPreInformer, nsClusterClient)
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a bug in the placement translator.  It was including APIBinding objects among those to downsync in SyncerConfig objects.

## Related issue(s)

Fixes #

/cc @yana1205 
/cc @dumb0002 
/cc @waltforme 