### PR TITLE
✨ Add kubestellar-release command to report release semver

### DIFF
--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
@@ -50,6 +50,17 @@ controllers and deletes the ESPW.
 This command accepts all the same flags as `kubestellar start` but
 ignores the `--log-folder`.
 
+## Kubestellar-release
+
+This command just echoes the [semantic version](https://semver.org/)
+of the release used.  This command is only available in archives built
+for a release.  Following is an example usage.
+
+```console
+$ kubestellar-release
+v0.2.3-preview
+```
+
 ## Creating SyncTarget/Location pairs
 
 In this PoC, the interface between infrastructure and workload

--- a/hack/make-release-platform-archive.sh
+++ b/hack/make-release-platform-archive.sh
@@ -38,6 +38,8 @@ cd "$srcdir/.."
 
 rm -rf bin/*
 make build OS="$target_os" ARCH="$target_arch" WHAT="./cmd/kubestellar-scheduler ./cmd/mailbox-controller ./cmd/placement-translator ./cmd/kubectl-kubestellar-syncer_gen"
+echo $'#!/usr/bin/env bash\necho' ${kcpe_version@Q} > bin/kubestellar-release
+chmod a+x bin/kubestellar-release
 mkdir -p build/release
 tar czf "build/release/$archname" --exclude bin/.gitignore bin config examples README.md LICENSE
 cd build/release


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates the script that creates a release archive to inject a command that reports the release's semver.

This addresses part 1 of #395 but not part 2.  I am not sure that this PR has the right answer.  And for part 2, maybe the answer lies in using commit-based tags rather than release semver; or content-based hash.

## Related issue(s)

Fixes #

/cc @clubanderson 
/cc @francostellari 
/cc @dumb0002 
