### PR TITLE
🐛 Make `kubestellar init` support syncer updating status

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -37,6 +37,7 @@ only used in the `start` subcommand.
 
 - `-V` or `--verbose`: calls for more verbose output.  This is a
   binary choice, not a matter of degree.
+- `-X`: turns on echoing of script lines
 - `--log-folder $pathname`: says where to put the logs from the
   controllers.  Will be `mkdir -p` if absent.  Defaults to
   `${PWD}/kubestellar-logs`.

--- a/docs/content/Coding Milestones/PoC2023q1/commands.md
+++ b/docs/content/Coding Milestones/PoC2023q1/commands.md
@@ -44,10 +44,13 @@ only used in the `start` subcommand.
 
 ### Kubestellar init
 
-This subcommand is used after installation to finish setup.
-
-This subcommand ensures that the edge service provider workspace
-(ESPW) exists and has the required contents.
+This subcommand is used after installation to finish setup and does
+two things.  One is to ensure that the edge service provider workspace
+(ESPW) exists and has the required contents.  The other is to ensure
+that the `root:compute` workspace has been extended with the RBAC
+objects that enable the syncer to propagate reported state for
+downsynced objects defined by the APIExport from that workspace of a
+subset of the Kubernetes API for managing containerized workloads.
 
 ### KubeStellar start
 

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -50,8 +50,10 @@ while (( $# > 0 )); do
     (--verbose|-V)
         verbosity=1
 	verbdir="";;
+    (-X)
+	set -x;;
     (-h|--help)
-        echo "Usage: $0 [start| stop][--log-folder log_folder] [-V|--verbose]"
+        echo "Usage: $0 [init | start | stop][--log-folder log_folder] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2 ; exit 1;
@@ -141,7 +143,7 @@ function ensure_espw() {
     else 
         kubectl ws create "$espw_name" --enter
     fi
-    kubectl apply -f $SCRIPT_DIR/../config/exports $verbdir
+    eval kubectl apply -f "$SCRIPT_DIR/../config/exports" $verbdir
     echo "Finished populating the espw with kubestellar apiexports"   
 }
 

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usage: $0 (start or stop | -v)
+# Usage: $0 (init or start or stop | -v)
 
 # Purpose: control whether the controllers are running, setting up the ESPW if necessary.. The following components are created:
 #           (a) 1 kcp workspace: edge service provider workspace (espw)
@@ -86,7 +86,55 @@ then
     exit 1
 fi
 
+# current ws at start does not matter, is root:compute on return
+function ensure_compute_status_updateable() {
+    kubectl ws root:compute &> /dev/null
+    kubectl apply -f - &> /dev/null <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute:apiexport:kubernetes:maximal-permission-policy-extended
+rules:
+- apiGroups:
+  - ""
+  - apps
+  - networking.k8s.io
+  resources:
+  - services/status
+  - pods/status
+  - ingresses/status
+  - deployments/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  verbs:
+  - get
+  - update
+  - patch
+EOF
+    kubectl apply -f - &> /dev/null <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute:authenticated:apiexport:kubernetes:maximal-permission-policy-extended
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute:apiexport:kubernetes:maximal-permission-policy-extended
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: apis.kcp.io:binding:system:authenticated
+EOF
+}
+
+# current ws at start does not matter, is ESPW on return
 function ensure_espw() {
+    kubectl ws root &> /dev/null
     if kubectl get Workspace "$espw_name" &> /dev/null; then
 	echo "espw workspace already exists -- using it:"
 	kubectl ws "$espw_name"
@@ -97,9 +145,8 @@ function ensure_espw() {
     echo "Finished populating the espw with kubestellar apiexports"   
 }
 
-kubectl ws root &> /dev/null
-
 if [ "$subcommand" == init ]; then
+    ensure_compute_status_updateable
     ensure_espw
     exit
 fi
@@ -130,6 +177,7 @@ if [ $subcommand == stop ]; then
    exit 0
 fi
 
+ensure_compute_status_updateable
 ensure_espw
 
 wait_for_process(){

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -53,7 +53,7 @@ while (( $# > 0 )); do
     (-X)
 	set -x;;
     (-h|--help)
-        echo "Usage: $0 [init | start | stop][--log-folder log_folder] [-V|--verbose] [-X]"
+        echo "Usage: $0 [init | start | stop] [--log-folder log_folder] [-V|--verbose] [-X]"
         exit 0;;
     (-*)
         echo "$0: unknown flag" >&2 ; exit 1;
@@ -106,15 +106,8 @@ rules:
   - pods/status
   - ingresses/status
   - deployments/status
-  verbs:
-  - update
-  - patch
-- apiGroups:
-  - apps
-  resources:
   - deployments/scale
   verbs:
-  - get
   - update
   - patch
 EOF


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR extends what `kubestellar init` does, making it also add the RBAC objects to the `root:compute` workspace that enable the syncer to update the `status` sub-objects of the objects whose Kind is defined by the kube APIExport from `root:compute`.

## Related issue(s)

Fixes #477 
Fixes #546

/cc @yana1205 
/cc @dumb0002 