### PR TITLE
📖 Fix a typo in docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
               - KubeStellar Sheduler: Coding Milestones/PoC2023q1/kubestellar-scheduler.md
               - KubeStellar Mailbox Controller: Coding Milestones/PoC2023q1/mailbox-controller.md
               - KubeStellar Placement Translator: Coding Milestones/PoC2023q1/placement-translator.md
-          - Roadap: Coding Milestones/PoC2023q1/roadmap-uses.md
+          - Roadmap: Coding Milestones/PoC2023q1/roadmap-uses.md
           - Environments:
               - Overview: Coding Milestones/PoC2023q1/environments/_index.md
               - Cloud Environment: Coding Milestones/PoC2023q1/environments/cloud-env.md


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a typo in the documentation which renders into a table of contents for PoC2023q1. Screenshot:

<img width="247" alt="image" src="https://github.com/kcp-dev/edge-mc/assets/8633434/082b176e-489e-400c-a75f-009f8ef4a6b6">
