### PR TITLE
🌱 Add Prowjobs

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.19"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,56 @@
+presubmits:
+  - name: pull-edge-mc-verify
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/edge-mc"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - verify-boilerplate
+            - verify-codegen
+            - verify-go-versions
+            - verify-imports
+            - verify-k8s-deps
+            - verify-modules
+            - verify-syncer-codegen
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 1
+
+  - name: pull-edge-mc-lint
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/edge-mc"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - lint
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pull-edge-mc-test-unit
+    always_run: true
+    decorate: true
+    clone_uri: "https://github.com/kcp-dev/edge-mc"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-2
+          command:
+            - make
+            - test
+          env:
+            - name: USE_GOTESTSUM
+              value: '1'
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -19,7 +19,6 @@ set -o pipefail
 
 VERSION=$(grep "go 1." go.mod | sed 's/go //')
 
-grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
 grep "FROM golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
 # grep -w "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
 # Note CONTRIBUTING.md isn't copied in the Dockerfile


### PR DESCRIPTION
## Summary
This PR replaces the openshift CI operator with basic in-repo Prowjobs.

Note that the verify and lint jobs purposefully do not use the `preset-goproxy`, as this seems to cause weird compatibility issues and errors like

```
< ../../../../pkg/mod/github.com/kcp-dev/kcp@v../pkg/admission/limitranger/admission.go::: github.com/kcp-dev/kubernetes@v..--aaaaabd: reading http://athens-proxy.athens.svc.cluster.local/github.com/kcp-dev/kubernetes/@v/v..--aaaaabd.zip:  Internal Server Error
< ../../../../pkg/mod/github.com/kcp-dev/kcp@v../pkg/admission/plugins.go::: github.com/kcp-dev/kubernetes@v..--aaaaabd: reading http://athens-proxy.athens.svc.cluster.local/github.com/kcp-dev/kubernetes/@v/v..--aaaaabd.zip:  Internal Server Error
```

(see https://public-prow.kcp.k8c.io/view/s3/prow-public-data/pr-logs/pull/kcp-dev_edge-mc/572/pull-edge-mc-lint/1666460364272832512)