### PR TITLE
🐛 Wait for root:compute workspace to be usable before proceeding

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -47,6 +47,14 @@ kcp_running() {
     fi
 }
 
+kcp_ready() {
+    if [ "$(kubectl ws root:compute 2> /dev/null)" == "" ]; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
 kcp_get_latest_version() {
     curl -sL https://github.com/kcp-dev/kcp/releases/latest | grep "</h1>" | head -n 1 | sed -e 's/<[^>]*>//g' | xargs
 }
@@ -203,8 +211,8 @@ if [ "$(kcp_running)" == "false" ]; then
         kcp start --bind-address $kcp_address >& kcp_log.txt &
     fi
     export KUBECONFIG="$(pwd)/.kcp/admin.kubeconfig"
-    sleep 5
-    until kubectl ws . &> /dev/null
+    sleep 10
+    until $(kcp_ready)
     do
         sleep 1
     done


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This fix is due to @francostellari .
This fixed a problem that Mike had when testing, in which the first attempt to create a workspace fails with an authorization failure.  Adding this wait made the authorization failure go away.

## Related issue(s)

Fixes #

/cc @francostellari 
/cc @dumb0002 
/cc @waltforme 
