### PR TITLE
🐛 Correctly set current workspace at start of teardown

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -367,6 +367,7 @@ Congratulations, you’ve just deployed a workload to two edge clusters using ku
 To remove the example usage, delete the IMW and WMW and kind clusters run the following commands:
 
 ```shell
+kubectl ws root
 kubectl delete workspace example-imw
 kubectl ws root:my-org
 kubectl kubestellar remove wmw demo1


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adjusts the commands at the end to correctly set the current workspace before proceeding with the teardown.

## Related issue(s)

Fixes #

/cc @dumb0002 
/cc @francostellari 
