### PR TITLE
✨ Add syncer image tag holding git info

### DIFF
--- a/hack/make-release-container.sh
+++ b/hack/make-release-container.sh
@@ -28,5 +28,7 @@ set -e
 srcdir=$(dirname "$0")
 cd "$srcdir/.."
 #docker login quay.io
-KO_DOCKER_REPO=quay.io/kubestellar/syncer ko build --platform=linux/amd64,linux/arm64,... --bare --tags="$kcpe_version" ./cmd/syncer
+GIT_COMMIT=$(git rev-parse --short HEAD || echo 'local')
+GIT_WARN=$( [ $(git status --porcelain=v2 | wc -l) == 0 ] || echo "-dirty")
+KO_DOCKER_REPO=quay.io/kubestellar/syncer ko build --platform=linux/amd64,linux/arm64,... --bare --tags="${kcpe_version},git${GIT_COMMIT}${GIT_WARN}" ./cmd/syncer
 cd "$srcdir"


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR updates `hack/make-release-container.sh`, to add a second tag on the built image that contains identifying git information: the commit ID and also a warning if the working tree does not equal (modulo ignored files) the commit contents.

This supports #422 

## Related issue(s)

Fixes #
