### PR TITLE
🌱 Rely more on type inference.

### DIFF
--- a/pkg/placement/binding-organizer.go
+++ b/pkg/placement/binding-organizer.go
@@ -121,12 +121,12 @@ func SimpleBindingOrganizer(logger klog.Logger) BindingOrganizer {
 			},
 		)
 
-		nsToGoLoseNamespace := NewSetChangeProjectorByMapMap[NamespaceDistributionTuple, SourceAndDestination, NamespaceName](
+		nsToGoLoseNamespace := NewSetChangeProjectorByMapMap(
 			TripleFactorerTo13and2[logicalcluster.Name, NamespaceName, SinglePlacement](), nsSrcAndDestAndLog)
 
 		nsToGo := SetWriterFork[NamespaceDistributionTuple](false, namespaceDistributionsRelay, nsToGoLoseNamespace)
 
-		sbo.namespacedWhatWhereFull = NewSetChangeProjectorByMapMap[NamespacedWhatWhereFullKey, NamespaceDistributionTuple, string /*epName*/](
+		sbo.namespacedWhatWhereFull = NewSetChangeProjectorByMapMap(
 			factorNamespacedWhatWhereFullKey, nsToGo)
 
 		clusterDistributionsReceiver := SetWriterFuncs[NonNamespacedDistributionTuple]{
@@ -194,17 +194,16 @@ func SimpleBindingOrganizer(logger klog.Logger) BindingOrganizer {
 			clusterChangeReceiver,
 		)
 
-		upsyncsRelay := SetWriterFuncs[Pair[SinglePlacement, edgeapi.UpsyncSet]]{
-			OnAdd: func(tup Pair[SinglePlacement, edgeapi.UpsyncSet]) bool {
+		upsyncsRelay := NewSetWriterFuncs(
+			func(tup Pair[SinglePlacement, edgeapi.UpsyncSet]) bool {
 				logger.V(4).Info("Upsyncs added", "tuple", tup)
 				return sbo.workloadProjectionSections.Upsyncs.Add(tup)
 			},
-			OnRemove: func(tup Pair[SinglePlacement, edgeapi.UpsyncSet]) bool {
+			func(tup Pair[SinglePlacement, edgeapi.UpsyncSet]) bool {
 				logger.V(4).Info("Upsyncs removed", "tuple", tup)
 				return sbo.workloadProjectionSections.Upsyncs.Remove(tup)
-			}}
-		sbo.upsyncsFull = NewSetChangeProjectorByHashMap[Triple[ExternalName /* of EdgePlacement object */, edgeapi.UpsyncSet, SinglePlacement],
-			Pair[SinglePlacement, edgeapi.UpsyncSet], ExternalName /* of EdgePlacement object */](
+			})
+		sbo.upsyncsFull = NewSetChangeProjectorByHashMap(
 			factorUpsyncTuple,
 			upsyncsRelay,
 			PairHashDomain[SinglePlacement, edgeapi.UpsyncSet](HashSinglePlacement{}, HashUpsyncSet{}),

--- a/pkg/placement/hash-domain.go
+++ b/pkg/placement/hash-domain.go
@@ -127,13 +127,13 @@ var HashLogicalClusterName = NewTransformHashDomain[logicalcluster.Name, string]
 
 var HashClusterString = PairHashDomain[logicalcluster.Name, string](HashLogicalClusterName, HashDomainString{})
 
-var factorExternalName = NewFactorer[ExternalName, logicalcluster.Name, string](
+var factorExternalName = NewFactorer(
 	func(whole ExternalName) Pair[logicalcluster.Name, string] { return NewPair(whole.Cluster, whole.Name) },
 	func(parts Pair[logicalcluster.Name, string]) ExternalName {
 		return ExternalName{parts.First, parts.Second}
 	})
 
-var HashExternalName = NewTransformHashDomain[ExternalName, Pair[logicalcluster.Name, string]](factorExternalName.First, HashClusterString)
+var HashExternalName = NewTransformHashDomain(factorExternalName.First, HashClusterString)
 
 type HashUpsyncSet struct{}
 

--- a/pkg/placement/join-dynamic-12vwith13_test.go
+++ b/pkg/placement/join-dynamic-12vwith13_test.go
@@ -28,7 +28,7 @@ import (
 func TestDynamicJoin12VWith13(t *testing.T) {
 	ctx := context.Background()
 	logger := klog.FromContext(ctx)
-	exerciseDynamicJoin12VWith13W[int, string, float32, complex64, Empty](
+	exerciseDynamicJoin12VWith13W(
 		t,
 		logger,
 		NewMapMapFactory[Pair[int, string], complex64](nil),

--- a/pkg/placement/join-dynamic-12vwith13w_test.go
+++ b/pkg/placement/join-dynamic-12vwith13w_test.go
@@ -85,7 +85,7 @@ func exerciseDynamicJoin12VWith13W[Col1, Col2, Col3, Val, Wal comparable](
 					return Pair[Triple[Col1, Col2, Col3], Pair[Val, Wal]]{}, false
 				},
 			)
-			MapAddAll[Triple[Col1, Col2, Col3], Pair[Val, Wal]](expectedJoin, vj)
+			MapAddAll(expectedJoin, vj)
 			MapEnumerateDifferences[Triple[Col1, Col2, Col3], Pair[Val, Wal]](expectedJoin, joinReceiver,
 				MapChangeReceiverFuncs[Triple[Col1, Col2, Col3], Pair[Val, Wal]]{
 					OnCreate: func(key Triple[Col1, Col2, Col3], val Pair[Val, Wal]) {

--- a/pkg/placement/join-dynamic-12with13.go
+++ b/pkg/placement/join-dynamic-12with13.go
@@ -28,7 +28,7 @@ import (
 // of the join of those two tables --- in a passive stance (i.e., is in terms of the stream receivers).
 // Note: the uniformity of the input and output types means that this can be chained.
 func NewDynamicJoin12with13[ColX, ColY, ColZ comparable](logger klog.Logger, receiver SetWriter[Pair[ColY, ColZ]]) (SetWriter[Pair[ColX, ColY]], SetWriter[Pair[ColX, ColZ]]) {
-	indexerAsReceiver := NewSetChangeProjectorByMapMap[Triple[ColX, ColY, ColZ], Pair[ColY, ColZ], ColX](
+	indexerAsReceiver := NewSetChangeProjectorByMapMap(
 		TripleFactorerTo23and1[ColX, ColY, ColZ](),
 		receiver,
 	)
@@ -53,8 +53,8 @@ func NewDynamicFullJoin12with13Parametric[ColX, ColY, ColZ any](logger klog.Logg
 	dj := &dynamicJoin12with13[ColX, ColY, ColZ]{
 		logger:   logger,
 		receiver: receiver,
-		xyReln:   NewHashRelation2[ColX, ColY](hashDomainX, hashDomainY),
-		xzReln:   NewHashRelation2[ColX, ColZ](hashDomainX, hashDomainZ),
+		xyReln:   NewHashRelation2(hashDomainX, hashDomainY),
+		xzReln:   NewHashRelation2(hashDomainX, hashDomainZ),
 	}
 	dj.xyReln = Relation2WithObservers[ColX, ColY](dj.xyReln, extrapolateFwd1[ColX, ColY, ColZ]{dj.xzReln, receiver})
 	dj.xzReln = Relation2WithObservers[ColX, ColZ](dj.xzReln, extrapolateFwd1[ColX, ColZ, ColY]{dj.xyReln, TripleSetWriterReverse23[ColX, ColY, ColZ]{receiver}})

--- a/pkg/placement/map-map.go
+++ b/pkg/placement/map-map.go
@@ -19,13 +19,13 @@ package placement
 // NewMapMap makes a new Map implemented by a Map, optionally with a given observer.
 // For providing initial values see AddArgs, AddAllByVisit, MapMapCopy below.
 func NewMapMap[Key comparable, Val any](observer MapChangeReceiver[Key, Val]) MapMap[Key, Val] {
-	return MintMapMap[Key, Val](map[Key]Val{}, observer)
+	return MintMapMap(map[Key]Val{}, observer)
 }
 
 // NewMapMapFactory makes a func that returns new Map implemented by a Map, optionally with a given observer.
 // In other words, this is the curried form of NewMapMap.
 func NewMapMapFactory[Key comparable, Val any](observer MapChangeReceiver[Key, Val]) func() MutableMap[Key, Val] {
-	return func() MutableMap[Key, Val] { return NewMapMap[Key, Val](observer) }
+	return func() MutableMap[Key, Val] { return NewMapMap(observer) }
 }
 
 // MintMapMap takes the given map and obervers puts the MapMap seal of approval on them.
@@ -55,7 +55,7 @@ func (mm MapMap[Key, Val]) AddAllByVisit(what Visitable[Pair[Key, Val]]) MapMap[
 
 // MapMapCopy creates a new MapMap holding what the given Visitable reported at construction time.
 func MapMapCopy[Key comparable, Val any](observer MapChangeReceiver[Key, Val], other Visitable[Pair[Key, Val]]) MapMap[Key, Val] {
-	return NewMapMap[Key, Val](observer).AddAllByVisit(other)
+	return NewMapMap(observer).AddAllByVisit(other)
 }
 
 var _ MutableMap[int, string] = MapMap[int, string]{}

--- a/pkg/placement/map-relation.go
+++ b/pkg/placement/map-relation.go
@@ -31,7 +31,7 @@ func NewMapRelation2[First, Second comparable](pairs ...Pair[First, Second]) Sin
 // by an index on the first column.
 // The representation is based on HashMaps.
 func NewHashRelation2[First, Second any](hashDomainFirst HashDomain[First], hashDomainSecond HashDomain[Second], pairs ...Pair[First, Second]) SingleIndexedRelation2[First, Second] {
-	return NewSingleIndexedRelation2[First, Second](
+	return NewSingleIndexedRelation2(
 		func(First) MutableSet[Second] { return NewHashSet(hashDomainSecond) },
 		NewHashMap[First, MutableSet[Second]](hashDomainFirst)(nil),
 		pairs...,

--- a/pkg/placement/map-set-differencer.go
+++ b/pkg/placement/map-set-differencer.go
@@ -17,7 +17,7 @@ limitations under the License.
 package placement
 
 func ResolvedWhatAsVisitable(rw WorkloadParts) Visitable[Pair[WorkloadPartID, WorkloadPartDetails]] {
-	return MintMapMap[WorkloadPartID, WorkloadPartDetails](rw, nil)
+	return MintMapMap(rw, nil)
 }
 
 func ResolvedWhereAsVisitable(rw ResolvedWhere) Visitable[SinglePlacement] { return rw }
@@ -72,11 +72,11 @@ var _ ResolvedWhereDifferencerConstructor = NewResolvedWhereDifferencer
 var _ DownsyncsDifferencerConstructor = NewWorkloadPartsDifferencer
 
 func NewResolvedWhereDifferencer(eltChangeReceiver SetWriter[SinglePlacement]) Receiver[ResolvedWhere] {
-	return NewSetDifferenceByMapAndEnum[ResolvedWhere, SinglePlacement](ResolvedWhereAsVisitable, eltChangeReceiver)
+	return NewSetDifferenceByMapAndEnum(ResolvedWhereAsVisitable, eltChangeReceiver)
 }
 
 func NewWorkloadPartsDifferencer(mappingReceiver MapChangeReceiver[WorkloadPartID, WorkloadPartDetails]) Receiver[WorkloadParts] {
-	return NewMapDifferenceByMapAndEnum[WorkloadParts, WorkloadPartID, WorkloadPartDetails](ResolvedWhatAsVisitable, mappingReceiver)
+	return NewMapDifferenceByMapAndEnum(ResolvedWhatAsVisitable, mappingReceiver)
 }
 
 func NewSetDifferenceByMapAndEnum[SetType any, Elt comparable](visitablize func(SetType) Visitable[Elt], eltChangeReceiver SetWriter[Elt]) Receiver[SetType] {
@@ -90,7 +90,7 @@ func NewSetDifferenceByMapAndEnum[SetType any, Elt comparable](visitablize func(
 func NewMapDifferenceByMapAndEnum[MapType any, Key, Val comparable](visitablize func(MapType) Visitable[Pair[Key, Val]], mappingChangeReceiver MapChangeReceiver[Key, Val]) Receiver[MapType] {
 	return mapDifferenceByMapAndEnum[MapType, Key, Val]{
 		visitablize: visitablize,
-		current:     NewMapMap[Key, Val](mappingChangeReceiver),
+		current:     NewMapMap(mappingChangeReceiver),
 	}
 }
 
@@ -107,12 +107,12 @@ type mapDifferenceByMapAndEnum[MapType any, Key, Val comparable] struct {
 
 func (dme setDifferenceByMapAndEnum[SetType, Elt]) Receive(nextA SetType) {
 	nextS := dme.visitablize(nextA)
-	SetUpdateToMatch[Elt](dme.current, nextS, dme.eltChangeReceiver)
+	SetUpdateToMatch(dme.current, nextS, dme.eltChangeReceiver)
 }
 
 func (dme mapDifferenceByMapAndEnum[MapType, Key, Val]) Receive(nextA MapType) {
 	nextS := dme.visitablize(nextA)
-	MapUpdateToMatch[Key, Val](dme.current, nextS)
+	MapUpdateToMatch(dme.current, nextS)
 }
 
 func SetUpdateToMatch[Elt comparable](current MutableSet[Elt], target Visitable[Elt], eltChangeReceiver SetWriter[Elt]) {

--- a/pkg/placement/map-set-differencer_test.go
+++ b/pkg/placement/map-set-differencer_test.go
@@ -33,7 +33,7 @@ func TestMapSetDifferencer(t *testing.T) {
 	reportedNew := NewMapSet[int]()
 	reportToGone := SetWriterReverse[int](reportedGone)
 	checkingReceiver := SetWriterFork[int](false, reportedNew, reportToGone)
-	differ := NewSetDifferenceByMapAndEnum[MapSet[int], int](MapSetAsVisitable[int], checkingReceiver)
+	differ := NewSetDifferenceByMapAndEnum(MapSetAsVisitable[int], checkingReceiver)
 	current := NewMapSet[int]()
 	for iteration := 1; iteration < 100; iteration++ {
 		next := genSet()

--- a/pkg/placement/map-set.go
+++ b/pkg/placement/map-set.go
@@ -39,7 +39,7 @@ func MapSetCopy[Elt comparable](source Visitable[Elt]) MapSet[Elt] {
 }
 
 func MapSetCopier[Elt comparable]() Reducer[Elt, MapSet[Elt]] {
-	return StatefulReducer[Elt, MapSet[Elt], MapSet[Elt]](NewEmptyMapSet[Elt], MapSetAddNoResult[Elt], Identity1[MapSet[Elt]])
+	return StatefulReducer(NewEmptyMapSet[Elt], MapSetAddNoResult[Elt], Identity1[MapSet[Elt]])
 }
 
 func MapSetAsVisitable[Elt comparable](ms MapSet[Elt]) Visitable[Elt] { return ms }

--- a/pkg/placement/relation-types.go
+++ b/pkg/placement/relation-types.go
@@ -85,7 +85,7 @@ func NewSingleIndexedRelation2[First, Second any](
 	secondSetFactory func(First) MutableSet[Second],
 	rep MutableMap[First, MutableSet[Second]],
 	pairs ...Pair[First, Second]) SingleIndexedRelation2[First, Second] {
-	wholeSet := NewGenericIndexedSet[Pair[First, Second], First, Second, MutableSet[Second], Set[Second]](
+	wholeSet := NewGenericIndexedSet(
 		PairFactorer[First, Second](),
 		secondSetFactory,
 		Identity1[MutableSet[Second]],

--- a/pkg/placement/rotations_test.go
+++ b/pkg/placement/rotations_test.go
@@ -93,7 +93,7 @@ func TestFactorers(t *testing.T) {
 		gen.ExternalName(),
 		gen.ClusterName(),
 		gen.String()))
-	t.Run("factorNamespacedJoinKeyLessNS", exerciseFactorer[NamespacedJoinKeyLessnS, ProjectionModeKey, logicalcluster.Name](
+	t.Run("factorNamespacedJoinKeyLessNS", exerciseFactorer(
 		factorNamespacedJoinKeyLessNS,
 		gen.NamespacedJoinKeyLessnS(),
 		gen.ProjectionModeKey(),
@@ -110,11 +110,11 @@ func TestFactorers(t *testing.T) {
 		NewTriple(gen.ExternalName(), gen.UpsyncSet(), gen.SinglePlacement()),
 		NewPair(gen.SinglePlacement(), gen.UpsyncSet()),
 		gen.ExternalName()))
-	t.Run("PairFactorer", exerciseFactorer[Pair[int, string], int, string](PairFactorer[int, string](),
+	t.Run("PairFactorer", exerciseFactorer(PairFactorer[int, string](),
 		Pair[int, string]{rand.Intn(100) + 301, gen.String()},
 		rand.Intn(100)+3,
 		gen.String()))
-	t.Run("PairReverser", exerciseRotator[Pair[int, string], Pair[string, int]](PairReverser[int, string](),
+	t.Run("PairReverser", exerciseRotator(PairReverser[int, string](),
 		Pair[int, string]{rand.Intn(100) + 301, gen.String()},
 		Pair[string, int]{gen.String(), rand.Intn(100) + 301}))
 	t.Run("TripleFactorerTo23and1", exerciseFactorer(
@@ -127,7 +127,7 @@ func TestFactorers(t *testing.T) {
 		Triple[int, string, float32]{rand.Intn(100) + 200, gen.String(), rand.Float32()},
 		Pair[int, float32]{rand.Intn(100) - 200, rand.Float32()},
 		gen.String()))
-	t.Run("TripleReverser", exerciseRotator[Triple[int, string, float64], Triple[float64, string, int]](TripleReverser[int, string, float64](),
+	t.Run("TripleReverser", exerciseRotator(TripleReverser[int, string, float64](),
 		Triple[int, string, float64]{rand.Intn(100) + 301, gen.String(), rand.Float64()},
 		Triple[float64, string, int]{rand.Float64(), gen.String(), rand.Intn(100) + 301}))
 }

--- a/pkg/placement/set-binder-assembly.go
+++ b/pkg/placement/set-binder-assembly.go
@@ -89,7 +89,7 @@ func NewSetBinder(
 		}
 
 		var downsyncJoinRightInput, upsyncJoinRightInput SetWriter[Pair[ExternalName, SinglePlacement]]
-		sb.downsyncJoinLeftInput, downsyncJoinRightInput = NewDynamicFullJoin12VWith13[ExternalName, WorkloadPartID, SinglePlacement, WorkloadPartDetails](sb.logger,
+		sb.downsyncJoinLeftInput, downsyncJoinRightInput = NewDynamicFullJoin12VWith13(sb.logger,
 			NewMappingReceiverFuncs(
 				func(tup Triple[ExternalName, WorkloadPartID, SinglePlacement], workloadPartDetails WorkloadPartDetails) {
 					sb.logger.V(4).Info("Adding singleBinding mapping", "epRef", tup.First, "partID", tup.Second, "where", tup.Third, "details", workloadPartDetails)

--- a/pkg/placement/set-binder-test.go
+++ b/pkg/placement/set-binder-test.go
@@ -85,7 +85,7 @@ func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiv
 	NamespacedModes := NewMapMap[ProjectionModeKey, ProjectionModeVal](nil)
 	NonNamespacedDistributions := NewMapSet[NonNamespacedDistributionTuple]()
 	NonNamespacedModes := NewMapMap[ProjectionModeKey, ProjectionModeVal](nil)
-	Upsyncs := NewHashSet[Pair[SinglePlacement, edgeapi.UpsyncSet]](PairHashDomain[SinglePlacement, edgeapi.UpsyncSet](HashSinglePlacement{}, HashUpsyncSet{}))
+	Upsyncs := NewHashSet(PairHashDomain[SinglePlacement, edgeapi.UpsyncSet](HashSinglePlacement{}, HashUpsyncSet{}))
 	projectionTracker := WorkloadProjectionSections{
 		NamespaceDistributions:          NamespaceDistributions,
 		NamespacedResourceDistributions: NamespacedResourceDistributions,
@@ -125,7 +125,7 @@ func exerciseSetBinder(t *testing.T, logger klog.Logger, resourceDiscoveryReceiv
 			},
 		})
 
-	expectedUpsyncs := NewHashSet[Pair[SinglePlacement, edgeapi.UpsyncSet]](
+	expectedUpsyncs := NewHashSet(
 		PairHashDomain[SinglePlacement, edgeapi.UpsyncSet](HashSinglePlacement{}, HashUpsyncSet{}),
 		NewPair(sp1, ups1[0]),
 		NewPair(sp1, ups1[1]))

--- a/pkg/placement/set-project.go
+++ b/pkg/placement/set-project.go
@@ -24,11 +24,11 @@ func NewSetChangeProjectorByMapMap[Whole any, PartA, PartB comparable](
 	factoring Factorer[Whole, PartA, PartB],
 	partAReceiver SetWriter[PartA],
 ) SetWriter[Whole] {
-	return NewSetChangeProjector[Whole, PartA, PartB](
+	return NewSetChangeProjector(
 		factoring,
 		partAReceiver,
 		func(observer MapChangeReceiver[PartA, MutableSet[PartB]]) MutableMap[PartA, MutableSet[PartB]] {
-			return NewMapMap[PartA, MutableSet[PartB]](observer)
+			return NewMapMap(observer)
 		},
 		func(PartA) MutableSet[PartB] { return NewEmptyMapSet[PartB]() },
 	)
@@ -40,13 +40,13 @@ func NewSetChangeProjectorByHashMap[Whole, PartA, PartB any](
 	hashDomainA HashDomain[PartA],
 	hashDomainB HashDomain[PartB],
 ) SetWriter[Whole] {
-	return NewSetChangeProjector[Whole, PartA, PartB](
+	return NewSetChangeProjector(
 		factoring,
 		partAReceiver,
 		func(observer MapChangeReceiver[PartA, MutableSet[PartB]]) MutableMap[PartA, MutableSet[PartB]] {
 			return NewHashMap[PartA, MutableSet[PartB]](hashDomainA)(observer)
 		},
-		func(PartA) MutableSet[PartB] { return NewHashSet[PartB](hashDomainB) },
+		func(PartA) MutableSet[PartB] { return NewHashSet(hashDomainB) },
 	)
 }
 
@@ -62,7 +62,7 @@ func NewSetChangeProjector[Whole, PartA, PartB any](
 ) SetWriter[Whole] {
 	// indexerRep ignores the set of PartB and notifies partAReceiver of PartA set change
 	indexerRep := repMaker(MapKeySetReceiver[PartA, MutableSet[PartB]](partAReceiver))
-	indexer := NewGenericIndexedSet[Whole, PartA, PartB, MutableSet[PartB], Set[PartB]](
+	indexer := NewGenericIndexedSet(
 		// nil,
 		factoring,
 		innerSetFactory,

--- a/pkg/placement/set-types.go
+++ b/pkg/placement/set-types.go
@@ -64,7 +64,7 @@ type SetWriter[Elt any] interface {
 	Remove(Elt) bool /* changed */
 }
 
-func NewSetWriterFuncs[Elt any](OnAdd, OnRemove func(Elt) bool) SetWriterFuncs[Elt] {
+func NewSetWriterFuncs[Elt any](OnAdd, OnRemove func(Elt) bool) SetWriter[Elt] {
 	return SetWriterFuncs[Elt]{OnAdd, OnRemove}
 }
 
@@ -433,7 +433,7 @@ func SetEqual[Elt any](set1, set2 Set[Elt]) bool {
 	if set1.LenIsCheap() {
 		return set1.Len() == set2.Len() && SetLessOrEqual(set1, set2)
 	}
-	return SetCompare[Elt](set1, set2).IsEqual()
+	return SetCompare(set1, set2).IsEqual()
 }
 
 func SetIntersection[Elt any](set1, set2 Set[Elt]) Set[Elt] {

--- a/pkg/placement/workload-projector.go
+++ b/pkg/placement/workload-projector.go
@@ -1387,7 +1387,7 @@ func (wp *workloadProjector) syncerConfigRelations(destination SinglePlacement) 
 		clusterScopedObjects: NewMapMap[metav1.GroupResource, Pair[ProjectionModeVal, MutableSet[string /*object name*/]]](nil),
 	}
 	if have {
-		nses := MapKeySet[NamespaceName, Set[logicalcluster.Name]](nsds.GetIndex1to2())
+		nses := MapKeySet(nsds.GetIndex1to2())
 		ans.namespaces = MapSetCopy(TransformVisitable[NamespaceName, string](nses, func(ns NamespaceName) string { return string(ns) }))
 	} else {
 		ans.namespaces = NewEmptyMapSet[string]()
@@ -1399,7 +1399,7 @@ func (wp *workloadProjector) syncerConfigRelations(destination SinglePlacement) 
 			logger.Error(nil, "No ProjectionModeVals for namespaced resources")
 			nsms = NewMapMap[metav1.GroupResource, ProjectionModeVal](nil)
 		}
-		nsrs := MapKeySet[metav1.GroupResource, Set[logicalcluster.Name]](nsrds.GetIndex1to2())
+		nsrs := MapKeySet(nsrds.GetIndex1to2())
 		ans.namespacedResources = MapSetCopy(TransformVisitable[metav1.GroupResource, edgeapi.NamespaceScopeDownsyncResource](nsrs, func(gr metav1.GroupResource) edgeapi.NamespaceScopeDownsyncResource {
 			pmv, ok := nsms.Get(gr)
 			if !ok {
@@ -1417,7 +1417,7 @@ func (wp *workloadProjector) syncerConfigRelations(destination SinglePlacement) 
 			logger.Error(nil, "No ProjectionModeVals for cluster-scoped resources")
 			nnsms = NewMapMap[metav1.GroupResource, ProjectionModeVal](nil)
 		}
-		objs := MapKeySet[GroupResourceInstance, Set[logicalcluster.Name]](nnsds.GetIndex1to2())
+		objs := MapKeySet(nnsds.GetIndex1to2())
 		objs.Visit(func(gri GroupResourceInstance) error {
 			gr := gri.First
 			rscMode := wp.resourceModes(gr)
@@ -1429,7 +1429,7 @@ func (wp *workloadProjector) syncerConfigRelations(destination SinglePlacement) 
 			if !ok {
 				logger.Error(nil, "Missing API version", "obj", gri)
 			}
-			cso := MapGetAdd[metav1.GroupResource, Pair[ProjectionModeVal, MutableSet[string /*object name*/]]](ans.clusterScopedObjects, gr,
+			cso := MapGetAdd(ans.clusterScopedObjects, gr,
 				true, func(metav1.GroupResource) Pair[ProjectionModeVal, MutableSet[string /*object name*/]] {
 					return NewPair[ProjectionModeVal, MutableSet[string]](pmv, NewEmptyMapSet[string /*object name*/]())
 				})


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR removes some explicit type parameterizations.  This makes lint stop telling me about unnecessary type arguments in those cases.

Unfortunately lint is so stupid that it complains about unnecessary type arguments when only some of the type arguments can be inferred, but go does not have an option to specify only some of the type parameters.

## Related issue(s)

Fixes #

/cc @waltforme 
