### PR TITLE
🐛 Fix a typo in 'partners' docs

### DIFF
--- a/docs/content/Community/partners/argocd.md
+++ b/docs/content/Community/partners/argocd.md
@@ -30,7 +30,7 @@ Once KubeStellar's workspaces are added, Argo CD Applications can be created as 
 There are a few examples listed [here](https://github.com/edge-experiments/gitops-source/tree/main/edge-mc),
 and the commands to use the examples are listed as follows.
 
-#### Create Argo CD Applications against KubeStellar's IWM
+#### Create Argo CD Applications against KubeStellar's IMW
 Create two Locations. The command and output should be similar to
 ```console
 $ argocd app create locations \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a typo in a recently added documentation, in response to a spelling check here: https://github.com/kcp-dev/edge-mc/actions/runs/5140080321/jobs/9251187073
