### PR TITLE
✨ First draft of customization command

### DIFF
--- a/cmd/emc-customize/main.go
+++ b/cmd/emc-customize/main.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	machruntime "k8s.io/apimachinery/pkg/runtime"
+	machserializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	machjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/klog/v2"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	"github.com/kcp-dev/edge-mc/pkg/customize"
+)
+
+func main() {
+	fs := pflag.NewFlagSet("emc-customize", pflag.ExitOnError)
+	klog.InitFlags(flag.CommandLine)
+	fs.AddGoFlagSet(flag.CommandLine)
+	var customizerFilename string = ""
+	fs.StringVar(&customizerFilename, "customizer-filename", customizerFilename, "pathname of file holding Customizer to apply")
+
+	ctx := context.Background()
+	logger := klog.FromContext(ctx)
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		logger.Error(err, "Command line parse failed")
+		os.Exit(1)
+	}
+
+	if fs.NArg() < 1 {
+		logger.Error(nil, "Need at least one positional arguments")
+		os.Exit(1)
+	}
+
+	scheme := machruntime.NewScheme()
+	edgeapi.AddToScheme(scheme)
+	schedulingv1alpha1.AddToScheme(scheme)
+
+	codecFactory := machserializer.NewCodecFactory(scheme)
+	decoder := codecFactory.UniversalDeserializer()
+
+	neededArgs := 1
+
+	var customizer *edgeapi.Customizer
+	if customizerFilename != "" {
+		obj, err := readObject(decoder, customizerFilename, &edgeapi.Customizer{})
+		if err != nil {
+			logger.Error(err, "Failed to read Customizer", "customizerFilename", customizerFilename)
+			os.Exit(10)
+		}
+		customizer = obj.(*edgeapi.Customizer)
+		expandCustomizer := customizer.GetAnnotations() != nil && customizer.GetAnnotations()[edgeapi.ParameterExpansionAnnotationKey] == "true"
+		if expandCustomizer {
+			neededArgs = 2
+		}
+	}
+	logger.V(2).Info("Customizer", "cust", customizer)
+
+	subj, err := readObject(decoder, fs.Arg(0), &unstructured.Unstructured{})
+	if err != nil {
+		logger.Error(err, "Failed to unmarshal subject", "filename", fs.Arg(0))
+		os.Exit(20)
+	}
+	subject, ok := subj.(*unstructured.Unstructured)
+	if !ok {
+		logger.Error(nil, "Failed to convert read object to Unstructure", "readObj", subj)
+		os.Exit(25)
+	}
+	if subject.GetAnnotations() != nil && subject.GetAnnotations()[edgeapi.ParameterExpansionAnnotationKey] == "true" {
+		neededArgs = 2
+	}
+
+	if fs.NArg() != neededArgs {
+		logger.Error(nil, "Wrong number of positional arguments", "needed", neededArgs, "got", fs.NArg())
+		os.Exit(1)
+	}
+
+	var location *schedulingv1alpha1.Location
+	if neededArgs > 1 {
+		obj, err := readObject(decoder, fs.Arg(1), &schedulingv1alpha1.Location{})
+		if err != nil {
+			logger.Error(err, "Failed to read Location", "locationFilename", fs.Arg(1))
+			os.Exit(30)
+		}
+		location = obj.(*schedulingv1alpha1.Location)
+	}
+	logger.V(2).Info("Location", "loc", location)
+
+	subject = customize.Customize(logger, subject, customizer, location)
+
+	err = writeObject(codecFactory, os.Stdout, subject)
+	if err != nil {
+		logger.Error(err, "Failed to write output")
+		os.Exit(99)
+	}
+}
+
+func readObject(decoder machruntime.Decoder, filename string, dest machruntime.Object) (machruntime.Object, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	decoded, _, err := decoder.Decode(bytes, nil, dest)
+	return decoded, err
+}
+
+func writeObject(cf machserializer.CodecFactory, dest io.Writer, source machruntime.Object) error {
+	ser := machjson.NewYAMLSerializer(machjson.DefaultMetaFactory, nil, nil)
+	ser.Encode(source, dest)
+	return nil
+}
+
+func readJSON(filename string, dest any) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	bytes, err := io.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bytes, dest)
+}
+
+func writeJSON(filename string, source any) error {
+	bytes, err := json.MarshalIndent(source, "", "  ")
+	if err == nil { // no, not really
+		return err
+	}
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(bytes)
+	return err
+}

