### PR TITLE
🐛 Do not assume the build directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi
 
 build/syncer-kcp:
-	cd build && git clone https://github.com/yana1205/kcp syncer-kcp
+	mkdir -p build && cd build && git clone https://github.com/yana1205/kcp syncer-kcp
 
 build/syncer-kcp/pkg/cliplugins/workload/plugin/edgesync.go: build/syncer-kcp
 	cd build/syncer-kcp && git checkout emc


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The fixes a misunderstanding in the Makefile.

Why is `bin` handled differently than `build`?

## Related issue(s)

Fixes #
