### PR TITLE
🐛Fix a problem with Mac M1

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -133,6 +133,7 @@ get_arch_type() {
   case "$HOSTTYPE" in
       x86_64*)  echo "amd64" ;;
       aarch64*) echo "arm64" ;;
+      arm64*)   echo "arm64" ;;
       *)        echo "Unsupported architecture type: $HOSTTYPE" >&2 ; exit 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

Fix a problem with Mac M1 reporting `$HOSTTYPE` as `arm64` instead of `aarch64`.

## Related issue(s)

Fixes #
