### PR TITLE
✨ Make default kcp version be v0.11.0

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -173,11 +173,11 @@ while (( $# > 0 )); do
     shift
 done
 
-if [ "$kcp_version" == "" ] || [ "$kcp_version" == latest ]; then
-    kcp_version=$(kcp_get_latest_version)
+if [ "$kcp_version" == "" ]; then
+    kcp_version=v0.11.0
 fi
 
-if [ "$kubestellar_version" == "" ]; then
+if [ "$kubestellar_version" == "" ] || [ "$kubestellar_version" == latest ]; then
     kubestellar_version=$(kubestellar_get_latest_version)
 fi
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the bootstrap script so that the default version of kcp is v0.11.0.  That is the only version of kcp that this release will work with.

## Related issue(s)

Fixes #

/cc @francostellari 
/cc @dumb0002 
/cc @clubanderson 
