### PR TITLE
🐛 Fixed oversight in platform archive construction

### DIFF
--- a/hack/make-release-platform-archive.sh
+++ b/hack/make-release-platform-archive.sh
@@ -37,7 +37,7 @@ srcdir=$(dirname "$0")
 cd "$srcdir/.."
 
 rm -rf bin/*
-make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/scheduler ./cmd/mailbox-controller ./cmd/placement-translator"
+make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/scheduler ./cmd/mailbox-controller ./cmd/placement-translator ./cmd/kubectl-kubesteallar-syncer_gen"
 mkdir -p build/release
 tar czf "build/release/$archname" --exclude bin/.gitignore bin config examples README.md LICENSE
 cd build/release


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes an old oversight: the syncer-gen plugin needs to be included in the script that builds a release archive.

## Related issue(s)

Fixes #

/cc @yana1205 
/cc @clubanderson 
