### PR TITLE
:bug: Correct broken links in docs related with syncer

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/edge-syncer.md
+++ b/docs/content/Coding Milestones/PoC2023q1/edge-syncer.md
@@ -149,7 +149,7 @@ After this, Edge-mc will put the following in the mailbox workspace.
   - The mailbox controller will put API Binding into the mailbox workspace.
 
 #### EdgeSyncConfig (will be replaced to SyncerConfig)
-- The example of EdgeSycnerConfig CR is [here](https://github.com/yana1205/edge-mc/blob/edge-syncer/pkg/syncer/scripts/edge-sync-config-for-kyverno-helm.yaml). Its CRD is [here](https://github.com/yana1205/edge-mc/blob/edge-syncer/pkg/syncer/config/crds/edge.kcp.io_edgesyncconfigs.yaml).
+- The example of EdgeSycnerConfig CR is [here](https://github.com/kcp-dev/edge-mc/blob/main/pkg/syncer/scripts/edge-sync-config-for-kyverno-helm.yaml). Its CRD is [here](https://github.com/kcp-dev/edge-mc/blob/main/config/crds/edge.kcp.io_edgesyncconfigs.yaml).
 - The CR here is used from edge syncer. 
 - The CR is placed at mb-ws to define
   - object selector

--- a/pkg/syncer/README.md
+++ b/pkg/syncer/README.md
@@ -32,7 +32,7 @@
 ## Edge Syncer feasibility verification
 
 ### Register an edge-syncer on a p-cluster to connect a mailbox workspace specified by name
-1. Created a mailbox workspace following to https://docs.kcp-edge.io/docs/coding-milestones/poc2023q1/mailbox-controller/
+1. Created a mailbox workspace following to https://docs.kubestellar.io/main/Coding%20Milestones/PoC2023q1/mailbox-controller/
     ```
     $ kubectl get Workspace
     NAME                                                       TYPE        REGION   PHASE   URL                                                                                                       AGE


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Correct broken links in docs related with syncer ([kubesteller](https://docs.kubestellar.io/main/Coding%20Milestones/PoC2023q1/edge-syncer/) and [README.md](https://github.com/kcp-dev/edge-mc/blob/main/pkg/syncer/README.md))

## Related issue(s)

Fixes #
