### PR TITLE
🐛 Update bootstrap-kubestellar.sh to support M1 arm64 Issue 533

### DIFF
--- a/bootstrap/bootstrap-kubestellar.sh
+++ b/bootstrap/bootstrap-kubestellar.sh
@@ -92,6 +92,7 @@ get_arch_type() {
   case "$HOSTTYPE" in
       x86_64*)  echo "amd64" ;;
       aarch64*) echo "arm64" ;;
+      arm64*)   echo "arm64" ;;
       *)        echo "Unsupported architecture type: $HOSTTYPE" >&2 ; exit 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

Update bootstrap-kubestellar.sh to support M1 arm64

## Related issue(s)

#533

Fixes #

#533