### PR TITLE
first commit of script to build container for specified version

### DIFF
--- a/hack/make-release-container.sh
+++ b/hack/make-release-container.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: $0 KCPE_VERSION
+
+kcpe_version="$1"
+
+set -e
+
+srcdir=$(dirname "$0")
+cd "$srcdir/.."
+docker login quay.io
+KO_DOCKER_REPO=quay.io/kcpedge/syncer ko build --platform=linux/amd64,linux/arm64,... --bare --tags="$kcpe_version" ./cmd/syncer

--- a/hack/make-release-full.sh
+++ b/hack/make-release-full.sh
@@ -17,7 +17,7 @@
 # Usage: $0 KCPE_VERSION
 
 if [ $# != 1 ]; then
-    echo "$0 usage: KCPE_VERSION target_os target_arch" >&2
+    echo "$0 usage: KCPE_VERSION" >&2
     exit 1
 fi
 
@@ -26,7 +26,14 @@ kcpe_version="$1"
 set -e
 
 srcdir=$(dirname "$0")
-cd "$srcdir/.."
-#docker login quay.io
-KO_DOCKER_REPO=quay.io/kcpedge/syncer ko build --platform=linux/amd64,linux/arm64,... --bare --tags="$kcpe_version" ./cmd/syncer
-cd "$srcdir"
+./make-release-container.sh $kcpe_version
+
+os_names=( darwin darwin linux linux linux )
+arch_names=( arm64 amd64 arm64 amd64 ppc64le )
+length=${#os_names[@]}
+for (( i=0; i<length; i++ ));
+do
+	echo "${os_names[$i]} ${arch_names[$i]}"
+    ./make-release-platform-archive.sh $kcpe_version ${os_names[$i]} ${arch_names[$i]}
+done
+

--- a/hack/make-release-full.sh
+++ b/hack/make-release-full.sh
@@ -26,7 +26,7 @@ kcpe_version="$1"
 set -e
 
 srcdir=$(dirname "$0")
-./make-release-container.sh $kcpe_version
+$srcdir/make-release-container.sh $kcpe_version
 
 os_names=( darwin darwin linux linux linux )
 arch_names=( arm64 amd64 arm64 amd64 ppc64le )
@@ -34,6 +34,6 @@ length=${#os_names[@]}
 for (( i=0; i<length; i++ ));
 do
 	echo "${os_names[$i]} ${arch_names[$i]}"
-    ./make-release-platform-archive.sh $kcpe_version ${os_names[$i]} ${arch_names[$i]}
+    $srcdir/make-release-platform-archive.sh $kcpe_version ${os_names[$i]} ${arch_names[$i]}
 done
 

--- a/hack/make-release-platform-archive.sh
+++ b/hack/make-release-platform-archive.sh
@@ -37,7 +37,7 @@ srcdir=$(dirname "$0")
 cd "$srcdir/.."
 
 rm -rf bin/*
-make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/scheduler ./cmd/mailbox-controller ./cmd/placement-translator ./cmd/syncer"
+make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/scheduler ./cmd/mailbox-controller ./cmd/placement-translator"
 mkdir -p build/release
 tar czf "build/release/$archname" --exclude bin/.gitignore bin README.md LICENSE
 cd build/release


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
this utility build the go container for syncer and deposits is in the quay.io registry for kcpedge/syncer.  Also, removing syncer from make-release-platform-achrive.sh since it is covered by make-release-container.sh

## Related issue(s)

Fixes #
