### PR TITLE
✨ Have `make build` copy scripts to bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,12 @@ ldflags:
 require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi
 
+bin/%.sh: scripts/%.sh
+	cp scripts/$$(basename $@) bin
+
 build: WHAT ?= ./cmd/... 
 #./tmc/cmd/...
-build: require-jq require-go require-git verify-go-versions ## Build the project
+build: require-jq require-go require-git verify-go-versions bin/ensure-location.sh bin/ensure-syncer-plugin.sh bin/ensure-wmw.sh bin/mailbox-prep.sh bin/remove-location.sh ## Build the project
 	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 #	ln -sf kubectl-workspace bin/kubectl-workspaces
 #	ln -sf kubectl-workspace bin/kubectl-ws

--- a/Makefile
+++ b/Makefile
@@ -106,15 +106,13 @@ ldflags:
 require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi
 
-bin/%.sh: scripts/%.sh
-	cp scripts/$$(basename $@) bin
-
 build: WHAT ?= ./cmd/... 
 #./tmc/cmd/...
-build: require-jq require-go require-git verify-go-versions bin/ensure-location.sh bin/ensure-syncer-plugin.sh bin/ensure-wmw.sh bin/mailbox-prep.sh bin/remove-location.sh ## Build the project
+build: require-jq require-go require-git verify-go-versions ## Build the project
 	GOOS=$(OS) GOARCH=$(ARCH) CGO_ENABLED=0 go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 #	ln -sf kubectl-workspace bin/kubectl-workspaces
 #	ln -sf kubectl-workspace bin/kubectl-ws
+	cp scripts/*.sh bin
 .PHONY: build
 
 .PHONY: build-all


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the behavior of `make build` to ensure that `bin` has a copy of the scripts from `scripts`.  This means that a user will need only the contents of the `bin` directory.

## Related issue(s)

Fixes #