--- a/cmd/emc-customize/main.go
+++ b/cmd/emc-customize/main.go
@@ -96,13 +96,13 @@ func main() {
 		neededArgs = 2
 	}
 
-	if fs.NArg() != neededArgs {
-		logger.Error(nil, "Wrong number of positional arguments", "needed", neededArgs, "got", fs.NArg())
+	if fs.NArg() < neededArgs || fs.NArg() > 2 {
+		logger.Error(nil, "Wrong number of positional arguments", "min", neededArgs, "max", 2, "got", fs.NArg())
 		os.Exit(1)
 	}
 
 	var location *schedulingv1alpha1.Location
-	if neededArgs > 1 {
+	if fs.NArg() > 1 {
 		obj, err := readObject(decoder, fs.Arg(1), &schedulingv1alpha1.Location{})
 		if err != nil {
 			logger.Error(err, "Failed to read Location", "locationFilename", fs.Arg(1))

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kcp-dev/logicalcluster/v3 v3.0.2
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.7.1
+	github.com/tidwall/sjson v1.2.5
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.4
@@ -75,6 +76,9 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/tidwall/gjson v1.14.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,14 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/customize/customize.go
+++ b/pkg/customize/customize.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customize
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+
+	edgeapi "github.com/kcp-dev/edge-mc/pkg/apis/edge/v1alpha1"
+	"github.com/kcp-dev/edge-mc/pkg/jsonpath"
+)
+
+func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer *edgeapi.Customizer, loc *schedulingv1alpha1.Location) *unstructured.Unstructured {
+	expandInput := input.GetAnnotations()[edgeapi.ParameterExpansionAnnotationKey] == "true"
+	expandCustomizer := customizer != nil && customizer.Annotations[edgeapi.ParameterExpansionAnnotationKey] == "true"
+	if customizer == nil && !expandInput {
+		return input
+	}
+	output := input.DeepCopy()
+	outputU := output.UnstructuredContent()
+	defs := Definitions{loc.GetLabels(), loc.GetAnnotations()}
+	if expandInput {
+		outputA := expandParameters(outputU, defs)
+		outputU = outputA.(map[string]any)
+	}
+	output.SetUnstructuredContent(outputU)
+	if customizer != nil {
+		jrs := []jsonpath.Replacement{}
+		for _, repl := range customizer.Replacements {
+			where := repl.Path
+			if expandCustomizer {
+				where = expandString(where, defs)
+			}
+			jp, err := jsonpath.ParsePath(where)
+			if err != nil {
+				logger.Error(err, "Failed to parse replacement path")
+				continue
+			}
+			valueStr := repl.Value
+			if expandCustomizer {
+				valueStr = expandString(valueStr, defs)
+			}
+			var valueAny any
+			err = json.Unmarshal([]byte(valueStr), &valueAny)
+			if err != nil {
+				logger.Error(err, "Failed to unmarshal replacement value", "replacementPath", repl.Path, "replacementValue", repl.Value, "valueStr", valueStr)
+				continue
+			}
+			jrs = append(jrs, jsonpath.Replacement{Path: jp, Value: valueAny})
+		}
+		outputU, err := jsonpath.Update(outputU, jrs...)
+		if err != nil {
+			logger.Error(err, "Failed to do update")
+		} else {
+			output.SetUnstructuredContent(outputU)
+		}
+	}
+	return output
+}
+
+type Definitions []map[string]string
+
+func (defs Definitions) Get(key string) (string, bool) {
+	for _, def := range defs {
+		if val, have := def[key]; have {
+			return val, true
+		}
+	}
+	return "", false
+}
+
+func expandString(input string, defs Definitions) string {
+	if !strings.ContainsRune(input, '%') {
+		return input
+	}
+	var builder strings.Builder
+	inputReader := strings.NewReader(input)
+	for {
+		next, _, err := inputReader.ReadRune()
+		if err == io.EOF {
+			break
+		}
+		if next != '%' {
+			builder.WriteRune(next)
+			continue
+		}
+		next, _, err = inputReader.ReadRune()
+		if err == io.EOF {
+			builder.WriteRune('%')
+			break
+		}
+		if next != '(' {
+			builder.WriteRune('%')
+			builder.WriteRune(next)
+			continue
+		}
+		name := readNameToReplace(inputReader)
+		replacement, found := defs.Get(name)
+		if found {
+			builder.WriteString(replacement)
+		} else {
+			builder.WriteString("%(")
+			builder.WriteString(name)
+			builder.WriteString(")")
+		}
+	}
+	return builder.String()
+}
+
+func readNameToReplace(inputReader io.RuneReader) string {
+	var builder strings.Builder
+	for {
+		next, _, err := inputReader.ReadRune()
+		if err != nil {
+			return builder.String()
+		}
+		if next == ')' {
+			return builder.String()
+		}
+		builder.WriteRune(next)
+	}
+}
+
+func expandParameters(data any, defs Definitions) any {
+	switch typed := data.(type) {
+	case string:
+		return expandString(typed, defs)
+	case map[string]any:
+		for key, val := range typed {
+			newVal := expandParameters(val, defs)
+			typed[key] = newVal
+		}
+		return typed
+	case []any:
+		for idx, val := range typed {
+			newVal := expandParameters(val, defs)
+			typed[idx] = newVal
+		}
+		return typed
+	default:
+		return typed
+	}
+}

--- a/pkg/customize/customize.go
+++ b/pkg/customize/customize.go
@@ -38,7 +38,10 @@ func Customize(logger klog.Logger, input *unstructured.Unstructured, customizer 
 	}
 	output := input.DeepCopy()
 	outputU := output.UnstructuredContent()
-	defs := Definitions{loc.GetLabels(), loc.GetAnnotations()}
+	var defs Definitions
+	if loc != nil {
+		defs = Definitions{loc.GetLabels(), loc.GetAnnotations()}
+	}
 	if expandInput {
 		outputA := expandParameters(outputU, defs)
 		outputU = outputA.(map[string]any)
@@ -119,6 +122,7 @@ func expandString(input string, defs Definitions) string {
 		if found {
 			builder.WriteString(replacement)
 		} else {
+			// TODO: report this error condition
 			builder.WriteString("%(")
 			builder.WriteString(name)
 			builder.WriteString(")")

--- a/pkg/jsonpath/jsonpath.go
+++ b/pkg/jsonpath/jsonpath.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/sjson"
+)
+
+func ParsePath(pathStr string) (Path, error) {
+	if !strings.HasPrefix(pathStr, "$.") {
+		return Path{}, errors.New("syntax error: does not start with '$.'")
+	}
+	return Path{pathStr[2:]}, nil
+}
+
+type Path struct {
+	sjsonPath string
+}
+
+func Update(data map[string]any, replacements ...Replacement) (map[string]any, error) {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	dataStr := string(dataBytes)
+	for _, repl := range replacements {
+		dataStr, err = sjson.Set(dataStr, repl.Path.sjsonPath, repl.Value)
+		if err != nil {
+			return nil, fmt.Errorf("error on replacing %s: %w", repl.Path.sjsonPath, err)
+		}
+	}
+	resultMap := map[string]any{}
+	err = json.Unmarshal([]byte(dataStr), &resultMap)
+	return resultMap, err
+}
+
+type Replacement struct {
+	Path  Path
+	Value any
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR begins the implementation of customization.  The customization is not yet implemented in the placement translator, but this PR introduces a CLI for exercising the prescribed customization.  The command is "emc-customize".

In this first draft, we do not have a full implementation of JSONPath for use in a Customizer's Replacements.  For now the syntax and semantics of a Replacement's Path are what is implemented in https://github.com/tidwall/sjson - with one nod toward JSONPath.  The Replacement's Path must start with "$.", and this is stripped off and the remainder of the path is handled by sjson.

I have exercised this and it is able to do the customization needed for the current MVI usage.

## Related issue(s)

Fixes #

/cc @francostellari 
/cc @waltforme 