### PR TITLE
🐛 Remove installation of edge CRDs in ESPW

### DIFF
--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/edge-scheduler.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/edge-scheduler.md
@@ -55,7 +55,7 @@ kubectl ws create edge --enter
 
 Install CRDs and APIExport.
 ```console
-kubectl apply -f ../kcp-edge/config/crds/ -f ../kcp-edge/config/exports/
+kubectl apply -f ../kcp-edge/config/exports/
 ```
 
 #### Create the Workload Management Workspace (WMW) and bind it to the ESPW APIs

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/example1.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/example1.md
@@ -189,10 +189,9 @@ kubectl ws create espw --enter
 This puts the definition and export of the edge-mc API in the edge
 service provider workspace.
 
-Use the following commands.
+Use the following command.
 
 ```shell
-kubectl create -f config/crds
 kubectl create -f config/exports
 ```
 

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/placement-translator.md
@@ -125,7 +125,6 @@ workspace", it suffices to do the following.
 
 ```console
 $ kubectl ws root:espw
-$ kubectl create -f config/crds
 $ kubectl create -f config/exports
 ```
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the various instructions to stop installing the edge CRD objects in the ESPW.  The contents of `config/exports/` are all that is needed, and adding the CRD objects might actually be causing a redundancy problem.

## Related issue(s)

Fixes #

/cc @yana1205 
/cc @waltforme 
/cc @dumb0002 
/cc @francostellari 
