### PR TITLE
:book: Fix documentation about syncer-gen plugin

### DIFF
--- a/.github/spellcheck/.wordlist.txt
+++ b/.github/spellcheck/.wordlist.txt
@@ -195,8 +195,10 @@ api
 apibinding
 apibindings
 apiGroup
+apiGroups
 apiVersion
 apiexport
+apiextensions
 apiresourceimports
 apis
 apiserver
@@ -235,6 +237,7 @@ deployers
 dev
 discoverable
 dismayingly
+dns
 downsync
 downSyncedResources
 downsynced
@@ -280,6 +283,7 @@ jq
 json
 kcp
 kcp's
+ko
 kube
 kubeconfig
 kubectl
@@ -313,6 +317,7 @@ namespaces
 namespacessyncer
 natured
 nonNamespacedObjects
+nonResourceURLs
 ns
 onboarding
 opensource
@@ -321,6 +326,8 @@ ownerReferences
 oyaml
 pathname
 pathnames
+policyreport
+policyreports
 pre
 prometheus
 provisioner
@@ -337,6 +344,7 @@ resourceVersion
 resourcequotas
 rolebinding
 rolebindings
+roleRef
 rollout
 scalability
 scalable
@@ -385,6 +393,8 @@ volumeMounts
 watchall
 webhook
 webhooks
+wgpolicyk
+wgpolicyk8s
 william
 wmw
 workspace

--- a/pkg/syncer/README.md
+++ b/pkg/syncer/README.md
@@ -77,7 +77,7 @@
     secret/kcp-edge-syncer-pcluster1-1na3tqcd created
     deployment.apps/kcp-edge-syncer-pcluster1-1na3tqcd created
     ```
-1. Edge Syncer successfully runs and interact with the emailbox workspace
+1. Edge Syncer successfully runs and interact with the mailbox workspace
     ```
     $ KUBECONFIG=/tmp/kind-pcluster1/kubeconfig.yaml kubectl get pod -A
     NAMESPACE                            NAME                                                  READY   STATUS    RESTARTS   AGE
@@ -148,7 +148,7 @@
       NAME                                            PASS   FAIL   WARN   ERROR   SKIP   AGE
       policyreport.wgpolicyk8s.io/pol-sample-policy   0      1      0      0       0      56s
       ```
-  1. On the emailbox workspace
+  1. On the mailbox workspace
     ```
     $ kubectl get policy,policyreport
     NAME                              BACKGROUND   VALIDATE ACTION   READY
@@ -171,7 +171,7 @@
     apiresourceschema.apis.kcp.io/v0-0-1.policyreports.wgpolicyk8s.io created
     apiexport.apis.kcp.io/policy-report created
     ```
-1. Create APIBindings in the emailbox workspace
+1. Create APIBindings in the mailbox workspace
     ```
     $ kubectl kcp ws root:edge:1lkhy98o1f84q2a3-mb-528a4f03-cb9b-4121-aa57-28c58ed19f22
     ```
@@ -209,7 +209,7 @@
         name: policyreports.wgpolicyk8s.io
         version: v1
     ```
-1. Now I can get policy reports across emailbox workspaces by one-shot from an API exposed in `edge` workspace.
+1. Now I can get policy reports across mailbox workspaces by one-shot from an API exposed in `edge` workspace.
     ```
     $ kubectl kcp ws root:edge
     Current workspace is "root:edge".

--- a/pkg/syncer/scripts/edge-syncer-bootstrap.template.yaml
+++ b/pkg/syncer/scripts/edge-syncer-bootstrap.template.yaml
@@ -102,6 +102,7 @@ spec:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=${syncer_id}
         - --sync-target-uid=${syncer_id}
+        - --from-cluster=${cluster_name}
         - --qps=30
         - --burst=30
         - --v=3


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fix the section **What kubestellar syncer-gen plugin does**
- CRD creation (step 10) is required only for non-mailbox workspace. Move CRD creation to the step for workspace creation (step 2). Also the location of CRD is fixed (`./pkg/syncer/config/crds/edge.kcp.io_edgesyncconfigs.yaml` => `./config/crds/edge.kcp.io_edgesyncconfigs.yaml`.)
- Fix edge-syncer-bootstrap.template.yaml
  - This template is only used for this section.  There is no impact on kubestellar syncer-gen plugin.

Fix misspelling in Syncer related docs

## Related issue(s)

Fixes #
