### PR TITLE
✨ Introduce kubestellar init

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -22,23 +22,18 @@ in that file.
 
 ## Platform control
 
-The `kubestellar` command has two subcommands, one for setup and one
-for teardown.
+The `kubestellar` command has three subcommands, one to finish setup
+and two for process control.
 
-### KubeStellar start
-
-This subcommand is used after installation.
-This subcommand does two things:
-1. It creates and populates the edge service provider workspace (ESPW) if it does not already exist; and
-2. It stops any running kubesteallar controllers and then starts them all.
+The usage synopsis is as follows.
 
 ```shell
-kubestellar start [flags]
+kubestellar [flags] subcommand [flags]
 ```
 
-The flags can appear before and/or after the subcommand.
-
-The available flags are as follows.
+This command accepts the following command line flags, which can
+appear before and/or after the subcommand.  The `--log-folder` flag is
+only used in the `start` subcommand.
 
 - `-V` or `--verbose`: calls for more verbose output.  This is a
   binary choice, not a matter of degree.
@@ -47,13 +42,25 @@ The available flags are as follows.
   `${PWD}/kubestellar-logs`.
 - `-h` or `--help`: print a brief usage message and terminate.
 
+### Kubestellar init
+
+This subcommand is used after installation to finish setup.
+
+This subcommand ensures that the edge service provider workspace
+(ESPW) exists and has the required contents.
+
+### KubeStellar start
+
+This subcommand is used after installation or process stops.
+
+This subcommand stops any running kubesteallar controllers and then
+starts them all.  It also does the same thing as `kubestellar init`.
+
 ### KubeStellar stop
 
-This subcommand undoes `kubestellar start`.  It stops any running
-controllers and deletes the ESPW.
-
-This command accepts all the same flags as `kubestellar start` but
-ignores the `--log-folder`.
+This subcommand undoes the primary function of `kubestellar start`,
+stopping any running KubeStellar controllers.  It does _not_ tear down
+the ESPW.
 
 ## KubeStellar-release
 

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -28,8 +28,9 @@
 
 set -e
 
-install=""
+subcommand=""
 verbosity=0
+verbdir="&> /dev/null"
 remove=0
 cleanup=0
 espw_name="espw"
@@ -39,17 +40,16 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 while (( $# > 0 )); do
     case "$1" in
-    (start)
-        install=1;; 
-    (stop) 
-        install=0;; 
+    (start|stop|init)
+        subcommand=$1;;
     (--log-folder)
         if (( $# > 1 ));
         then { log_folder="$2"; shift; }
         else { echo "$0: missing log folder" >&2; exit 1; }
         fi;;
     (--verbose|-V)
-        verbosity=1;;
+        verbosity=1
+	verbdir="";;
     (-h|--help)
         echo "Usage: $0 [start| stop][--log-folder log_folder] [-V|--verbose]"
         exit 0;;
@@ -63,20 +63,9 @@ while (( $# > 0 )); do
     shift
 done
 
-
-# Check if docker is running
-if ! docker ps > /dev/null
-then
-  echo "Docker Not running ...."
-  exit 1
-fi
-
-# Check go version
-go_version=`go version | { read _ _ v _; echo ${v#go}; }`
-
-function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
-if [ $(ver $go_version) -lt $(ver 1.19) ]; then
-    echo "Update your go version to at least 1.19"
+if [ "$subcommand" == "" ]; then
+    echo "$0: missing a subcommand" >&2
+    exit 1
 fi
 
 # Check if a given process name is running
@@ -95,6 +84,24 @@ if [ $(process_running kcp) != "running" ]
 then
     echo "kcp is not running - please start it ...."
     exit 1
+fi
+
+function ensure_espw() {
+    if kubectl get Workspace "$espw_name" &> /dev/null; then
+	echo "espw workspace already exists -- using it:"
+	kubectl ws "$espw_name"
+    else 
+        kubectl ws create "$espw_name" --enter
+    fi
+    kubectl apply -f $SCRIPT_DIR/../config/exports $verbdir
+    echo "Finished populating the espw with kubestellar apiexports"   
+}
+
+kubectl ws root &> /dev/null
+
+if [ "$subcommand" == init ]; then
+    ensure_espw
+    exit
 fi
 
 # Check mailbox-controller is already running
@@ -118,18 +125,12 @@ then
     pkill -f placement-translator
 fi
 
-kubectl ws root &> /dev/null
-
-if [ $install -eq 0 ]; then 
-   if kubectl get Workspace "$espw_name" &> /dev/null; then
-      kubectl delete ws "$espw_name"
-      echo "Deleted workspace: $espw_name"
-   fi
-   
+if [ $subcommand == stop ]; then    
    echo "kubestellar stopped ....."
    exit 0
 fi
 
+ensure_espw
 
 wait_for_process(){
   status=$(process_running $1)
@@ -155,23 +156,6 @@ echo "****************************************"
 echo "Launching KubeStellar ..."
 echo "****************************************"
 
-
-if kubectl get Workspace "$espw_name" &> /dev/null; then
-   echo "espw workspace already exists -- using it:"
-   kubectl ws "$espw_name"
-else 
-   if [ $verbosity == 1 ]; then
-        kubectl ws create "$espw_name" --enter
-        kubectl apply -f   $SCRIPT_DIR/../config/crds 
-        kubectl apply -f   $SCRIPT_DIR/../config/exports
-        echo "Finished populate the espw with kubestellar crds and apiexports"
-   else
-        kubectl ws create "$espw_name" --enter
-        kubectl apply -f  $SCRIPT_DIR/../config/crds &> /dev/null
-        kubectl apply -f  $SCRIPT_DIR/../config/exports &> /dev/null
-        echo "Finished populate the espw with kubestellar crds and apiexports"
-   fi
-fi
 
 sleep 5
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR starts the process of factoring the ESPW control out of the process control.  In particular:
- `kubestellar init` is a new command that just ensures that the ESPW is setup;
- `kubestellar start` still implicitly ensures that the ESPW is setup, so that the bootstrap script does not have to change simultaneously;
- `kubestellar stop` no longer destroys the ESPW (this change is OK to make here because we have no script that invokes `kubestellar stop` and the only recipe, the quickstart, follows it with such obliteration that this detail matters not).

This is part of the project of factoring #403 to respect evolutionary discipline; the other part is #408.

## Related issue(s)

This is the first permissible steps to addressing #401
