### PR TITLE
🐛 Update warning banner to say latest _release_

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,8 +6,8 @@
 {% endblock %}
 
 {% block outdated %}
-  You're not viewing the latest version.
+  You're not viewing the latest release.
   <a href="{{ '../latest/' ~ base_url }}"> 
-    <strong>Click here to go to latest.</strong>
+    <strong>Click here to go to latest release.</strong>
   </a>
 {% endblock %}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes the warning banner on the website to refer to the "latest release" rather than the "latest version", and also clarifies a bare "latest" to "latest release".  This is needed because the latest release is older and generally different from the latest version.

## Related issue(s)

Fixes #

/cc @clubanderson 
/cc @francostellari 
/cc @dumb0002 
