### PR TITLE
✨ Extend bootstrap command line to recognize "latest"

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -25,7 +25,7 @@ This guide is intended to show how to quickly bring up a **KubeStellar** environ
 KubeStellar works in the context of kcp, so to use KubeStellar you also need kcp. Download the kcp and **KubeStellar** binaries and scripts into a `kubestellar` subfolder in your current working directory using the following command:
 
 ```shell
-bash <(curl -s https://raw.githubusercontent.com/kcp-dev/edge-mc/main/bootstrap/bootstrap-kubestellar.sh)
+bash <(curl -s https://raw.githubusercontent.com/kcp-dev/edge-mc/main/bootstrap/bootstrap-kubestellar.sh) --kubestellar-version latest
 export PATH="$PATH:$(pwd)/kcp/bin:$(pwd)/kubestellar/bin"
 export KUBECONFIG="$(pwd)/.kcp/admin.kubeconfig"
 ```

--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -173,7 +173,7 @@ while (( $# > 0 )); do
     shift
 done
 
-if [ "$kcp_version" == "" ]; then
+if [ "$kcp_version" == "" ] || [ "$kcp_version" == latest ]; then
     kcp_version=$(kcp_get_latest_version)
 fi
 

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
@@ -364,7 +364,9 @@ and does the following things.
 This script accepts the following command line flags; all are optional.
 
 - `--kubestellar-version $version`: specifies the release of
-  KubeStellar to use.  The default is the latest regular release.
+  KubeStellar to use.  When using a specific version, include the
+  leading "v".  The default is the latest regular release, and the
+  value "latest" means the same thing.
 - `--kcp-version $version`: specifies the kcp release to use.  The
   default is the one that works with the chosen release of
   KubeStellar.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends the command line parsing in the bootstrap strip to recognize the literal "latest" to mean the same thing as omitting that flag: use the latest regular release.

## Related issue(s)

Fixes #

/cc @francostellari 
/cc @clubanderson 
@dumb0002 
