### PR TITLE
📖 Document non-deletion of Namespace objects

### DIFF
--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
@@ -76,10 +76,14 @@ from the MBWS and making the following changes.
   is set to `yes`.
 - The remainder of the `metadata` is unchanged.
 
-For objects that exist in a mailbox workspace and whose API
-GroupResource has been relevant to the placement translator since it
-started, ones that have the `edge.kcp.io/projected=yes` label but are
-not currently desired are deleted.
+For objects --- other than `Namespace` objects --- that exist in a
+mailbox workspace and whose API GroupResource has been relevant to the
+placement translator since it started, ones that have the
+`edge.kcp.io/projected=yes` label but are not currently desired are
+deleted.  The exclusion for `Namespace` objects is there because the
+placement translator does not take full ownership of them, rather it
+takes the position that there might be other parties that create
+`Namespace` objects or rely on their existence.
 
 ## Usage
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR documents the exclusion of Namespace objects from those that the placement translator might delete in a mailbox workspace.

## Related issue(s)

Fixes #

/cc @waltforme 