### PR TITLE
🐛 Fix bootstrap-kubestellar condition for calling start

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -238,10 +238,12 @@ if [ "$(kubestellar_installed)" == "false" ]; then
     fi
 fi
 
+kubectl ws root
+
 # Ensure KubeStellar is running
-if [ "$(kubestellar_running)" == "false" ]; then
+if [ "$(kubestellar_running)" == "false" ] || ! kubectl get workspaces.tenancy.kcp.io espw &> /dev/null ; then
     if [ "$verbose" != "" ]; then
-        echo "Starting Kubestellar..."
+        echo "Starting or restarting Kubestellar..."
     fi
     kubestellar start $verbose
 fi

--- a/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/en/docs/Coding Milestones/PoC2023q1/commands.md
@@ -359,7 +359,8 @@ and does the following things.
 2. Starts a kcp server if one is not already running.
 3. Downloads and installs kubestellar if it is not already evident on
    `$PATH` (using [the script below](#install-kubestellar).
-4. `kubestellar start` if the KubeStellar controllers are not already running.
+4. `kubestellar start` if the KubeStellar controllers are not already
+   running or the ESPW does not (yet) exist.
 
 This script accepts the following command line flags; all are optional.
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR expands the conditions underwhich bootstrap-kubestellar.sh calls `kubestellar start`, to include absence of the ESPW.

I am factoring #403 into two pieces, and this is one of them, to obey the necessary evolutionary discipline.  This change will get to users before a new release is made, and so has to work with the current release.

## Related issue(s)

Fixes #402
