### PR TITLE
🐛 Make root:compute export the rest of namespaced kube API

### DIFF
--- a/config/kube/crds/cluster-scoped/core.k8s.io_persistentvolumes.yaml
+++ b/config/kube/crds/cluster-scoped/core.k8s.io_persistentvolumes.yaml
@@ -1,0 +1,1093 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: persistentvolumes.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    kind: PersistentVolume
+    listKind: PersistentVolumeList
+    plural: persistentvolumes
+    shortNames:
+    - pv
+    singular: persistentvolume
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'PersistentVolume (PV) is a storage resource provisioned by an
+          administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'spec defines a specification of a persistent volume owned
+              by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes'
+            properties:
+              accessModes:
+                description: 'accessModes contains all ways the volume can be mounted.
+                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
+                items:
+                  type: string
+                type: array
+              awsElasticBlockStore:
+                description: 'awsElasticBlockStore represents an AWS Disk resource
+                  that is attached to a kubelet''s host machine and then exposed to
+                  the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                properties:
+                  fsType:
+                    description: 'fsType is the filesystem type of the volume that
+                      you want to mount. Tip: Ensure that the filesystem type is supported
+                      by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                      Implicitly inferred to be "ext4" if unspecified. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: string
+                  partition:
+                    description: 'partition is the partition in the volume that you
+                      want to mount. If omitted, the default is to mount by volume
+                      name. Examples: For volume /dev/sda1, you specify the partition
+                      as "1". Similarly, the volume partition for /dev/sda is "0"
+                      (or you can leave the property empty).'
+                    format: int32
+                    type: integer
+                  readOnly:
+                    description: 'readOnly value true will force the readOnly setting
+                      in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: boolean
+                  volumeID:
+                    description: 'volumeID is unique ID of the persistent disk resource
+                      in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: string
+                required:
+                - volumeID
+                type: object
+              azureDisk:
+                description: azureDisk represents an Azure Data Disk mount on the
+                  host and bind mount to the pod.
+                properties:
+                  cachingMode:
+                    description: 'cachingMode is the Host Caching mode: None, Read
+                      Only, Read Write.'
+                    type: string
+                  diskName:
+                    description: diskName is the Name of the data disk in the blob
+                      storage
+                    type: string
+                  diskURI:
+                    description: diskURI is the URI of data disk in the blob storage
+                    type: string
+                  fsType:
+                    description: fsType is Filesystem type to mount. Must be a filesystem
+                      type supported by the host operating system. Ex. "ext4", "xfs",
+                      "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  kind:
+                    description: 'kind expected values are Shared: multiple blob disks
+                      per storage account  Dedicated: single blob disk per storage
+                      account  Managed: azure managed data disk (only in managed availability
+                      set). defaults to shared'
+                    type: string
+                  readOnly:
+                    description: readOnly Defaults to false (read/write). ReadOnly
+                      here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                required:
+                - diskName
+                - diskURI
+                type: object
+              azureFile:
+                description: azureFile represents an Azure File Service mount on the
+                  host and bind mount to the pod.
+                properties:
+                  readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly
+                      here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                  secretName:
+                    description: secretName is the name of secret that contains Azure
+                      Storage Account Name and Key
+                    type: string
+                  secretNamespace:
+                    description: secretNamespace is the namespace of the secret that
+                      contains Azure Storage Account Name and Key default is the same
+                      as the Pod
+                    type: string
+                  shareName:
+                    description: shareName is the azure Share Name
+                    type: string
+                required:
+                - secretName
+                - shareName
+                type: object
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: 'capacity is the description of the persistent volume''s
+                  resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
+                type: object
+              cephfs:
+                description: cephFS represents a Ceph FS mount on the host that shares
+                  a pod's lifetime
+                properties:
+                  monitors:
+                    description: 'monitors is Required: Monitors is a collection of
+                      Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    items:
+                      type: string
+                    type: array
+                  path:
+                    description: 'path is Optional: Used as the mounted root, rather
+                      than the full Ceph tree, default is /'
+                    type: string
+                  readOnly:
+                    description: 'readOnly is Optional: Defaults to false (read/write).
+                      ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: boolean
+                  secretFile:
+                    description: 'secretFile is Optional: SecretFile is the path to
+                      key ring for User, default is /etc/ceph/user.secret More info:
+                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: string
+                  secretRef:
+                    description: 'secretRef is Optional: SecretRef is reference to
+                      the authentication secret for User, default is empty. More info:
+                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  user:
+                    description: 'user is Optional: User is the rados user name, default
+                      is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                    type: string
+                required:
+                - monitors
+                type: object
+              cinder:
+                description: 'cinder represents a cinder volume attached and mounted
+                  on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                properties:
+                  fsType:
+                    description: 'fsType Filesystem type to mount. Must be a filesystem
+                      type supported by the host operating system. Examples: "ext4",
+                      "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: string
+                  readOnly:
+                    description: 'readOnly is Optional: Defaults to false (read/write).
+                      ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: boolean
+                  secretRef:
+                    description: 'secretRef is Optional: points to a secret object
+                      containing parameters used to connect to OpenStack.'
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  volumeID:
+                    description: 'volumeID used to identify the volume in cinder.
+                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                    type: string
+                required:
+                - volumeID
+                type: object
+              claimRef:
+                description: 'claimRef is part of a bi-directional binding between
+                  PersistentVolume and PersistentVolumeClaim. Expected to be non-nil
+                  when bound. claim.VolumeName is the authoritative bind between PV
+                  and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              csi:
+                description: csi represents storage that is handled by an external
+                  CSI driver (Beta feature).
+                properties:
+                  controllerExpandSecretRef:
+                    description: controllerExpandSecretRef is a reference to the secret
+                      object containing sensitive information to pass to the CSI driver
+                      to complete the CSI ControllerExpandVolume call. This is an
+                      beta field and requires enabling ExpandCSIVolumes feature gate.
+                      This field is optional, and may be empty if no secret is required.
+                      If the secret object contains more than one secret, all secrets
+                      are passed.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  controllerPublishSecretRef:
+                    description: controllerPublishSecretRef is a reference to the
+                      secret object containing sensitive information to pass to the
+                      CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume
+                      calls. This field is optional, and may be empty if no secret
+                      is required. If the secret object contains more than one secret,
+                      all secrets are passed.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  driver:
+                    description: driver is the name of the driver to use for this
+                      volume. Required.
+                    type: string
+                  fsType:
+                    description: fsType to mount. Must be a filesystem type supported
+                      by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                    type: string
+                  nodeExpandSecretRef:
+                    description: nodeExpandSecretRef is a reference to the secret
+                      object containing sensitive information to pass to the CSI driver
+                      to complete the CSI NodeExpandVolume call. This is an alpha
+                      field and requires enabling CSINodeExpandSecret feature gate.
+                      This field is optional, may be omitted if no secret is required.
+                      If the secret object contains more than one secret, all secrets
+                      are passed.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  nodePublishSecretRef:
+                    description: nodePublishSecretRef is a reference to the secret
+                      object containing sensitive information to pass to the CSI driver
+                      to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                      calls. This field is optional, and may be empty if no secret
+                      is required. If the secret object contains more than one secret,
+                      all secrets are passed.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  nodeStageSecretRef:
+                    description: nodeStageSecretRef is a reference to the secret object
+                      containing sensitive information to pass to the CSI driver to
+                      complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume
+                      calls. This field is optional, and may be empty if no secret
+                      is required. If the secret object contains more than one secret,
+                      all secrets are passed.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  readOnly:
+                    description: readOnly value to pass to ControllerPublishVolumeRequest.
+                      Defaults to false (read/write).
+                    type: boolean
+                  volumeAttributes:
+                    additionalProperties:
+                      type: string
+                    description: volumeAttributes of the volume to publish.
+                    type: object
+                  volumeHandle:
+                    description: volumeHandle is the unique volume name returned by
+                      the CSI volume plugin’s CreateVolume to refer to the volume
+                      on all subsequent calls. Required.
+                    type: string
+                required:
+                - driver
+                - volumeHandle
+                type: object
+              fc:
+                description: fc represents a Fibre Channel resource that is attached
+                  to a kubelet's host machine and then exposed to the pod.
+                properties:
+                  fsType:
+                    description: fsType is the filesystem type to mount. Must be a
+                      filesystem type supported by the host operating system. Ex.
+                      "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  lun:
+                    description: 'lun is Optional: FC target lun number'
+                    format: int32
+                    type: integer
+                  readOnly:
+                    description: 'readOnly is Optional: Defaults to false (read/write).
+                      ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                    type: boolean
+                  targetWWNs:
+                    description: 'targetWWNs is Optional: FC target worldwide names
+                      (WWNs)'
+                    items:
+                      type: string
+                    type: array
+                  wwids:
+                    description: 'wwids Optional: FC volume world wide identifiers
+                      (wwids) Either wwids or combination of targetWWNs and lun must
+                      be set, but not both simultaneously.'
+                    items:
+                      type: string
+                    type: array
+                type: object
+              flexVolume:
+                description: flexVolume represents a generic volume resource that
+                  is provisioned/attached using an exec based plugin.
+                properties:
+                  driver:
+                    description: driver is the name of the driver to use for this
+                      volume.
+                    type: string
+                  fsType:
+                    description: fsType is the Filesystem type to mount. Must be a
+                      filesystem type supported by the host operating system. Ex.
+                      "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume
+                      script.
+                    type: string
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: 'options is Optional: this field holds extra command
+                      options if any.'
+                    type: object
+                  readOnly:
+                    description: 'readOnly is Optional: defaults to false (read/write).
+                      ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                    type: boolean
+                  secretRef:
+                    description: 'secretRef is Optional: SecretRef is reference to
+                      the secret object containing sensitive information to pass to
+                      the plugin scripts. This may be empty if no secret object is
+                      specified. If the secret object contains more than one secret,
+                      all secrets are passed to the plugin scripts.'
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                required:
+                - driver
+                type: object
+              flocker:
+                description: flocker represents a Flocker volume attached to a kubelet's
+                  host machine and exposed to the pod for its usage. This depends
+                  on the Flocker control service being running
+                properties:
+                  datasetName:
+                    description: datasetName is Name of the dataset stored as metadata
+                      -> name on the dataset for Flocker should be considered as deprecated
+                    type: string
+                  datasetUUID:
+                    description: datasetUUID is the UUID of the dataset. This is unique
+                      identifier of a Flocker dataset
+                    type: string
+                type: object
+              gcePersistentDisk:
+                description: 'gcePersistentDisk represents a GCE Disk resource that
+                  is attached to a kubelet''s host machine and then exposed to the
+                  pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                properties:
+                  fsType:
+                    description: 'fsType is filesystem type of the volume that you
+                      want to mount. Tip: Ensure that the filesystem type is supported
+                      by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                      Implicitly inferred to be "ext4" if unspecified. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: string
+                  partition:
+                    description: 'partition is the partition in the volume that you
+                      want to mount. If omitted, the default is to mount by volume
+                      name. Examples: For volume /dev/sda1, you specify the partition
+                      as "1". Similarly, the volume partition for /dev/sda is "0"
+                      (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    format: int32
+                    type: integer
+                  pdName:
+                    description: 'pdName is unique name of the PD resource in GCE.
+                      Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: string
+                  readOnly:
+                    description: 'readOnly here will force the ReadOnly setting in
+                      VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: boolean
+                required:
+                - pdName
+                type: object
+              glusterfs:
+                description: 'glusterfs represents a Glusterfs volume that is attached
+                  to a host and exposed to the pod. Provisioned by an admin. More
+                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                properties:
+                  endpoints:
+                    description: 'endpoints is the endpoint name that details Glusterfs
+                      topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: string
+                  endpointsNamespace:
+                    description: 'endpointsNamespace is the namespace that contains
+                      Glusterfs endpoint. If this field is empty, the EndpointNamespace
+                      defaults to the same namespace as the bound PVC. More info:
+                      https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: string
+                  path:
+                    description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: string
+                  readOnly:
+                    description: 'readOnly here will force the Glusterfs volume to
+                      be mounted with read-only permissions. Defaults to false. More
+                      info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                    type: boolean
+                required:
+                - endpoints
+                - path
+                type: object
+              hostPath:
+                description: 'hostPath represents a directory on the host. Provisioned
+                  by a developer or tester. This is useful for single-node development
+                  and testing only! On-host storage is not supported in any way and
+                  WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                properties:
+                  path:
+                    description: 'path of the directory on the host. If the path is
+                      a symlink, it will follow the link to the real path. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                    type: string
+                  type:
+                    description: 'type for HostPath Volume Defaults to "" More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                    type: string
+                required:
+                - path
+                type: object
+              iscsi:
+                description: iscsi represents an ISCSI Disk resource that is attached
+                  to a kubelet's host machine and then exposed to the pod. Provisioned
+                  by an admin.
+                properties:
+                  chapAuthDiscovery:
+                    description: chapAuthDiscovery defines whether support iSCSI Discovery
+                      CHAP authentication
+                    type: boolean
+                  chapAuthSession:
+                    description: chapAuthSession defines whether support iSCSI Session
+                      CHAP authentication
+                    type: boolean
+                  fsType:
+                    description: 'fsType is the filesystem type of the volume that
+                      you want to mount. Tip: Ensure that the filesystem type is supported
+                      by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                      Implicitly inferred to be "ext4" if unspecified. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                    type: string
+                  initiatorName:
+                    description: initiatorName is the custom iSCSI Initiator Name.
+                      If initiatorName is specified with iscsiInterface simultaneously,
+                      new iSCSI interface <target portal>:<volume name> will be created
+                      for the connection.
+                    type: string
+                  iqn:
+                    description: iqn is Target iSCSI Qualified Name.
+                    type: string
+                  iscsiInterface:
+                    description: iscsiInterface is the interface Name that uses an
+                      iSCSI transport. Defaults to 'default' (tcp).
+                    type: string
+                  lun:
+                    description: lun is iSCSI Target Lun number.
+                    format: int32
+                    type: integer
+                  portals:
+                    description: portals is the iSCSI Target Portal List. The Portal
+                      is either an IP or ip_addr:port if the port is other than default
+                      (typically TCP ports 860 and 3260).
+                    items:
+                      type: string
+                    type: array
+                  readOnly:
+                    description: readOnly here will force the ReadOnly setting in
+                      VolumeMounts. Defaults to false.
+                    type: boolean
+                  secretRef:
+                    description: secretRef is the CHAP Secret for iSCSI target and
+                      initiator authentication
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  targetPortal:
+                    description: targetPortal is iSCSI Target Portal. The Portal is
+                      either an IP or ip_addr:port if the port is other than default
+                      (typically TCP ports 860 and 3260).
+                    type: string
+                required:
+                - targetPortal
+                - iqn
+                - lun
+                type: object
+              local:
+                description: local represents directly-attached storage with node
+                  affinity
+                properties:
+                  fsType:
+                    description: fsType is the filesystem type to mount. It applies
+                      only when the Path is a block device. Must be a filesystem type
+                      supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                      The default value is to auto-select a filesystem if unspecified.
+                    type: string
+                  path:
+                    description: path of the full path to the volume on the node.
+                      It can be either a directory or block device (disk, partition,
+                      ...).
+                    type: string
+                required:
+                - path
+                type: object
+              mountOptions:
+                description: 'mountOptions is the list of mount options, e.g. ["ro",
+                  "soft"]. Not validated - mount will simply fail if one is invalid.
+                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+                items:
+                  type: string
+                type: array
+              nfs:
+                description: 'nfs represents an NFS mount on the host. Provisioned
+                  by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                properties:
+                  path:
+                    description: 'path that is exported by the NFS server. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: string
+                  readOnly:
+                    description: 'readOnly here will force the NFS export to be mounted
+                      with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: boolean
+                  server:
+                    description: 'server is the hostname or IP address of the NFS
+                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: string
+                required:
+                - server
+                - path
+                type: object
+              nodeAffinity:
+                description: nodeAffinity defines constraints that limit what nodes
+                  this volume can be accessed from. This field influences the scheduling
+                  of pods that use this volume.
+                properties:
+                  required:
+                    description: required specifies hard node constraints that must
+                      be met.
+                    properties:
+                      nodeSelectorTerms:
+                        description: Required. A list of node selector terms. The
+                          terms are ORed.
+                        items:
+                          description: A null or empty node selector term matches
+                            no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                            type implements a subset of the NodeSelectorTerm.
+                          properties:
+                            matchExpressions:
+                              description: A list of node selector requirements by
+                                node's labels.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchFields:
+                              description: A list of node selector requirements by
+                                node's fields.
+                              items:
+                                description: A node selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: The label key that the selector applies
+                                      to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                      Possible enum values:
+                                       - `"DoesNotExist"`
+                                       - `"Exists"`
+                                       - `"Gt"`
+                                       - `"In"`
+                                       - `"Lt"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: An array of string values. If the
+                                      operator is In or NotIn, the values array must
+                                      be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. If the operator
+                                      is Gt or Lt, the values array must have a single
+                                      element, which will be interpreted as an integer.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    required:
+                    - nodeSelectorTerms
+                    type: object
+                type: object
+              persistentVolumeReclaimPolicy:
+                description: |-
+                  persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+                  Possible enum values:
+                   - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+                   - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+                   - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+                type: string
+              photonPersistentDisk:
+                description: photonPersistentDisk represents a PhotonController persistent
+                  disk attached and mounted on kubelets host machine
+                properties:
+                  fsType:
+                    description: fsType is the filesystem type to mount. Must be a
+                      filesystem type supported by the host operating system. Ex.
+                      "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  pdID:
+                    description: pdID is the ID that identifies Photon Controller
+                      persistent disk
+                    type: string
+                required:
+                - pdID
+                type: object
+              portworxVolume:
+                description: portworxVolume represents a portworx volume attached
+                  and mounted on kubelets host machine
+                properties:
+                  fsType:
+                    description: fSType represents the filesystem type to mount Must
+                      be a filesystem type supported by the host operating system.
+                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly
+                      here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                  volumeID:
+                    description: volumeID uniquely identifies a Portworx volume
+                    type: string
+                required:
+                - volumeID
+                type: object
+              quobyte:
+                description: quobyte represents a Quobyte mount on the host that shares
+                  a pod's lifetime
+                properties:
+                  group:
+                    description: group to map volume access to Default is no group
+                    type: string
+                  readOnly:
+                    description: readOnly here will force the Quobyte volume to be
+                      mounted with read-only permissions. Defaults to false.
+                    type: boolean
+                  registry:
+                    description: registry represents a single or multiple Quobyte
+                      Registry services specified as a string as host:port pair (multiple
+                      entries are separated with commas) which acts as the central
+                      registry for volumes
+                    type: string
+                  tenant:
+                    description: tenant owning the given Quobyte volume in the Backend
+                      Used with dynamically provisioned Quobyte volumes, value is
+                      set by the plugin
+                    type: string
+                  user:
+                    description: user to map volume access to Defaults to serivceaccount
+                      user
+                    type: string
+                  volume:
+                    description: volume is a string that references an already created
+                      Quobyte volume by name.
+                    type: string
+                required:
+                - registry
+                - volume
+                type: object
+              rbd:
+                description: 'rbd represents a Rados Block Device mount on the host
+                  that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                properties:
+                  fsType:
+                    description: 'fsType is the filesystem type of the volume that
+                      you want to mount. Tip: Ensure that the filesystem type is supported
+                      by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                      Implicitly inferred to be "ext4" if unspecified. More info:
+                      https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                    type: string
+                  image:
+                    description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                  keyring:
+                    description: 'keyring is the path to key ring for RBDUser. Default
+                      is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                  monitors:
+                    description: 'monitors is a collection of Ceph monitors. More
+                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    items:
+                      type: string
+                    type: array
+                  pool:
+                    description: 'pool is the rados pool name. Default is rbd. More
+                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                  readOnly:
+                    description: 'readOnly here will force the ReadOnly setting in
+                      VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: boolean
+                  secretRef:
+                    description: 'secretRef is name of the authentication secret for
+                      RBDUser. If provided overrides keyring. Default is nil. More
+                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  user:
+                    description: 'user is the rados user name. Default is admin. More
+                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                    type: string
+                required:
+                - monitors
+                - image
+                type: object
+              scaleIO:
+                description: scaleIO represents a ScaleIO persistent volume attached
+                  and mounted on Kubernetes nodes.
+                properties:
+                  fsType:
+                    description: fsType is the filesystem type to mount. Must be a
+                      filesystem type supported by the host operating system. Ex.
+                      "ext4", "xfs", "ntfs". Default is "xfs"
+                    type: string
+                  gateway:
+                    description: gateway is the host address of the ScaleIO API Gateway.
+                    type: string
+                  protectionDomain:
+                    description: protectionDomain is the name of the ScaleIO Protection
+                      Domain for the configured storage.
+                    type: string
+                  readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly
+                      here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                  secretRef:
+                    description: secretRef references to the secret for ScaleIO user
+                      and other sensitive information. If this is not provided, Login
+                      operation will fail.
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference
+                          a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the
+                          secret name must be unique.
+                        type: string
+                    type: object
+                  sslEnabled:
+                    description: sslEnabled is the flag to enable/disable SSL communication
+                      with Gateway, default false
+                    type: boolean
+                  storageMode:
+                    description: storageMode indicates whether the storage for a volume
+                      should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                    type: string
+                  storagePool:
+                    description: storagePool is the ScaleIO Storage Pool associated
+                      with the protection domain.
+                    type: string
+                  system:
+                    description: system is the name of the storage system as configured
+                      in ScaleIO.
+                    type: string
+                  volumeName:
+                    description: volumeName is the name of a volume already created
+                      in the ScaleIO system that is associated with this volume source.
+                    type: string
+                required:
+                - gateway
+                - system
+                - secretRef
+                type: object
+              storageClassName:
+                description: storageClassName is the name of StorageClass to which
+                  this persistent volume belongs. Empty value means that this volume
+                  does not belong to any StorageClass.
+                type: string
+              storageos:
+                description: 'storageOS represents a StorageOS volume that is attached
+                  to the kubelet''s host machine and mounted into the pod More info:
+                  https://examples.k8s.io/volumes/storageos/README.md'
+                properties:
+                  fsType:
+                    description: fsType is the filesystem type to mount. Must be a
+                      filesystem type supported by the host operating system. Ex.
+                      "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  readOnly:
+                    description: readOnly defaults to false (read/write). ReadOnly
+                      here will force the ReadOnly setting in VolumeMounts.
+                    type: boolean
+                  secretRef:
+                    description: secretRef specifies the secret to use for obtaining
+                      the StorageOS API credentials.  If not specified, default values
+                      will be attempted.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  volumeName:
+                    description: volumeName is the human-readable name of the StorageOS
+                      volume.  Volume names are only unique within a namespace.
+                    type: string
+                  volumeNamespace:
+                    description: volumeNamespace specifies the scope of the volume
+                      within StorageOS.  If no namespace is specified then the Pod's
+                      namespace will be used.  This allows the Kubernetes name scoping
+                      to be mirrored within StorageOS for tighter integration. Set
+                      VolumeName to any name to override the default behaviour. Set
+                      to "default" if you are not using namespaces within StorageOS.
+                      Namespaces that do not pre-exist within StorageOS will be created.
+                    type: string
+                type: object
+              volumeMode:
+                description: volumeMode defines if a volume is intended to be used
+                  with a formatted filesystem or to remain in raw block state. Value
+                  of Filesystem is implied when not included in spec.
+                type: string
+              vsphereVolume:
+                description: vsphereVolume represents a vSphere volume attached and
+                  mounted on kubelets host machine
+                properties:
+                  fsType:
+                    description: fsType is filesystem type to mount. Must be a filesystem
+                      type supported by the host operating system. Ex. "ext4", "xfs",
+                      "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    type: string
+                  storagePolicyID:
+                    description: storagePolicyID is the storage Policy Based Management
+                      (SPBM) profile ID associated with the StoragePolicyName.
+                    type: string
+                  storagePolicyName:
+                    description: storagePolicyName is the storage Policy Based Management
+                      (SPBM) profile name.
+                    type: string
+                  volumePath:
+                    description: volumePath is the path that identifies vSphere volume
+                      vmdk
+                    type: string
+                required:
+                - volumePath
+                type: object
+            type: object
+          status:
+            description: 'status represents the current information/status for the
+              persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes'
+            properties:
+              message:
+                description: message is a human-readable message indicating details
+                  about why the volume is in this state.
+                type: string
+              phase:
+                description: |-
+                  phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+
+                  Possible enum values:
+                   - `"Available"` used for PersistentVolumes that are not yet bound Available volumes are held by the binder and matched to PersistentVolumeClaims
+                   - `"Bound"` used for PersistentVolumes that are bound
+                   - `"Failed"` used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+                   - `"Pending"` used for PersistentVolumes that are not available
+                   - `"Released"` used for PersistentVolumes where the bound PersistentVolumeClaim was deleted released volumes must be recycled before becoming available again this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
+                type: string
+              reason:
+                description: reason is a brief CamelCase string that describes any
+                  failure and is meant for machine parsing and tidy display in the
+                  CLI.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/flowcontrol.apiserver.k8s.io_flowschemas.yaml
+++ b/config/kube/crds/cluster-scoped/flowcontrol.apiserver.k8s.io_flowschemas.yaml
@@ -1,0 +1,315 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: flowschemas.flowcontrol.apiserver.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: flowcontrol.apiserver.k8s.io
+  names:
+    kind: FlowSchema
+    listKind: FlowSchemaList
+    plural: flowschemas
+    singular: flowschema
+  scope: Cluster
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: 'FlowSchema defines the schema of a group of flows. Note that
+          a flow is made up of a set of inbound API requests with similar attributes
+          and is identified by a pair of strings: the name of the FlowSchema and a
+          "flow distinguisher".'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: '`spec` is the specification of the desired behavior of a
+              FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              distinguisherMethod:
+                description: '`distinguisherMethod` defines how to compute the flow
+                  distinguisher for requests that match this schema. `nil` specifies
+                  that the distinguisher is disabled and thus will always be the empty
+                  string.'
+                properties:
+                  type:
+                    description: '`type` is the type of flow distinguisher method
+                      The supported types are "ByUser" and "ByNamespace". Required.'
+                    type: string
+                required:
+                - type
+                type: object
+              matchingPrecedence:
+                description: '`matchingPrecedence` is used to choose among the FlowSchemas
+                  that match a given request. The chosen FlowSchema is among those
+                  with the numerically lowest (which we take to be logically highest)
+                  MatchingPrecedence.  Each MatchingPrecedence value must be ranged
+                  in [1,10000]. Note that if the precedence is not specified, it will
+                  be set to 1000 as default.'
+                format: int32
+                type: integer
+              priorityLevelConfiguration:
+                description: '`priorityLevelConfiguration` should reference a PriorityLevelConfiguration
+                  in the cluster. If the reference cannot be resolved, the FlowSchema
+                  will be ignored and marked as invalid in its status. Required.'
+                properties:
+                  name:
+                    description: '`name` is the name of the priority level configuration
+                      being referenced Required.'
+                    type: string
+                required:
+                - name
+                type: object
+              rules:
+                description: '`rules` describes which requests will match this flow
+                  schema. This FlowSchema matches a request if and only if at least
+                  one member of rules matches the request. if it is an empty slice,
+                  there will be no requests matching the FlowSchema.'
+                items:
+                  description: PolicyRulesWithSubjects prescribes a test that applies
+                    to a request to an apiserver. The test considers the subject making
+                    the request, the verb being requested, and the resource to be
+                    acted upon. This PolicyRulesWithSubjects matches a request if
+                    and only if both (a) at least one member of subjects matches the
+                    request and (b) at least one member of resourceRules or nonResourceRules
+                    matches the request.
+                  properties:
+                    nonResourceRules:
+                      description: '`nonResourceRules` is a list of NonResourcePolicyRules
+                        that identify matching requests according to their verb and
+                        the target non-resource URL.'
+                      items:
+                        description: NonResourcePolicyRule is a predicate that matches
+                          non-resource requests according to their verb and the target
+                          non-resource URL. A NonResourcePolicyRule matches a request
+                          if and only if both (a) at least one member of verbs matches
+                          the request and (b) at least one member of nonResourceURLs
+                          matches the request.
+                        properties:
+                          nonResourceURLs:
+                            description: |-
+                              `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+                                - "/healthz" is legal
+                                - "/hea*" is illegal
+                                - "/hea" is legal but matches nothing
+                                - "/hea/*" also matches nothing
+                                - "/healthz/*" matches all per-component health checks.
+                              "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          verbs:
+                            description: '`verbs` is a list of matching verbs and
+                              may not be empty. "*" matches all verbs. If it is present,
+                              it must be the only entry. Required.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - verbs
+                        - nonResourceURLs
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    resourceRules:
+                      description: '`resourceRules` is a slice of ResourcePolicyRules
+                        that identify matching requests according to their verb and
+                        the target resource. At least one of `resourceRules` and `nonResourceRules`
+                        has to be non-empty.'
+                      items:
+                        description: 'ResourcePolicyRule is a predicate that matches
+                          some resource requests, testing the request''s verb and
+                          the target resource. A ResourcePolicyRule matches a resource
+                          request if and only if: (a) at least one member of verbs
+                          matches the request, (b) at least one member of apiGroups
+                          matches the request, (c) at least one member of resources
+                          matches the request, and (d) either (d1) the request does
+                          not specify a namespace (i.e., `Namespace==""`) and clusterScope
+                          is true or (d2) the request specifies a namespace and least
+                          one member of namespaces matches the request''s namespace.'
+                        properties:
+                          apiGroups:
+                            description: '`apiGroups` is a list of matching API groups
+                              and may not be empty. "*" matches all API groups and,
+                              if present, must be the only entry. Required.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          clusterScope:
+                            description: '`clusterScope` indicates whether to match
+                              requests that do not specify a namespace (which happens
+                              either because the resource is not namespaced or the
+                              request targets all namespaces). If this field is omitted
+                              or false then the `namespaces` field must contain a
+                              non-empty list.'
+                            type: boolean
+                          namespaces:
+                            description: '`namespaces` is a list of target namespaces
+                              that restricts matches.  A request that specifies a
+                              target namespace matches only if either (a) this list
+                              contains that target namespace or (b) this list contains
+                              "*".  Note that "*" matches any specified namespace
+                              but does not match a request that _does not specify_
+                              a namespace (see the `clusterScope` field for that).
+                              This list may be empty, but only if `clusterScope` is
+                              true.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          resources:
+                            description: '`resources` is a list of matching resources
+                              (i.e., lowercase and plural) with, if desired, subresource.  For
+                              example, [ "services", "nodes/status" ].  This list
+                              may not be empty. "*" matches all resources and, if
+                              present, must be the only entry. Required.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          verbs:
+                            description: '`verbs` is a list of matching verbs and
+                              may not be empty. "*" matches all verbs and, if present,
+                              must be the only entry. Required.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - verbs
+                        - apiGroups
+                        - resources
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    subjects:
+                      description: subjects is the list of normal user, serviceaccount,
+                        or group that this rule cares about. There must be at least
+                        one member in this slice. A slice that includes both the system:authenticated
+                        and system:unauthenticated user groups matches every request.
+                        Required.
+                      items:
+                        description: Subject matches the originator of a request,
+                          as identified by the request authentication system. There
+                          are three ways of matching an originator; by user, group,
+                          or service account.
+                        properties:
+                          group:
+                            description: '`group` matches based on user group name.'
+                            properties:
+                              name:
+                                description: name is the user group that matches,
+                                  or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go
+                                  for some well-known group names. Required.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          kind:
+                            description: '`kind` indicates which one of the other
+                              fields is non-empty. Required'
+                            type: string
+                          serviceAccount:
+                            description: '`serviceAccount` matches ServiceAccounts.'
+                            properties:
+                              name:
+                                description: '`name` is the name of matching ServiceAccount
+                                  objects, or "*" to match regardless of name. Required.'
+                                type: string
+                              namespace:
+                                description: '`namespace` is the namespace of matching
+                                  ServiceAccount objects. Required.'
+                                type: string
+                            required:
+                            - namespace
+                            - name
+                            type: object
+                          user:
+                            description: '`user` matches based on username.'
+                            properties:
+                              name:
+                                description: '`name` is the username that matches,
+                                  or "*" to match all usernames. Required.'
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        required:
+                        - kind
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - subjects
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - priorityLevelConfiguration
+            type: object
+          status:
+            description: '`status` is the current status of a FlowSchema. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              conditions:
+                description: '`conditions` is a list of the current states of FlowSchema.'
+                items:
+                  description: FlowSchemaCondition describes conditions for a FlowSchema.
+                  properties:
+                    lastTransitionTime:
+                      description: '`lastTransitionTime` is the last time the condition
+                        transitioned from one status to another.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: '`message` is a human-readable message indicating
+                        details about last transition.'
+                      type: string
+                    reason:
+                      description: '`reason` is a unique, one-word, CamelCase reason
+                        for the condition''s last transition.'
+                      type: string
+                    status:
+                      description: '`status` is the status of the condition. Can be
+                        True, False, Unknown. Required.'
+                      type: string
+                    type:
+                      description: '`type` is the type of the condition. Required.'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1beta2

--- a/config/kube/crds/cluster-scoped/flowcontrol.apiserver.k8s.io_prioritylevelconfigurations.yaml
+++ b/config/kube/crds/cluster-scoped/flowcontrol.apiserver.k8s.io_prioritylevelconfigurations.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: prioritylevelconfigurations.flowcontrol.apiserver.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: flowcontrol.apiserver.k8s.io
+  names:
+    kind: PriorityLevelConfiguration
+    listKind: PriorityLevelConfigurationList
+    plural: prioritylevelconfigurations
+    singular: prioritylevelconfiguration
+  scope: Cluster
+  versions:
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: PriorityLevelConfiguration represents the configuration of a
+          priority level.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: '`spec` is the specification of the desired behavior of a
+              "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              limited:
+                description: '`limited` specifies how requests are handled for a Limited
+                  priority level. This field must be non-empty if and only if `type`
+                  is `"Limited"`.'
+                properties:
+                  assuredConcurrencyShares:
+                    description: |-
+                      `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                                  ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+                      bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+                    format: int32
+                    type: integer
+                  limitResponse:
+                    description: '`limitResponse` indicates what to do with requests
+                      that can not be executed right now'
+                    properties:
+                      queuing:
+                        description: '`queuing` holds the configuration parameters
+                          for queuing. This field may be non-empty only if `type`
+                          is `"Queue"`.'
+                        properties:
+                          handSize:
+                            description: '`handSize` is a small positive number that
+                              configures the shuffle sharding of requests into queues.  When
+                              enqueuing a request at this priority level the request''s
+                              flow identifier (a string pair) is hashed and the hash
+                              value is used to shuffle the list of queues and deal
+                              a hand of the size specified here.  The request is put
+                              into one of the shortest queues in that hand. `handSize`
+                              must be no larger than `queues`, and should be significantly
+                              smaller (so that a few heavy flows do not saturate most
+                              of the queues).  See the user-facing documentation for
+                              more extensive guidance on setting this field.  This
+                              field has a default value of 8.'
+                            format: int32
+                            type: integer
+                          queueLengthLimit:
+                            description: '`queueLengthLimit` is the maximum number
+                              of requests allowed to be waiting in a given queue of
+                              this priority level at a time; excess requests are rejected.  This
+                              value must be positive.  If not specified, it will be
+                              defaulted to 50.'
+                            format: int32
+                            type: integer
+                          queues:
+                            description: '`queues` is the number of queues for this
+                              priority level. The queues exist independently at each
+                              apiserver. The value must be positive.  Setting it to
+                              1 effectively precludes shufflesharding and thus makes
+                              the distinguisher method of associated flow schemas
+                              irrelevant.  This field has a default value of 64.'
+                            format: int32
+                            type: integer
+                        type: object
+                      type:
+                        description: '`type` is "Queue" or "Reject". "Queue" means
+                          that requests that can not be executed upon arrival are
+                          held in a queue until they can be executed or a queuing
+                          limit is reached. "Reject" means that requests that can
+                          not be executed upon arrival are rejected. Required.'
+                        type: string
+                    required:
+                    - type
+                    type: object
+                type: object
+              type:
+                description: '`type` indicates whether this priority level is subject
+                  to limitation on request execution.  A value of `"Exempt"` means
+                  that requests of this priority level are not subject to a limit
+                  (and thus are never queued) and do not detract from the capacity
+                  made available to other priority levels.  A value of `"Limited"`
+                  means that (a) requests of this priority level _are_ subject to
+                  limits and (b) some of the server''s limited capacity is made available
+                  exclusively to this priority level. Required.'
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: '`status` is the current status of a "request-priority".
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              conditions:
+                description: '`conditions` is the current state of "request-priority".'
+                items:
+                  description: PriorityLevelConfigurationCondition defines the condition
+                    of priority level.
+                  properties:
+                    lastTransitionTime:
+                      description: '`lastTransitionTime` is the last time the condition
+                        transitioned from one status to another.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: '`message` is a human-readable message indicating
+                        details about last transition.'
+                      type: string
+                    reason:
+                      description: '`reason` is a unique, one-word, CamelCase reason
+                        for the condition''s last transition.'
+                      type: string
+                    status:
+                      description: '`status` is the status of the condition. Can be
+                        True, False, Unknown. Required.'
+                      type: string
+                    type:
+                      description: '`type` is the type of the condition. Required.'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1beta2

--- a/config/kube/crds/cluster-scoped/networking.k8s.io_ingressclasses.yaml
+++ b/config/kube/crds/cluster-scoped/networking.k8s.io_ingressclasses.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: ingressclasses.networking.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: networking.k8s.io
+  names:
+    kind: IngressClass
+    listKind: IngressClassList
+    plural: ingressclasses
+    singular: ingressclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: IngressClass represents the class of the Ingress, referenced
+          by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation
+          can be used to indicate that an IngressClass should be considered default.
+          When a single IngressClass resource has this annotation set to true, new
+          Ingress resources without a class specified will be assigned this default
+          class.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Spec is the desired state of the IngressClass. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              controller:
+                description: Controller refers to the name of the controller that
+                  should handle this class. This allows for different "flavors" that
+                  are controlled by the same controller. For example, you may have
+                  different Parameters for the same implementing controller. This
+                  should be specified as a domain-prefixed path no more than 250 characters
+                  in length, e.g. "acme.io/ingress-controller". This field is immutable.
+                type: string
+              parameters:
+                description: Parameters is a link to a custom resource containing
+                  additional configuration for the controller. This is optional if
+                  the controller does not require extra parameters.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced.
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the resource being
+                      referenced. This field is required when scope is set to "Namespace"
+                      and must be unset when scope is set to "Cluster".
+                    type: string
+                  scope:
+                    description: Scope represents if this refers to a cluster or namespace
+                      scoped resource. This may be set to "Cluster" (default) or "Namespace".
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/node.k8s.io_runtimeclasses.yaml
+++ b/config/kube/crds/cluster-scoped/node.k8s.io_runtimeclasses.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: runtimeclasses.node.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: node.k8s.io
+  names:
+    kind: RuntimeClass
+    listKind: RuntimeClassList
+    plural: runtimeclasses
+    singular: runtimeclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: RuntimeClass defines a class of container runtime supported in
+          the cluster. The RuntimeClass is used to determine which container runtime
+          is used to run all containers in a pod. RuntimeClasses are manually defined
+          by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet
+          is responsible for resolving the RuntimeClassName reference before running
+          the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          handler:
+            description: Handler specifies the underlying runtime and configuration
+              that the CRI implementation will use to handle pods of this class. The
+              possible values are specific to the node & CRI configuration.  It is
+              assumed that all handlers are available on every node, and handlers
+              of the same name are equivalent on every node. For example, a handler
+              called "runc" might specify that the runc OCI runtime (using native
+              Linux containers) will be used to run the containers in a pod. The Handler
+              must be lowercase, conform to the DNS Label (RFC 1123) requirements,
+              and is immutable.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          overhead:
+            description: |-
+              Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+               https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
+            properties:
+              podFixed:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: PodFixed represents the fixed resource overhead associated
+                  with running a pod.
+                type: object
+            type: object
+          scheduling:
+            description: Scheduling holds the scheduling constraints to ensure that
+              pods running with this RuntimeClass are scheduled to nodes that support
+              it. If scheduling is nil, this RuntimeClass is assumed to be supported
+              by all nodes.
+            properties:
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: nodeSelector lists labels that must be present on nodes
+                  that support this RuntimeClass. Pods using this RuntimeClass can
+                  only be scheduled to a node matched by this selector. The RuntimeClass
+                  nodeSelector is merged with a pod's existing nodeSelector. Any conflicts
+                  will cause the pod to be rejected in admission.
+                type: object
+              tolerations:
+                description: tolerations are appended (excluding duplicates) to pods
+                  running with this RuntimeClass during admission, effectively unioning
+                  the set of nodes tolerated by the pod and the RuntimeClass.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                        Possible enum values:
+                         - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                         - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                         - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                        Possible enum values:
+                         - `"Equal"`
+                         - `"Exists"`
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        required:
+        - handler
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/scheduling.k8s.io_priorityclasses.yaml
+++ b/config/kube/crds/cluster-scoped/scheduling.k8s.io_priorityclasses.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: priorityclasses.scheduling.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: scheduling.k8s.io
+  names:
+    kind: PriorityClass
+    listKind: PriorityClassList
+    plural: priorityclasses
+    shortNames:
+    - pc
+    singular: priorityclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PriorityClass defines mapping from a priority class name to the
+          priority integer value. The value can be any valid integer.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          description:
+            description: description is an arbitrary string that usually provides
+              guidelines on when this priority class should be used.
+            type: string
+          globalDefault:
+            description: globalDefault specifies whether this PriorityClass should
+              be considered as the default priority for pods that do not have any
+              priority class. Only one PriorityClass can be marked as `globalDefault`.
+              However, if more than one PriorityClasses exists with their `globalDefault`
+              field set to true, the smallest value of such global default PriorityClasses
+              will be used as the default priority.
+            type: boolean
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          preemptionPolicy:
+            description: PreemptionPolicy is the Policy for preempting pods with lower
+              priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+              if unset.
+            type: string
+          value:
+            description: The value of this priority class. This is the actual priority
+              that pods receive when they have the name of this class in their pod
+              spec.
+            format: int32
+            type: integer
+        required:
+        - value
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/storage.k8s.io_csidrivers.yaml
+++ b/config/kube/crds/cluster-scoped/storage.k8s.io_csidrivers.yaml
@@ -1,0 +1,145 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: csidrivers.storage.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: storage.k8s.io
+  names:
+    kind: CSIDriver
+    listKind: CSIDriverList
+    plural: csidrivers
+    singular: csidriver
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CSIDriver captures information about a Container Storage Interface
+          (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller
+          uses this object to determine whether attach is required. Kubelet uses this
+          object to determine whether pod information needs to be passed on mount.
+          CSIDriver objects are non-namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the CSI Driver.
+            properties:
+              attachRequired:
+                description: |-
+                  attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+
+                  This field is immutable.
+                type: boolean
+              fsGroupPolicy:
+                description: |-
+                  Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details.
+
+                  This field is immutable.
+
+                  Defaults to ReadWriteOnceWithFSType, which will examine each volume to determine if Kubernetes should modify ownership and permissions of the volume. With the default policy the defined fsGroup will only be applied if a fstype is defined and the volume's access mode contains ReadWriteOnce.
+                type: string
+              podInfoOnMount:
+                description: |-
+                  If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" if the volume is an ephemeral inline volume
+                                                  defined by a CSIVolumeSource, otherwise "false"
+
+                  "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+
+                  This field is immutable.
+                type: boolean
+              requiresRepublish:
+                description: |-
+                  RequiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+                  Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+                type: boolean
+              seLinuxMount:
+                description: |-
+                  SELinuxMount specifies if the CSI driver supports "-o context" mount option.
+
+                  When "true", the CSI driver must ensure that all volumes provided by this CSI driver can be mounted separately with different `-o context` options. This is typical for storage backends that provide volumes as filesystems on block devices or as independent shared volumes. Kubernetes will call NodeStage / NodePublish with "-o context=xyz" mount option when mounting a ReadWriteOncePod volume used in Pod that has explicitly set SELinux context. In the future, it may be expanded to other volume AccessModes. In any case, Kubernetes will ensure that the volume is mounted only with a single SELinux context.
+
+                  When "false", Kubernetes won't pass any special SELinux mount options to the driver. This is typical for volumes that represent subdirectories of a bigger shared filesystem.
+
+                  Default is "false".
+                type: boolean
+              storageCapacity:
+                description: |-
+                  If set to true, storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information.
+
+                  The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+                  Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+                  This field was immutable in Kubernetes <= 1.22 and now is mutable.
+                type: boolean
+              tokenRequests:
+                description: |-
+                  TokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+                    "<audience>": {
+                      "token": <token>,
+                      "expirationTimestamp": <expiration timestamp in RFC3339>,
+                    },
+                    ...
+                  }
+
+                  Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+                items:
+                  description: TokenRequest contains parameters of a service account
+                    token.
+                  properties:
+                    audience:
+                      description: Audience is the intended audience of the token
+                        in "TokenRequestSpec". It will default to the audiences of
+                        kube apiserver.
+                      type: string
+                    expirationSeconds:
+                      description: ExpirationSeconds is the duration of validity of
+                        the token in "TokenRequestSpec". It has the same default value
+                        of "ExpirationSeconds" in "TokenRequestSpec".
+                      format: int64
+                      type: integer
+                  required:
+                  - audience
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              volumeLifecycleModes:
+                description: |-
+                  volumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism. The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume. For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future. This field is beta.
+
+                  This field is immutable.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/storage.k8s.io_csinodes.yaml
+++ b/config/kube/crds/cluster-scoped/storage.k8s.io_csinodes.yaml
@@ -1,0 +1,125 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: csinodes.storage.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: storage.k8s.io
+  names:
+    kind: CSINode
+    listKind: CSINodeList
+    plural: csinodes
+    singular: csinode
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CSINode holds information about all CSI drivers installed on
+          a node. CSI drivers do not need to create the CSINode object directly. As
+          long as they use the node-driver-registrar sidecar container, the kubelet
+          will automatically populate the CSINode object for the CSI driver as part
+          of kubelet plugin registration. CSINode has the same name as a node. If
+          the object is missing, it means either there are no CSI Drivers available
+          on the node, or the Kubelet version is low enough that it doesn't create
+          this object. CSINode has an OwnerReference that points to the corresponding
+          node object.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of CSINode
+            properties:
+              drivers:
+                description: drivers is a list of information of all CSI Drivers existing
+                  on a node. If all drivers in the list are uninstalled, this can
+                  become empty.
+                items:
+                  description: CSINodeDriver holds information about the specification
+                    of one CSI driver installed on a node
+                  properties:
+                    allocatable:
+                      description: allocatable represents the volume resources of
+                        a node that are available for scheduling. This field is beta.
+                      properties:
+                        count:
+                          description: Maximum number of unique volumes managed by
+                            the CSI driver that can be used on a node. A volume that
+                            is both attached and mounted on a node is considered to
+                            be used once, not twice. The same rule applies for a unique
+                            volume that is shared among multiple pods on the same
+                            node. If this field is not specified, then the supported
+                            number of volumes on this node is unbounded.
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: This is the name of the CSI driver that this object
+                        refers to. This MUST be the same name returned by the CSI
+                        GetPluginName() call for that driver.
+                      type: string
+                    nodeID:
+                      description: nodeID of the node from the driver point of view.
+                        This field enables Kubernetes to communicate with storage
+                        systems that do not share the same nomenclature for nodes.
+                        For example, Kubernetes may refer to a given node as "node1",
+                        but the storage system may refer to the same node as "nodeA".
+                        When Kubernetes issues a command to the storage system to
+                        attach a volume to a specific node, it can use this field
+                        to refer to the node name using the ID that the storage system
+                        will understand, e.g. "nodeA" instead of "node1". This field
+                        is required.
+                      type: string
+                    topologyKeys:
+                      description: topologyKeys is the list of keys supported by the
+                        driver. When a driver is initialized on a cluster, it provides
+                        a set of topology keys that it understands (e.g. "company.com/zone",
+                        "company.com/region"). When a driver is initialized on a node,
+                        it provides the same topology keys along with values. Kubelet
+                        will expose these topology keys as labels on its own node
+                        object. When Kubernetes does topology aware provisioning,
+                        it can use this list to determine which labels it should retrieve
+                        from the node object and pass back to the driver. It is possible
+                        for different nodes to use different topology keys. This can
+                        be empty if driver does not support topology.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - nodeID
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - drivers
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/storage.k8s.io_storageclasses.yaml
+++ b/config/kube/crds/cluster-scoped/storage.k8s.io_storageclasses.yaml
@@ -1,0 +1,120 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: storageclasses.storage.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: storage.k8s.io
+  names:
+    kind: StorageClass
+    listKind: StorageClassList
+    plural: storageclasses
+    shortNames:
+    - sc
+    singular: storageclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
+
+          StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
+        properties:
+          allowVolumeExpansion:
+            description: AllowVolumeExpansion shows whether the storage class allow
+              volume expand
+            type: boolean
+          allowedTopologies:
+            description: Restrict the node topologies where volumes can be dynamically
+              provisioned. Each volume plugin defines its own supported topology specifications.
+              An empty TopologySelectorTerm list means there is no topology restriction.
+              This field is only honored by servers that enable the VolumeScheduling
+              feature.
+            items:
+              description: A topology selector term represents the result of label
+                queries. A null or empty topology selector term matches no objects.
+                The requirements of them are ANDed. It provides a subset of functionality
+                as NodeSelectorTerm. This is an alpha feature and may change in the
+                future.
+              properties:
+                matchLabelExpressions:
+                  description: A list of topology selector requirements by labels.
+                  items:
+                    description: A topology selector requirement is a selector that
+                      matches given label. This is an alpha feature and may change
+                      in the future.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                      values:
+                        description: An array of string values. One value must match
+                          the label to be selected. Each entry in Values is ORed.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - values
+                    type: object
+                  type: array
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          mountOptions:
+            description: Dynamically provisioned PersistentVolumes of this storage
+              class are created with these mountOptions, e.g. ["ro", "soft"]. Not
+              validated - mount of the PVs will simply fail if one is invalid.
+            items:
+              type: string
+            type: array
+          parameters:
+            additionalProperties:
+              type: string
+            description: Parameters holds the parameters for the provisioner that
+              should create volumes of this storage class.
+            type: object
+          provisioner:
+            description: Provisioner indicates the type of the provisioner.
+            type: string
+          reclaimPolicy:
+            description: Dynamically provisioned PersistentVolumes of this storage
+              class are created with this reclaimPolicy. Defaults to Delete.
+            type: string
+          volumeBindingMode:
+            description: VolumeBindingMode indicates how PersistentVolumeClaims should
+              be provisioned and bound.  When unset, VolumeBindingImmediate is used.
+              This field is only honored by servers that enable the VolumeScheduling
+              feature.
+            type: string
+        required:
+        - provisioner
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/cluster-scoped/storage.k8s.io_volumeattachments.yaml
+++ b/config/kube/crds/cluster-scoped/storage.k8s.io_volumeattachments.yaml
@@ -1,0 +1,1194 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: volumeattachments.storage.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: storage.k8s.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    singular: volumeattachment
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+          VolumeAttachment objects are non-namespaced.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired attach/detach volume behavior.
+              Populated by the Kubernetes system.
+            properties:
+              attacher:
+                description: Attacher indicates the name of the volume driver that
+                  MUST handle this request. This is the name returned by GetPluginName().
+                type: string
+              nodeName:
+                description: The node that the volume should be attached to.
+                type: string
+              source:
+                description: Source represents the volume that should be attached.
+                properties:
+                  inlineVolumeSpec:
+                    description: inlineVolumeSpec contains all the information necessary
+                      to attach a persistent volume defined by a pod's inline VolumeSource.
+                      This field is populated only for the CSIMigration feature. It
+                      contains translated fields from a pod's inline VolumeSource
+                      to a PersistentVolumeSpec. This field is beta-level and is only
+                      honored by servers that enabled the CSIMigration feature.
+                    properties:
+                      accessModes:
+                        description: 'accessModes contains all ways the volume can
+                          be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
+                        items:
+                          type: string
+                        type: array
+                      awsElasticBlockStore:
+                        description: 'awsElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume
+                              that you want to mount. If omitted, the default is to
+                              mount by volume name. Examples: For volume /dev/sda1,
+                              you specify the partition as "1". Similarly, the volume
+                              partition for /dev/sda is "0" (or you can leave the
+                              property empty).'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly value true will force the readOnly
+                              setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'volumeID is unique ID of the persistent
+                              disk resource in AWS (Amazon EBS volume). More info:
+                              https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        description: azureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          cachingMode:
+                            description: 'cachingMode is the Host Caching mode: None,
+                              Read Only, Read Write.'
+                            type: string
+                          diskName:
+                            description: diskName is the Name of the data disk in
+                              the blob storage
+                            type: string
+                          diskURI:
+                            description: diskURI is the URI of data disk in the blob
+                              storage
+                            type: string
+                          fsType:
+                            description: fsType is Filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'kind expected values are Shared: multiple
+                              blob disks per storage account  Dedicated: single blob
+                              disk per storage account  Managed: azure managed data
+                              disk (only in managed availability set). defaults to
+                              shared'
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        description: azureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: secretName is the name of secret that contains
+                              Azure Storage Account Name and Key
+                            type: string
+                          secretNamespace:
+                            description: secretNamespace is the namespace of the secret
+                              that contains Azure Storage Account Name and Key default
+                              is the same as the Pod
+                            type: string
+                          shareName:
+                            description: shareName is the azure Share Name
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      capacity:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'capacity is the description of the persistent
+                          volume''s resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
+                        type: object
+                      cephfs:
+                        description: cephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          monitors:
+                            description: 'monitors is Required: Monitors is a collection
+                              of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: 'path is Optional: Used as the mounted root,
+                              rather than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'secretFile is Optional: SecretFile is the
+                              path to key ring for User, default is /etc/ceph/user.secret
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'secretRef is Optional: SecretRef is reference
+                              to the authentication secret for User, default is empty.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is Optional: User is the rados user
+                              name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        description: 'cinder represents a cinder volume attached and
+                          mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType Filesystem type to mount. Must be
+                              a filesystem type supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is Optional: points to a secret
+                              object containing parameters used to connect to OpenStack.'
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          volumeID:
+                            description: 'volumeID used to identify the volume in
+                              cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      claimRef:
+                        description: 'claimRef is part of a bi-directional binding
+                          between PersistentVolume and PersistentVolumeClaim. Expected
+                          to be non-nil when bound. claim.VolumeName is the authoritative
+                          bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      csi:
+                        description: csi represents storage that is handled by an
+                          external CSI driver (Beta feature).
+                        properties:
+                          controllerExpandSecretRef:
+                            description: controllerExpandSecretRef is a reference
+                              to the secret object containing sensitive information
+                              to pass to the CSI driver to complete the CSI ControllerExpandVolume
+                              call. This is an beta field and requires enabling ExpandCSIVolumes
+                              feature gate. This field is optional, and may be empty
+                              if no secret is required. If the secret object contains
+                              more than one secret, all secrets are passed.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          controllerPublishSecretRef:
+                            description: controllerPublishSecretRef is a reference
+                              to the secret object containing sensitive information
+                              to pass to the CSI driver to complete the CSI ControllerPublishVolume
+                              and ControllerUnpublishVolume calls. This field is optional,
+                              and may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secrets are
+                              passed.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          driver:
+                            description: driver is the name of the driver to use for
+                              this volume. Required.
+                            type: string
+                          fsType:
+                            description: fsType to mount. Must be a filesystem type
+                              supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs".
+                            type: string
+                          nodeExpandSecretRef:
+                            description: nodeExpandSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodeExpandVolume
+                              call. This is an alpha field and requires enabling CSINodeExpandSecret
+                              feature gate. This field is optional, may be omitted
+                              if no secret is required. If the secret object contains
+                              more than one secret, all secrets are passed.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          nodePublishSecretRef:
+                            description: nodePublishSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodePublishVolume
+                              and NodeUnpublishVolume calls. This field is optional,
+                              and may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secrets are
+                              passed.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          nodeStageSecretRef:
+                            description: nodeStageSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodeStageVolume
+                              and NodeStageVolume and NodeUnstageVolume calls. This
+                              field is optional, and may be empty if no secret is
+                              required. If the secret object contains more than one
+                              secret, all secrets are passed.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          readOnly:
+                            description: readOnly value to pass to ControllerPublishVolumeRequest.
+                              Defaults to false (read/write).
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            description: volumeAttributes of the volume to publish.
+                            type: object
+                          volumeHandle:
+                            description: volumeHandle is the unique volume name returned
+                              by the CSI volume plugin’s CreateVolume to refer to
+                              the volume on all subsequent calls. Required.
+                            type: string
+                        required:
+                        - driver
+                        - volumeHandle
+                        type: object
+                      fc:
+                        description: fc represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          lun:
+                            description: 'lun is Optional: FC target lun number'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'targetWWNs is Optional: FC target worldwide
+                              names (WWNs)'
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            description: 'wwids Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        description: flexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        properties:
+                          driver:
+                            description: driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: fsType is the Filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                              depends on FlexVolume script.
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            description: 'options is Optional: this field holds extra
+                              command options if any.'
+                            type: object
+                          readOnly:
+                            description: 'readOnly is Optional: defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is Optional: SecretRef is reference
+                              to the secret object containing sensitive information
+                              to pass to the plugin scripts. This may be empty if
+                              no secret object is specified. If the secret object
+                              contains more than one secret, all secrets are passed
+                              to the plugin scripts.'
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        description: flocker represents a Flocker volume attached
+                          to a kubelet's host machine and exposed to the pod for its
+                          usage. This depends on the Flocker control service being
+                          running
+                        properties:
+                          datasetName:
+                            description: datasetName is Name of the dataset stored
+                              as metadata -> name on the dataset for Flocker should
+                              be considered as deprecated
+                            type: string
+                          datasetUUID:
+                            description: datasetUUID is the UUID of the dataset. This
+                              is unique identifier of a Flocker dataset
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        description: 'gcePersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        properties:
+                          fsType:
+                            description: 'fsType is filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume
+                              that you want to mount. If omitted, the default is to
+                              mount by volume name. Examples: For volume /dev/sda1,
+                              you specify the partition as "1". Similarly, the volume
+                              partition for /dev/sda is "0" (or you can leave the
+                              property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            format: int32
+                            type: integer
+                          pdName:
+                            description: 'pdName is unique name of the PD resource
+                              in GCE. Used to identify the disk in GCE. More info:
+                              https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      glusterfs:
+                        description: 'glusterfs represents a Glusterfs volume that
+                          is attached to a host and exposed to the pod. Provisioned
+                          by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        properties:
+                          endpoints:
+                            description: 'endpoints is the endpoint name that details
+                              Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          endpointsNamespace:
+                            description: 'endpointsNamespace is the namespace that
+                              contains Glusterfs endpoint. If this field is empty,
+                              the EndpointNamespace defaults to the same namespace
+                              as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'path is the Glusterfs volume path. More
+                              info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        description: 'hostPath represents a directory on the host.
+                          Provisioned by a developer or tester. This is useful for
+                          single-node development and testing only! On-host storage
+                          is not supported in any way and WILL NOT WORK in a multi-node
+                          cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        properties:
+                          path:
+                            description: 'path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        description: iscsi represents an ISCSI Disk resource that
+                          is attached to a kubelet's host machine and then exposed
+                          to the pod. Provisioned by an admin.
+                        properties:
+                          chapAuthDiscovery:
+                            description: chapAuthDiscovery defines whether support
+                              iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: chapAuthSession defines whether support iSCSI
+                              Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                            type: string
+                          initiatorName:
+                            description: initiatorName is the custom iSCSI Initiator
+                              Name. If initiatorName is specified with iscsiInterface
+                              simultaneously, new iSCSI interface <target portal>:<volume
+                              name> will be created for the connection.
+                            type: string
+                          iqn:
+                            description: iqn is Target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iscsiInterface is the interface Name that
+                              uses an iSCSI transport. Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: lun is iSCSI Target Lun number.
+                            format: int32
+                            type: integer
+                          portals:
+                            description: portals is the iSCSI Target Portal List.
+                              The Portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            description: readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: secretRef is the CHAP Secret for iSCSI target
+                              and initiator authentication
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          targetPortal:
+                            description: targetPortal is iSCSI Target Portal. The
+                              Portal is either an IP or ip_addr:port if the port is
+                              other than default (typically TCP ports 860 and 3260).
+                            type: string
+                        required:
+                        - targetPortal
+                        - iqn
+                        - lun
+                        type: object
+                      local:
+                        description: local represents directly-attached storage with
+                          node affinity
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. It
+                              applies only when the Path is a block device. Must be
+                              a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". The default value is to auto-select
+                              a filesystem if unspecified.
+                            type: string
+                          path:
+                            description: path of the full path to the volume on the
+                              node. It can be either a directory or block device (disk,
+                              partition, ...).
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      mountOptions:
+                        description: 'mountOptions is the list of mount options, e.g.
+                          ["ro", "soft"]. Not validated - mount will simply fail if
+                          one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+                        items:
+                          type: string
+                        type: array
+                      nfs:
+                        description: 'nfs represents an NFS mount on the host. Provisioned
+                          by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        properties:
+                          path:
+                            description: 'path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                        required:
+                        - server
+                        - path
+                        type: object
+                      nodeAffinity:
+                        description: nodeAffinity defines constraints that limit what
+                          nodes this volume can be accessed from. This field influences
+                          the scheduling of pods that use this volume.
+                        properties:
+                          required:
+                            description: required specifies hard node constraints
+                              that must be met.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      persistentVolumeReclaimPolicy:
+                        description: |-
+                          persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+                          Possible enum values:
+                           - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+                           - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+                           - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+                        type: string
+                      photonPersistentDisk:
+                        description: photonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: pdID is the ID that identifies Photon Controller
+                              persistent disk
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        description: portworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: volumeID uniquely identifies a Portworx volume
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      quobyte:
+                        description: quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          group:
+                            description: group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: readOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          tenant:
+                            description: tenant owning the given Quobyte volume in
+                              the Backend Used with dynamically provisioned Quobyte
+                              volumes, value is set by the plugin
+                            type: string
+                          user:
+                            description: user to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        description: 'rbd represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                            type: string
+                          image:
+                            description: 'image is the rados image name. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'monitors is a collection of Ceph monitors.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            description: 'pool is the rados pool name. Default is
+                              rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is the rados user name. Default is
+                              admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - monitors
+                        - image
+                        type: object
+                      scaleIO:
+                        description: scaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+                            type: string
+                          gateway:
+                            description: gateway is the host address of the ScaleIO
+                              API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: protectionDomain is the name of the ScaleIO
+                              Protection Domain for the configured storage.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            properties:
+                              name:
+                                description: name is unique within a namespace to
+                                  reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which
+                                  the secret name must be unique.
+                                type: string
+                            type: object
+                          sslEnabled:
+                            description: sslEnabled is the flag to enable/disable
+                              SSL communication with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: storageMode indicates whether the storage
+                              for a volume should be ThickProvisioned or ThinProvisioned.
+                              Default is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: storagePool is the ScaleIO Storage Pool associated
+                              with the protection domain.
+                            type: string
+                          system:
+                            description: system is the name of the storage system
+                              as configured in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: volumeName is the name of a volume already
+                              created in the ScaleIO system that is associated with
+                              this volume source.
+                            type: string
+                        required:
+                        - gateway
+                        - system
+                        - secretRef
+                        type: object
+                      storageClassName:
+                        description: storageClassName is the name of StorageClass
+                          to which this persistent volume belongs. Empty value means
+                          that this volume does not belong to any StorageClass.
+                        type: string
+                      storageos:
+                        description: 'storageOS represents a StorageOS volume that
+                          is attached to the kubelet''s host machine and mounted into
+                          the pod More info: https://examples.k8s.io/volumes/storageos/README.md'
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object
+                                  instead of an entire object, this string should
+                                  contain a valid JSON/Go field access statement,
+                                  such as desiredState.manifest.containers[2]. For
+                                  example, if the object reference is to a container
+                                  within a pod, this would take on a value like: "spec.containers{name}"
+                                  (where "name" refers to the name of the container
+                                  that triggered the event) or if no container name
+                                  is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only
+                                  to have some well-defined way of referencing a part
+                                  of an object.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info:
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this
+                                  reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          volumeName:
+                            description: volumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: volumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                        type: object
+                      volumeMode:
+                        description: volumeMode defines if a volume is intended to
+                          be used with a formatted filesystem or to remain in raw
+                          block state. Value of Filesystem is implied when not included
+                          in spec.
+                        type: string
+                      vsphereVolume:
+                        description: vsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: storagePolicyID is the storage Policy Based
+                              Management (SPBM) profile ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: storagePolicyName is the storage Policy Based
+                              Management (SPBM) profile name.
+                            type: string
+                          volumePath:
+                            description: volumePath is the path that identifies vSphere
+                              volume vmdk
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    type: object
+                  persistentVolumeName:
+                    description: Name of the persistent volume to attach.
+                    type: string
+                type: object
+            required:
+            - attacher
+            - source
+            - nodeName
+            type: object
+          status:
+            description: Status of the VolumeAttachment request. Populated by the
+              entity completing the attach or detach operation, i.e. the external-attacher.
+            properties:
+              attachError:
+                description: The last error encountered during attach operation, if
+                  any. This field must only be set by the entity completing the attach
+                  operation, i.e. the external-attacher.
+                properties:
+                  message:
+                    description: String detailing the error encountered during Attach
+                      or Detach operation. This string may be logged, so it should
+                      not contain sensitive information.
+                    type: string
+                  time:
+                    description: Time the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              attached:
+                description: Indicates the volume is successfully attached. This field
+                  must only be set by the entity completing the attach operation,
+                  i.e. the external-attacher.
+                type: boolean
+              attachmentMetadata:
+                additionalProperties:
+                  type: string
+                description: Upon successful attach, this field is populated with
+                  any information returned by the attach operation that must be passed
+                  into subsequent WaitForAttach or Mount calls. This field must only
+                  be set by the entity completing the attach operation, i.e. the external-attacher.
+                type: object
+              detachError:
+                description: The last error encountered during detach operation, if
+                  any. This field must only be set by the entity completing the detach
+                  operation, i.e. the external-attacher.
+                properties:
+                  message:
+                    description: String detailing the error encountered during Attach
+                      or Detach operation. This string may be logged, so it should
+                      not contain sensitive information.
+                    type: string
+                  time:
+                    description: Time the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - attached
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/apps_daemonsets.yaml
+++ b/config/kube/crds/namespaced/apps_daemonsets.yaml
@@ -1,0 +1,7390 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: daemonsets.apps
+spec:
+  conversion:
+    strategy: None
+  group: apps
+  names:
+    categories:
+    - all
+    kind: DaemonSet
+    listKind: DaemonSetList
+    plural: daemonsets
+    shortNames:
+    - ds
+    singular: daemonset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DaemonSet represents the configuration of a daemon set.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              minReadySeconds:
+                description: The minimum number of seconds for which a newly created
+                  DaemonSet pod should be ready without any of its container crashing,
+                  for it to be considered available. Defaults to 0 (pod will be considered
+                  available as soon as it is ready).
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old history to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 10.
+                format: int32
+                type: integer
+              selector:
+                description: 'A label query over pods that are managed by the daemon
+                  set. Must match in order to be controlled. It must match the pod
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: 'An object that describes the pod that will be created.
+                  The DaemonSet will create exactly one copy of this pod on every
+                  node that matches the template''s node selector (or on every node
+                  if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - preference
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                          Possible enum values:
+                           - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                           - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Optional: SecurityContext defines the
+                                security options the ephemeral container should be
+                                run with. If set, the fields of SecurityContext override
+                                the equivalent fields of PodSecurityContext.'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Subpath mounts are not allowed for ephemeral
+                                containers. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostUsers:
+                        description: 'Use the host''s user namespace. Optional: Default
+                          to true. If set to true or not present, the pod will be
+                          run in the host user namespace, useful for when the pod
+                          needs a feature only available to the host user namespace,
+                          such as loading a kernel module with CAP_SYS_MODULE. When
+                          set to false, a new userns is created for the pod. Setting
+                          false is useful for mitigating container breakout vulnerabilities
+                          even allowing users to run their containers as root without
+                          actually having root privileges on the host. This field
+                          is alpha-level and is only honored by servers that enable
+                          the UserNamespacesSupport feature.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                          Possible enum values:
+                           - `"Always"`
+                           - `"Never"`
+                           - `"OnFailure"`
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      setHostnameAsFQDN:
+                        description: If true the pod's hostname will be configured
+                          as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                Possible enum values:
+                                 - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                 - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                 - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                Possible enum values:
+                                 - `"Equal"`
+                                 - `"Exists"`
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                Possible enum values:
+                                 - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                 - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - targetPortal
+                              - iqn
+                              - lun
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - server
+                              - path
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              - image
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - system
+                              - secretRef
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+              updateStrategy:
+                description: An update strategy to replace existing DaemonSet pods
+                  with new pods.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if type
+                      = "RollingUpdate".
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of nodes with an existing
+                          available DaemonSet pod that can have an updated DaemonSet
+                          pod during during an update. Value can be an absolute number
+                          (ex: 5) or a percentage of desired pods (ex: 10%). This
+                          can not be 0 if MaxUnavailable is 0. Absolute number is
+                          calculated from percentage by rounding up to a minimum of
+                          1. Default value is 0. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked
+                          as deleted. The update starts by launching new pods on 30%
+                          of nodes. Once an updated pod is available (Ready for at
+                          least minReadySeconds) the old DaemonSet pod on that node
+                          is marked deleted. If the old pod becomes unavailable for
+                          any reason (Ready transitions to false, is evicted, or is
+                          drained) an updated pod is immediatedly created on that
+                          node without considering surge limits. Allowing surge implies
+                          the possibility that the resources consumed by the daemonset
+                          on any given node can double if the readiness check fails,
+                          and so resource intensive daemonsets should take into account
+                          that they may cause evictions during disruption.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of DaemonSet pods that can
+                          be unavailable during the update. Value can be an absolute
+                          number (ex: 5) or a percentage of total number of DaemonSet
+                          pods at the start of the update (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This cannot
+                          be 0 if MaxSurge is 0 Default value is 1. Example: when
+                          this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+
+                      Possible enum values:
+                       - `"OnDelete"` Replace the old daemons only when it's killed
+                       - `"RollingUpdate"` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+                    type: string
+                type: object
+            required:
+            - selector
+            - template
+            type: object
+          status:
+            description: 'The current status of this daemon set. This data may be
+              out of date by some window of time. Populated by the system. Read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              collisionCount:
+                description: Count of hash collisions for the DaemonSet. The DaemonSet
+                  controller uses this field as a collision avoidance mechanism when
+                  it needs to create the name for the newest ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a DaemonSet's
+                  current state.
+                items:
+                  description: DaemonSetCondition describes the state of a DaemonSet
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of DaemonSet condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentNumberScheduled:
+                description: 'The number of nodes that are running at least 1 daemon
+                  pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              desiredNumberScheduled:
+                description: 'The total number of nodes that should be running the
+                  daemon pod (including nodes correctly running the daemon pod). More
+                  info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              numberAvailable:
+                description: The number of nodes that should be running the daemon
+                  pod and have one or more of the daemon pod running and available
+                  (ready for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              numberMisscheduled:
+                description: 'The number of nodes that are running the daemon pod,
+                  but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                format: int32
+                type: integer
+              numberReady:
+                description: numberReady is the number of nodes that should be running
+                  the daemon pod and have one or more of the daemon pod running with
+                  a Ready Condition.
+                format: int32
+                type: integer
+              numberUnavailable:
+                description: The number of nodes that should be running the daemon
+                  pod and have none of the daemon pod running and available (ready
+                  for at least spec.minReadySeconds)
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The most recent generation observed by the daemon set
+                  controller.
+                format: int64
+                type: integer
+              updatedNumberScheduled:
+                description: The total number of nodes that are running updated daemon
+                  pod
+                format: int32
+                type: integer
+            required:
+            - currentNumberScheduled
+            - numberMisscheduled
+            - desiredNumberScheduled
+            - numberReady
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/apps_replicasets.yaml
+++ b/config/kube/crds/namespaced/apps_replicasets.yaml
@@ -1,0 +1,7301 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: replicasets.apps
+spec:
+  conversion:
+    strategy: None
+  group: apps
+  names:
+    categories:
+    - all
+    kind: ReplicaSet
+    listKind: ReplicaSetList
+    plural: replicasets
+    shortNames:
+    - rs
+    singular: replicaset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ReplicaSet ensures that a specified number of pod replicas are
+          running at any given time.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Spec defines the specification of the desired behavior of
+              the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created pod
+                  should be ready without any of its container crashing, for it to
+                  be considered available. Defaults to 0 (pod will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: 'Replicas is the number of desired replicas. This is
+                  a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller'
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over pods that should match
+                  the replica count. Label keys and values that must match in order
+                  to be controlled by this replica set. It must match the pod template''s
+                  labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: 'Template is the object that describes the pod that will
+                  be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - preference
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                          Possible enum values:
+                           - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                           - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Optional: SecurityContext defines the
+                                security options the ephemeral container should be
+                                run with. If set, the fields of SecurityContext override
+                                the equivalent fields of PodSecurityContext.'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Subpath mounts are not allowed for ephemeral
+                                containers. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostUsers:
+                        description: 'Use the host''s user namespace. Optional: Default
+                          to true. If set to true or not present, the pod will be
+                          run in the host user namespace, useful for when the pod
+                          needs a feature only available to the host user namespace,
+                          such as loading a kernel module with CAP_SYS_MODULE. When
+                          set to false, a new userns is created for the pod. Setting
+                          false is useful for mitigating container breakout vulnerabilities
+                          even allowing users to run their containers as root without
+                          actually having root privileges on the host. This field
+                          is alpha-level and is only honored by servers that enable
+                          the UserNamespacesSupport feature.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                          Possible enum values:
+                           - `"Always"`
+                           - `"Never"`
+                           - `"OnFailure"`
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      setHostnameAsFQDN:
+                        description: If true the pod's hostname will be configured
+                          as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                Possible enum values:
+                                 - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                 - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                 - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                Possible enum values:
+                                 - `"Equal"`
+                                 - `"Exists"`
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                Possible enum values:
+                                 - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                 - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - targetPortal
+                              - iqn
+                              - lun
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - server
+                              - path
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              - image
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - system
+                              - secretRef
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            description: 'Status is the most recently observed status of the ReplicaSet.
+              This data may be out of date by some window of time. Populated by the
+              system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this replica set.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a replica
+                  set's current state.
+                items:
+                  description: ReplicaSetCondition describes the state of a replica
+                    set at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of replica set condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              fullyLabeledReplicas:
+                description: The number of pods that have labels matching the labels
+                  of the pod template of the replicaset.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed ReplicaSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of pods targeted by this
+                  ReplicaSet with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: 'Replicas is the most recently oberved number of replicas.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller'
+                format: int32
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/apps_statefulsets.yaml
+++ b/config/kube/crds/namespaced/apps_statefulsets.yaml
@@ -1,0 +1,7701 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: statefulsets.apps
+spec:
+  conversion:
+    strategy: None
+  group: apps
+  names:
+    categories:
+    - all
+    kind: StatefulSet
+    listKind: StatefulSetList
+    plural: statefulsets
+    shortNames:
+    - sts
+    singular: statefulset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+            - Network: A single stable DNS and hostname.
+            - Storage: As many VolumeClaims as requested.
+
+          The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired identities of pods in this set.
+            properties:
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created pod
+                  should be ready without any of its container crashing for it to
+                  be considered available. Defaults to 0 (pod will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              persistentVolumeClaimRetentionPolicy:
+                description: persistentVolumeClaimRetentionPolicy describes the lifecycle
+                  of persistent volume claims created from volumeClaimTemplates. By
+                  default, all persistent volume claims are created as needed and
+                  retained until manually deleted. This policy allows the lifecycle
+                  to be altered, for example by deleting persistent volume claims
+                  when their stateful set is deleted, or when their pod is scaled
+                  down. This requires the StatefulSetAutoDeletePVC feature gate to
+                  be enabled, which is alpha.  +optional
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
+              podManagementPolicy:
+                description: |-
+                  podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+
+                  Possible enum values:
+                   - `"OrderedReady"` will create pods in strictly increasing order on scale up and strictly decreasing order on scale down, progressing only when the previous pod is ready or terminated. At most one pod will be changed at any time.
+                   - `"Parallel"` will create and delete pods as soon as the stateful set replica count is changed, and will not wait for pods to be ready or complete termination.
+                type: string
+              replicas:
+                description: replicas is the desired number of replicas of the given
+                  Template. These are replicas in the sense that they are instantiations
+                  of the same Template, but individual replicas also have a consistent
+                  identity. If unspecified, defaults to 1.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: revisionHistoryLimit is the maximum number of revisions
+                  that will be maintained in the StatefulSet's revision history. The
+                  revision history consists of all revisions not represented by a
+                  currently applied StatefulSetSpec version. The default value is
+                  10.
+                format: int32
+                type: integer
+              selector:
+                description: 'selector is a label query over pods that should match
+                  the replica count. It must match the pod template''s labels. More
+                  info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              serviceName:
+                description: 'serviceName is the name of the service that governs
+                  this StatefulSet. This service must exist before the StatefulSet,
+                  and is responsible for the network identity of the set. Pods get
+                  DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                  where "pod-specific-string" is managed by the StatefulSet controller.'
+                type: string
+              template:
+                description: template is the object that describes the pod that will
+                  be created if insufficient replicas are detected. Each pod stamped
+                  out by the StatefulSet will fulfill this Template, but have a unique
+                  identity from the rest of the StatefulSet.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - preference
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                          Possible enum values:
+                           - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                           - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Optional: SecurityContext defines the
+                                security options the ephemeral container should be
+                                run with. If set, the fields of SecurityContext override
+                                the equivalent fields of PodSecurityContext.'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Subpath mounts are not allowed for ephemeral
+                                containers. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostUsers:
+                        description: 'Use the host''s user namespace. Optional: Default
+                          to true. If set to true or not present, the pod will be
+                          run in the host user namespace, useful for when the pod
+                          needs a feature only available to the host user namespace,
+                          such as loading a kernel module with CAP_SYS_MODULE. When
+                          set to false, a new userns is created for the pod. Setting
+                          false is useful for mitigating container breakout vulnerabilities
+                          even allowing users to run their containers as root without
+                          actually having root privileges on the host. This field
+                          is alpha-level and is only honored by servers that enable
+                          the UserNamespacesSupport feature.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                          Possible enum values:
+                           - `"Always"`
+                           - `"Never"`
+                           - `"OnFailure"`
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      setHostnameAsFQDN:
+                        description: If true the pod's hostname will be configured
+                          as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                Possible enum values:
+                                 - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                 - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                 - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                Possible enum values:
+                                 - `"Equal"`
+                                 - `"Exists"`
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                Possible enum values:
+                                 - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                 - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - targetPortal
+                              - iqn
+                              - lun
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - server
+                              - path
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              - image
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - system
+                              - secretRef
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+              updateStrategy:
+                description: updateStrategy indicates the StatefulSetUpdateStrategy
+                  that will be employed to update Pods in the StatefulSet when a revision
+                  is made to Template.
+                properties:
+                  rollingUpdate:
+                    description: RollingUpdate is used to communicate parameters when
+                      Type is RollingUpdateStatefulSetStrategyType.
+                    properties:
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This can not
+                          be 0. Defaults to 1. This field is alpha-level and is only
+                          honored by servers that enable the MaxUnavailableStatefulSet
+                          feature. The field applies to all pods in the range 0 to
+                          Replicas-1. That means if there is any unavailable pod in
+                          the range 0 to Replicas-1, it will be counted towards MaxUnavailable.'
+                        x-kubernetes-int-or-string: true
+                      partition:
+                        description: Partition indicates the ordinal at which the
+                          StatefulSet should be partitioned for updates. During a
+                          rolling update, all pods from ordinal Replicas-1 to Partition
+                          are updated. All pods from ordinal Partition-1 to 0 remain
+                          untouched. This is helpful in being able to do a canary
+                          based deployment. The default value is 0.
+                        format: int32
+                        type: integer
+                    type: object
+                  type:
+                    description: |-
+                      Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+
+                      Possible enum values:
+                       - `"OnDelete"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.
+                       - `"RollingUpdate"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.
+                    type: string
+                type: object
+              volumeClaimTemplates:
+                description: volumeClaimTemplates is a list of claims that pods are
+                  allowed to reference. The StatefulSet controller is responsible
+                  for mapping network identities to claims in a way that maintains
+                  the identity of a pod. Every claim in this list must have at least
+                  one matching (by name) volumeMount in one container in the template.
+                  A claim in this list takes precedence over any volumes in the template,
+                  with the same name.
+                items:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      description: 'spec defines the desired characteristics of a
+                        volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        accessModes:
+                          description: 'accessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          description: 'dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim) If the provisioner
+                            or an external controller can support the specified data
+                            source, it will create a new volume based on the contents
+                            of the specified data source. If the AnyVolumeDataSource
+                            feature gate is enabled, this field will always have the
+                            same contents as the DataSourceRef field.'
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        dataSourceRef:
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                              preserves all values, and generates an error if a disallowed value is
+                              specified.
+                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          description: 'resources represents the minimum resources
+                            the volume should have. If RecoverVolumeExpansionFailure
+                            feature is enabled users are allowed to specify resource
+                            requirements that are lower than previous value but must
+                            still be higher than capacity recorded in the status field
+                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        selector:
+                          description: selector is a label query over volumes to consider
+                            for binding.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        storageClassName:
+                          description: 'storageClassName is the name of the StorageClass
+                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec.
+                          type: string
+                        volumeName:
+                          description: volumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    status:
+                      description: 'status represents the current information/status
+                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        accessModes:
+                          description: 'accessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        allocatedResources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: allocatedResources is the storage resource
+                            within AllocatedResources tracks the capacity allocated
+                            to a PVC. It may be larger than the actual capacity when
+                            a volume expansion operation is requested. For storage
+                            quota, the larger value from allocatedResources and PVC.spec.resources
+                            is used. If allocatedResources is not set, PVC.spec.resources
+                            alone is used for quota calculation. If a volume expansion
+                            capacity request is lowered, allocatedResources is only
+                            lowered if there are no expansion operations in progress
+                            and if the actual volume capacity is equal or lower than
+                            the requested capacity. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
+                          type: object
+                        capacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: capacity represents the actual resources of
+                            the underlying volume.
+                          type: object
+                        conditions:
+                          description: conditions is the current Condition of persistent
+                            volume claim. If underlying persistent volume is being
+                            resized then the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contails details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: lastProbeTime is the time we probed the
+                                  condition.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: lastTransitionTime is the time the condition
+                                  transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: message is the human-readable message
+                                  indicating details about last transition.
+                                type: string
+                              reason:
+                                description: reason is a unique, this should be a
+                                  short, machine understandable string that gives
+                                  the reason for condition's last transition. If it
+                                  reports "ResizeStarted" that means the underlying
+                                  persistent volume is being resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - type
+                          x-kubernetes-list-type: map
+                        phase:
+                          description: |-
+                            phase represents the current phase of PersistentVolumeClaim.
+
+                            Possible enum values:
+                             - `"Bound"` used for PersistentVolumeClaims that are bound
+                             - `"Lost"` used for PersistentVolumeClaims that lost their underlying PersistentVolume. The claim was bound to a PersistentVolume and this volume does not exist any longer and all data on it was lost.
+                             - `"Pending"` used for PersistentVolumeClaims that are not yet bound
+                          type: string
+                        resizeStatus:
+                          description: resizeStatus stores status of resize operation.
+                            ResizeStatus is not set by default but when expansion
+                            is complete resizeStatus is set to empty string by resize
+                            controller or kubelet. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            required:
+            - selector
+            - template
+            - serviceName
+            type: object
+          status:
+            description: Status is the current status of Pods in this StatefulSet.
+              This data may be out of date by some window of time.
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this statefulset.
+                format: int32
+                type: integer
+              collisionCount:
+                description: collisionCount is the count of hash collisions for the
+                  StatefulSet. The StatefulSet controller uses this field as a collision
+                  avoidance mechanism when it needs to create the name for the newest
+                  ControllerRevision.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a statefulset's
+                  current state.
+                items:
+                  description: StatefulSetCondition describes the state of a statefulset
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of statefulset condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentReplicas:
+                description: currentReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  currentRevision.
+                format: int32
+                type: integer
+              currentRevision:
+                description: currentRevision, if not empty, indicates the version
+                  of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  for this StatefulSet. It corresponds to the StatefulSet's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of pods created for this
+                  StatefulSet with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the number of Pods created by the StatefulSet
+                  controller.
+                format: int32
+                type: integer
+              updateRevision:
+                description: updateRevision, if not empty, indicates the version of
+                  the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+                type: string
+              updatedReplicas:
+                description: updatedReplicas is the number of Pods created by the
+                  StatefulSet controller from the StatefulSet version indicated by
+                  updateRevision.
+                format: int32
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/autoscaling_horizontalpodautoscalers.yaml
+++ b/config/kube/crds/namespaced/autoscaling_horizontalpodautoscalers.yaml
@@ -1,0 +1,1172 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: horizontalpodautoscalers.autoscaling
+spec:
+  conversion:
+    strategy: None
+  group: autoscaling
+  names:
+    categories:
+    - all
+    kind: HorizontalPodAutoscaler
+    listKind: HorizontalPodAutoscalerList
+    plural: horizontalpodautoscalers
+    shortNames:
+    - hpa
+    singular: horizontalpodautoscaler
+  scope: Namespaced
+  versions:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: HorizontalPodAutoscaler is the configuration for a horizontal
+          pod autoscaler, which automatically manages the replica count of any resource
+          implementing the scale subresource based on the metrics specified.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'spec is the specification for the behaviour of the autoscaler.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+            properties:
+              behavior:
+                description: behavior configures the scaling behavior of the target
+                  in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                  If not set, the default HPAScalingRules for scale up and scale down
+                  are used.
+                properties:
+                  scaleDown:
+                    description: scaleDown is scaling policy for scaling Down. If
+                      not set, the default value is to allow to scale down to minReplicas
+                      pods, with a 300 second stabilization window (i.e., the highest
+                      recommendation for the last 300sec is used).
+                    properties:
+                      policies:
+                        description: policies is a list of potential scaling polices
+                          which can be used during scaling. At least one policy must
+                          be specified, otherwise the HPAScalingRules will be discarded
+                          as invalid
+                        items:
+                          description: HPAScalingPolicy is a single policy which must
+                            hold true for a specified past interval.
+                          properties:
+                            periodSeconds:
+                              description: PeriodSeconds specifies the window of time
+                                for which the policy should hold true. PeriodSeconds
+                                must be greater than zero and less than or equal to
+                                1800 (30 min).
+                              format: int32
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              type: string
+                            value:
+                              description: Value contains the amount of change which
+                                is permitted by the policy. It must be greater than
+                                zero
+                              format: int32
+                              type: integer
+                          required:
+                          - type
+                          - value
+                          - periodSeconds
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      selectPolicy:
+                        description: selectPolicy is used to specify which policy
+                          should be used. If not set, the default value Max is used.
+                        type: string
+                      stabilizationWindowSeconds:
+                        description: 'StabilizationWindowSeconds is the number of
+                          seconds for which past recommendations should be considered
+                          while scaling up or scaling down. StabilizationWindowSeconds
+                          must be greater than or equal to zero and less than or equal
+                          to 3600 (one hour). If not set, use the default values:
+                          - For scale up: 0 (i.e. no stabilization is done). - For
+                          scale down: 300 (i.e. the stabilization window is 300 seconds
+                          long).'
+                        format: int32
+                        type: integer
+                    type: object
+                  scaleUp:
+                    description: |-
+                      scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+                        * increase no more than 4 pods per 60 seconds
+                        * double the number of pods per 60 seconds
+                      No stabilization is used.
+                    properties:
+                      policies:
+                        description: policies is a list of potential scaling polices
+                          which can be used during scaling. At least one policy must
+                          be specified, otherwise the HPAScalingRules will be discarded
+                          as invalid
+                        items:
+                          description: HPAScalingPolicy is a single policy which must
+                            hold true for a specified past interval.
+                          properties:
+                            periodSeconds:
+                              description: PeriodSeconds specifies the window of time
+                                for which the policy should hold true. PeriodSeconds
+                                must be greater than zero and less than or equal to
+                                1800 (30 min).
+                              format: int32
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              type: string
+                            value:
+                              description: Value contains the amount of change which
+                                is permitted by the policy. It must be greater than
+                                zero
+                              format: int32
+                              type: integer
+                          required:
+                          - type
+                          - value
+                          - periodSeconds
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      selectPolicy:
+                        description: selectPolicy is used to specify which policy
+                          should be used. If not set, the default value Max is used.
+                        type: string
+                      stabilizationWindowSeconds:
+                        description: 'StabilizationWindowSeconds is the number of
+                          seconds for which past recommendations should be considered
+                          while scaling up or scaling down. StabilizationWindowSeconds
+                          must be greater than or equal to zero and less than or equal
+                          to 3600 (one hour). If not set, use the default values:
+                          - For scale up: 0 (i.e. no stabilization is done). - For
+                          scale down: 300 (i.e. the stabilization window is 300 seconds
+                          long).'
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              maxReplicas:
+                description: maxReplicas is the upper limit for the number of replicas
+                  to which the autoscaler can scale up. It cannot be less that minReplicas.
+                format: int32
+                type: integer
+              metrics:
+                description: metrics contains the specifications for which to use
+                  to calculate the desired replica count (the maximum replica count
+                  across all metrics will be used).  The desired replica count is
+                  calculated multiplying the ratio between the target value and the
+                  current value by the current number of pods.  Ergo, metrics used
+                  must decrease as the pod count is increased, and vice-versa.  See
+                  the individual metric source types for more information about how
+                  each type of metric must respond. If not set, the default metric
+                  will be set to 80% average CPU utilization.
+                items:
+                  description: MetricSpec specifies how to scale based on a single
+                    metric (only `type` and one other matching field should be set
+                    at once).
+                  properties:
+                    containerResource:
+                      description: containerResource refers to a resource metric (such
+                        as those specified in requests and limits) known to Kubernetes
+                        describing a single container in each pod of the current scale
+                        target (e.g. CPU or memory). Such metrics are built in to
+                        Kubernetes, and have special scaling options on top of those
+                        available to normal per-pod metrics using the "pods" source.
+                        This is an alpha feature and can be enabled by the HPAContainerMetrics
+                        feature flag.
+                      properties:
+                        container:
+                          description: container is the name of the container in the
+                            pods of the scaling target
+                          type: string
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                        target:
+                          description: target specifies the target value for the given
+                            metric
+                          properties:
+                            averageUtilization:
+                              description: averageUtilization is the target value
+                                of the average of the resource metric across all relevant
+                                pods, represented as a percentage of the requested
+                                value of the resource for the pods. Currently only
+                                valid for Resource metric source type
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the target value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: type represents whether the metric type
+                                is Utilization, Value, or AverageValue
+                              type: string
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the target value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - name
+                      - target
+                      - container
+                      type: object
+                    external:
+                      description: external refers to a global metric that is not
+                        associated with any Kubernetes object. It allows autoscaling
+                        based on information coming from components running outside
+                        of cluster (for example length of queue in cloud messaging
+                        service, or QPS from loadbalancer running outside of cluster).
+                      properties:
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        target:
+                          description: target specifies the target value for the given
+                            metric
+                          properties:
+                            averageUtilization:
+                              description: averageUtilization is the target value
+                                of the average of the resource metric across all relevant
+                                pods, represented as a percentage of the requested
+                                value of the resource for the pods. Currently only
+                                valid for Resource metric source type
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the target value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: type represents whether the metric type
+                                is Utilization, Value, or AverageValue
+                              type: string
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the target value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - metric
+                      - target
+                      type: object
+                    object:
+                      description: object refers to a metric describing a single kubernetes
+                        object (for example, hits-per-second on an Ingress object).
+                      properties:
+                        describedObject:
+                          description: describedObject specifies the descriptions
+                            of a object,such as kind,name apiVersion
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        target:
+                          description: target specifies the target value for the given
+                            metric
+                          properties:
+                            averageUtilization:
+                              description: averageUtilization is the target value
+                                of the average of the resource metric across all relevant
+                                pods, represented as a percentage of the requested
+                                value of the resource for the pods. Currently only
+                                valid for Resource metric source type
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the target value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: type represents whether the metric type
+                                is Utilization, Value, or AverageValue
+                              type: string
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the target value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - describedObject
+                      - target
+                      - metric
+                      type: object
+                    pods:
+                      description: pods refers to a metric describing each pod in
+                        the current scale target (for example, transactions-processed-per-second).  The
+                        values will be averaged together before being compared to
+                        the target value.
+                      properties:
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        target:
+                          description: target specifies the target value for the given
+                            metric
+                          properties:
+                            averageUtilization:
+                              description: averageUtilization is the target value
+                                of the average of the resource metric across all relevant
+                                pods, represented as a percentage of the requested
+                                value of the resource for the pods. Currently only
+                                valid for Resource metric source type
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the target value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: type represents whether the metric type
+                                is Utilization, Value, or AverageValue
+                              type: string
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the target value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - metric
+                      - target
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory).
+                        Such metrics are built in to Kubernetes, and have special
+                        scaling options on top of those available to normal per-pod
+                        metrics using the "pods" source.
+                      properties:
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                        target:
+                          description: target specifies the target value for the given
+                            metric
+                          properties:
+                            averageUtilization:
+                              description: averageUtilization is the target value
+                                of the average of the resource metric across all relevant
+                                pods, represented as a percentage of the requested
+                                value of the resource for the pods. Currently only
+                                valid for Resource metric source type
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the target value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: type represents whether the metric type
+                                is Utilization, Value, or AverageValue
+                              type: string
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the target value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - name
+                      - target
+                      type: object
+                    type:
+                      description: 'type is the type of metric source.  It should
+                        be one of "ContainerResource", "External", "Object", "Pods"
+                        or "Resource", each mapping to a matching field in the object.
+                        Note: "ContainerResource" type is available on when the feature-gate
+                        HPAContainerMetrics is enabled'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              minReplicas:
+                description: minReplicas is the lower limit for the number of replicas
+                  to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas
+                  is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled
+                  and at least one Object or External metric is configured.  Scaling
+                  is active as long as at least one metric value is available.
+                format: int32
+                type: integer
+              scaleTargetRef:
+                description: scaleTargetRef points to the target resource to scale,
+                  and is used to the pods for which metrics should be collected, as
+                  well as to actually change the replica count.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - scaleTargetRef
+            - maxReplicas
+            type: object
+          status:
+            description: status is the current information about the autoscaler.
+            properties:
+              conditions:
+                description: conditions is the set of conditions required for this
+                  autoscaler to scale its target, and indicates whether or not those
+                  conditions are met.
+                items:
+                  description: HorizontalPodAutoscalerCondition describes the state
+                    of a HorizontalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentMetrics:
+                description: currentMetrics is the last read state of the metrics
+                  used by this autoscaler.
+                items:
+                  description: MetricStatus describes the last-read state of a single
+                    metric.
+                  properties:
+                    containerResource:
+                      description: container resource refers to a resource metric
+                        (such as those specified in requests and limits) known to
+                        Kubernetes describing a single container in each pod in the
+                        current scale target (e.g. CPU or memory). Such metrics are
+                        built in to Kubernetes, and have special scaling options on
+                        top of those available to normal per-pod metrics using the
+                        "pods" source.
+                      properties:
+                        container:
+                          description: Container is the name of the container in the
+                            pods of the scaling target
+                          type: string
+                        current:
+                          description: current contains the current value for the
+                            given metric
+                          properties:
+                            averageUtilization:
+                              description: currentAverageUtilization is the current
+                                value of the average of the resource metric across
+                                all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the current value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the current value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        name:
+                          description: Name is the name of the resource in question.
+                          type: string
+                      required:
+                      - name
+                      - current
+                      - container
+                      type: object
+                    external:
+                      description: external refers to a global metric that is not
+                        associated with any Kubernetes object. It allows autoscaling
+                        based on information coming from components running outside
+                        of cluster (for example length of queue in cloud messaging
+                        service, or QPS from loadbalancer running outside of cluster).
+                      properties:
+                        current:
+                          description: current contains the current value for the
+                            given metric
+                          properties:
+                            averageUtilization:
+                              description: currentAverageUtilization is the current
+                                value of the average of the resource metric across
+                                all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the current value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the current value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - metric
+                      - current
+                      type: object
+                    object:
+                      description: object refers to a metric describing a single kubernetes
+                        object (for example, hits-per-second on an Ingress object).
+                      properties:
+                        current:
+                          description: current contains the current value for the
+                            given metric
+                          properties:
+                            averageUtilization:
+                              description: currentAverageUtilization is the current
+                                value of the average of the resource metric across
+                                all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the current value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the current value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        describedObject:
+                          description: DescribedObject specifies the descriptions
+                            of a object,such as kind,name apiVersion
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - metric
+                      - current
+                      - describedObject
+                      type: object
+                    pods:
+                      description: pods refers to a metric describing each pod in
+                        the current scale target (for example, transactions-processed-per-second).  The
+                        values will be averaged together before being compared to
+                        the target value.
+                      properties:
+                        current:
+                          description: current contains the current value for the
+                            given metric
+                          properties:
+                            averageUtilization:
+                              description: currentAverageUtilization is the current
+                                value of the average of the resource metric across
+                                all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the current value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the current value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        metric:
+                          description: metric identifies the target metric by name
+                            and selector
+                          properties:
+                            name:
+                              description: name is the name of the given metric
+                              type: string
+                            selector:
+                              description: selector is the string-encoded form of
+                                a standard kubernetes label selector for the given
+                                metric When set, it is passed as an additional parameter
+                                to the metrics server for more specific metrics scoping.
+                                When unset, just the metricName will be used to gather
+                                metrics.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - metric
+                      - current
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory).
+                        Such metrics are built in to Kubernetes, and have special
+                        scaling options on top of those available to normal per-pod
+                        metrics using the "pods" source.
+                      properties:
+                        current:
+                          description: current contains the current value for the
+                            given metric
+                          properties:
+                            averageUtilization:
+                              description: currentAverageUtilization is the current
+                                value of the average of the resource metric across
+                                all relevant pods, represented as a percentage of
+                                the requested value of the resource for the pods.
+                              format: int32
+                              type: integer
+                            averageValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: averageValue is the current value of the
+                                average of the metric across all relevant pods (as
+                                a quantity)
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            value:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: value is the current value of the metric
+                                (as a quantity).
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        name:
+                          description: Name is the name of the resource in question.
+                          type: string
+                      required:
+                      - name
+                      - current
+                      type: object
+                    type:
+                      description: 'type is the type of metric source.  It will be
+                        one of "ContainerResource", "External", "Object", "Pods" or
+                        "Resource", each corresponds to a matching field in the object.
+                        Note: "ContainerResource" type is available on when the feature-gate
+                        HPAContainerMetrics is enabled'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              currentReplicas:
+                description: currentReplicas is current number of replicas of pods
+                  managed by this autoscaler, as last seen by the autoscaler.
+                format: int32
+                type: integer
+              desiredReplicas:
+                description: desiredReplicas is the desired number of replicas of
+                  pods managed by this autoscaler, as last calculated by the autoscaler.
+                format: int32
+                type: integer
+              lastScaleTime:
+                description: lastScaleTime is the last time the HorizontalPodAutoscaler
+                  scaled the number of pods, used by the autoscaler to control how
+                  often the number of pods is changed.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by this autoscaler.
+                format: int64
+                type: integer
+            required:
+            - desiredReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v2

--- a/config/kube/crds/namespaced/batch_cronjobs.yaml
+++ b/config/kube/crds/namespaced/batch_cronjobs.yaml
@@ -1,0 +1,8287 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: cronjobs.batch
+spec:
+  conversion:
+    strategy: None
+  group: batch
+  names:
+    categories:
+    - all
+    kind: CronJob
+    listKind: CronJobList
+    plural: cronjobs
+    shortNames:
+    - cj
+    singular: cronjob
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CronJob represents the configuration of a single cron job.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of a cron job, including
+              the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              concurrencyPolicy:
+                description: |-
+                  Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+
+                  Possible enum values:
+                   - `"Allow"` allows CronJobs to run concurrently.
+                   - `"Forbid"` forbids concurrent runs, skipping next run if previous hasn't finished yet.
+                   - `"Replace"` cancels currently running job and replaces it with a new one.
+                type: string
+              failedJobsHistoryLimit:
+                description: The number of failed finished jobs to retain. Value must
+                  be non-negative integer. Defaults to 1.
+                format: int32
+                type: integer
+              jobTemplate:
+                description: Specifies the job that will be created when executing
+                  a CronJob.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata of the jobs created
+                      from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the job.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Specifies the duration in seconds relative to
+                          the startTime that the job may be continuously active before
+                          the system tries to terminate it; value must be positive
+                          integer. If a Job is suspended (at creation or through an
+                          update), this timer will effectively be stopped and reset
+                          when the Job is resumed again.
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        description: Specifies the number of retries before marking
+                          this job failed. Defaults to 6
+                        format: int32
+                        type: integer
+                      completionMode:
+                        description: |-
+                          CompletionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+                          `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+                          `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                          More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+                        type: string
+                      completions:
+                        description: 'Specifies the desired number of successfully
+                          finished pods the job should be run with.  Setting to nil
+                          means that the success of any pod signals the success of
+                          all pods, and allows parallelism to have any positive value.  Setting
+                          to 1 means that parallelism is limited to 1 and the success
+                          of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                        format: int32
+                        type: integer
+                      manualSelector:
+                        description: 'manualSelector controls generation of pod labels
+                          and pod selectors. Leave `manualSelector` unset unless you
+                          are certain what you are doing. When false or unset, the
+                          system pick labels unique to this job and appends those
+                          labels to the pod template.  When true, the user is responsible
+                          for picking unique labels and specifying the selector.  Failure
+                          to pick a unique label may cause this and other jobs to
+                          not function correctly.  However, You may see `manualSelector=true`
+                          in jobs that were created with the old `extensions/v1beta1`
+                          API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+                        type: boolean
+                      parallelism:
+                        description: 'Specifies the maximum desired number of pods
+                          the job should run at any given time. The actual number
+                          of pods running in steady state will be less than this number
+                          when ((.spec.completions - .status.successful) < .spec.parallelism),
+                          i.e. when the work left to do is less than max parallelism.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        description: |-
+                          Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+                          This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+                        properties:
+                          rules:
+                            description: A list of pod failure policy rules. The rules
+                              are evaluated in order. Once a rule matches a Pod failure,
+                              the remaining of the rules are ignored. When no rule
+                              matches the Pod failure, the default handling applies
+                              - the counter of pod failures is incremented and it
+                              is checked against the backoffLimit. At most 20 elements
+                              are allowed.
+                            items:
+                              description: PodFailurePolicyRule describes how a pod
+                                failure is handled when the requirements are met.
+                                One of OnExitCodes and onPodConditions, but not both,
+                                can be used in each rule.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: - FailJob: indicates that the pod's job is marked as Failed and all
+                                      running pods are terminated.
+                                    - Ignore: indicates that the counter towards the .backoffLimit is not
+                                      incremented and a replacement pod is created.
+                                    - Count: indicates that the pod is handled in the default way - the
+                                      counter towards the .backoffLimit is incremented.
+                                    Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+
+                                    Possible enum values:
+                                     - `"Count"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.
+                                     - `"FailJob"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.
+                                     - `"Ignore"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.
+                                  type: string
+                                onExitCodes:
+                                  description: Represents the requirement on the container
+                                    exit codes.
+                                  properties:
+                                    containerName:
+                                      description: Restricts the check for exit codes
+                                        to the container with the specified name.
+                                        When null, the rule applies to all containers.
+                                        When specified, it should match one the container
+                                        or initContainer names in the pod template.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: - In: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is in the set of specified values.
+                                        - NotIn: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is not in the set of specified values.
+                                        Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+
+                                        Possible enum values:
+                                         - `"In"`
+                                         - `"NotIn"`
+                                      type: string
+                                    values:
+                                      description: Specifies the set of values. Each
+                                        returned container exit code (might be multiple
+                                        in case of multiple containers) is checked
+                                        against this set of values with respect to
+                                        the operator. The list of values must be ordered
+                                        and must not contain duplicates. Value '0'
+                                        cannot be used for the In operator. At least
+                                        one element is required. At most 255 elements
+                                        are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  description: Represents the requirement on the pod
+                                    conditions. The requirement is represented as
+                                    a list of pod condition patterns. The requirement
+                                    is satisfied if at least one pattern matches an
+                                    actual pod condition. At most 20 elements are
+                                    allowed.
+                                  items:
+                                    description: PodFailurePolicyOnPodConditionsPattern
+                                      describes a pattern for matching an actual pod
+                                      condition type.
+                                    properties:
+                                      status:
+                                        description: Specifies the required Pod condition
+                                          status. To match a pod condition it is required
+                                          that the specified status equals the pod
+                                          condition status. Defaults to True.
+                                        type: string
+                                      type:
+                                        description: Specifies the required Pod condition
+                                          type. To match a pod condition it is required
+                                          that specified type equals the pod condition
+                                          type.
+                                        type: string
+                                    required:
+                                    - type
+                                    - status
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              - onPodConditions
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      selector:
+                        description: 'A label query over pods that should match the
+                          pod count. Normally, the system sets this field for you.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      suspend:
+                        description: Suspend specifies whether the Job controller
+                          should create Pods or not. If a Job is created with suspend
+                          set to true, no Pods are created by the Job controller.
+                          If a Job is suspended after creation (i.e. the flag goes
+                          from false to true), the Job controller will delete all
+                          active Pods associated with this Job. Users must design
+                          their workload to gracefully handle this. Suspending a Job
+                          will reset the StartTime field of the Job, effectively resetting
+                          the ActiveDeadlineSeconds timer too. Defaults to false.
+                        type: boolean
+                      template:
+                        description: 'Describes the pod that will be created when
+                          executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                        properties:
+                          metadata:
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          spec:
+                            description: 'Specification of the desired behavior of
+                              the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                            properties:
+                              activeDeadlineSeconds:
+                                description: Optional duration in seconds the pod
+                                  may be active on the node relative to StartTime
+                                  before the system will actively try to mark it failed
+                                  and kill associated containers. Value must be a
+                                  positive integer.
+                                format: int64
+                                type: integer
+                              affinity:
+                                description: If specified, the pod's scheduling constraints
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node matches the corresponding matchExpressions;
+                                          the node(s) with the highest sum are the
+                                          most preferred.
+                                        items:
+                                          description: An empty preferred scheduling
+                                            term matches all objects with implicit
+                                            weight 0 (i.e. it's a no-op). A null preferred
+                                            scheduling term matches no objects (i.e.
+                                            is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                          Possible enum values:
+                                                           - `"DoesNotExist"`
+                                                           - `"Exists"`
+                                                           - `"Gt"`
+                                                           - `"In"`
+                                                           - `"Lt"`
+                                                           - `"NotIn"`
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                          Possible enum values:
+                                                           - `"DoesNotExist"`
+                                                           - `"Exists"`
+                                                           - `"Gt"`
+                                                           - `"In"`
+                                                           - `"Lt"`
+                                                           - `"NotIn"`
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - weight
+                                          - preference
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to an update),
+                                          the system may or may not try to eventually
+                                          evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: A null or empty node selector
+                                                term matches no objects. The requirements
+                                                of them are ANDed. The TopologySelectorTerm
+                                                type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                          Possible enum values:
+                                                           - `"DoesNotExist"`
+                                                           - `"Exists"`
+                                                           - `"Gt"`
+                                                           - `"In"`
+                                                           - `"Lt"`
+                                                           - `"NotIn"`
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: A node selector requirement
+                                                      is a selector that contains
+                                                      values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                          Possible enum values:
+                                                           - `"DoesNotExist"`
+                                                           - `"Exists"`
+                                                           - `"Gt"`
+                                                           - `"In"`
+                                                           - `"Lt"`
+                                                           - `"NotIn"`
+                                                        type: string
+                                                      values:
+                                                        description: An array of string
+                                                          values. If the operator
+                                                          is In or NotIn, the values
+                                                          array must be non-empty.
+                                                          If the operator is Exists
+                                                          or DoesNotExist, the values
+                                                          array must be empty. If
+                                                          the operator is Gt or Lt,
+                                                          the values array must have
+                                                          a single element, which
+                                                          will be interpreted as an
+                                                          integer. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            type: array
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          affinity expressions specified by this field,
+                                          but it may choose a node that violates one
+                                          or more of the expressions. The node that
+                                          is most preferred is the one with the greatest
+                                          sum of weights, i.e. for each node that
+                                          meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          affinity expressions, etc.), compute a sum
+                                          by iterating through the elements of this
+                                          field and adding "weight" to the sum if
+                                          the node has pods which matches the corresponding
+                                          podAffinityTerm; the node(s) with the highest
+                                          sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - weight
+                                          - podAffinityTerm
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the affinity requirements specified
+                                          by this field cease to be met at some point
+                                          during pod execution (e.g. due to a pod
+                                          label update), the system may or may not
+                                          try to eventually evict the pod from its
+                                          node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: The scheduler will prefer to
+                                          schedule pods to nodes that satisfy the
+                                          anti-affinity expressions specified by this
+                                          field, but it may choose a node that violates
+                                          one or more of the expressions. The node
+                                          that is most preferred is the one with the
+                                          greatest sum of weights, i.e. for each node
+                                          that meets all of the scheduling requirements
+                                          (resource request, requiredDuringScheduling
+                                          anti-affinity expressions, etc.), compute
+                                          a sum by iterating through the elements
+                                          of this field and adding "weight" to the
+                                          sum if the node has pods which matches the
+                                          corresponding podAffinityTerm; the node(s)
+                                          with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: A label query over
+                                                    a set of resources, in this case
+                                                    pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaceSelector:
+                                                  description: A label query over
+                                                    the set of namespaces that the
+                                                    term applies to. The term is applied
+                                                    to the union of the namespaces
+                                                    selected by this field and the
+                                                    ones listed in the namespaces
+                                                    field. null selector and null
+                                                    or empty namespaces list means
+                                                    "this pod's namespace". An empty
+                                                    selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                namespaces:
+                                                  description: namespaces specifies
+                                                    a static list of namespace names
+                                                    that the term applies to. The
+                                                    term is applied to the union of
+                                                    the namespaces listed in this
+                                                    field and the ones selected by
+                                                    namespaceSelector. null or empty
+                                                    namespaces list and null namespaceSelector
+                                                    means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  description: This pod should be
+                                                    co-located (affinity) or not co-located
+                                                    (anti-affinity) with the pods
+                                                    matching the labelSelector in
+                                                    the specified namespaces, where
+                                                    co-located is defined as running
+                                                    on a node whose value of the label
+                                                    with key topologyKey matches that
+                                                    of any node on which any of the
+                                                    selected pods is running. Empty
+                                                    topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: weight associated with
+                                                matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - weight
+                                          - podAffinityTerm
+                                          type: object
+                                        type: array
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: If the anti-affinity requirements
+                                          specified by this field are not met at scheduling
+                                          time, the pod will not be scheduled onto
+                                          the node. If the anti-affinity requirements
+                                          specified by this field cease to be met
+                                          at some point during pod execution (e.g.
+                                          due to a pod label update), the system may
+                                          or may not try to eventually evict the pod
+                                          from its node. When there are multiple elements,
+                                          the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all
+                                          terms must be satisfied.
+                                        items:
+                                          description: Defines a set of pods (namely
+                                            those matching the labelSelector relative
+                                            to the given namespace(s)) that this pod
+                                            should be co-located (affinity) or not
+                                            co-located (anti-affinity) with, where
+                                            co-located is defined as running on a
+                                            node whose value of the label with key
+                                            <topologyKey> matches that of any node
+                                            on which a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: A label query over a set
+                                                of resources, in this case pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaceSelector:
+                                              description: A label query over the
+                                                set of namespaces that the term applies
+                                                to. The term is applied to the union
+                                                of the namespaces selected by this
+                                                field and the ones listed in the namespaces
+                                                field. null selector and null or empty
+                                                namespaces list means "this pod's
+                                                namespace". An empty selector ({})
+                                                matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: A label selector
+                                                      requirement is a selector that
+                                                      contains values, a key, and
+                                                      an operator that relates the
+                                                      key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: operator represents
+                                                          a key's relationship to
+                                                          a set of values. Valid operators
+                                                          are In, NotIn, Exists and
+                                                          DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: values is an
+                                                          array of string values.
+                                                          If the operator is In or
+                                                          NotIn, the values array
+                                                          must be non-empty. If the
+                                                          operator is Exists or DoesNotExist,
+                                                          the values array must be
+                                                          empty. This array is replaced
+                                                          during a strategic merge
+                                                          patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: matchLabels is a map
+                                                    of {key,value} pairs. A single
+                                                    {key,value} in the matchLabels
+                                                    map is equivalent to an element
+                                                    of matchExpressions, whose key
+                                                    field is "key", the operator is
+                                                    "In", and the values array contains
+                                                    only "value". The requirements
+                                                    are ANDed.
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              description: namespaces specifies a
+                                                static list of namespace names that
+                                                the term applies to. The term is applied
+                                                to the union of the namespaces listed
+                                                in this field and the ones selected
+                                                by namespaceSelector. null or empty
+                                                namespaces list and null namespaceSelector
+                                                means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              description: This pod should be co-located
+                                                (affinity) or not co-located (anti-affinity)
+                                                with the pods matching the labelSelector
+                                                in the specified namespaces, where
+                                                co-located is defined as running on
+                                                a node whose value of the label with
+                                                key topologyKey matches that of any
+                                                node on which any of the selected
+                                                pods is running. Empty topologyKey
+                                                is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                description: AutomountServiceAccountToken indicates
+                                  whether a service account token should be automatically
+                                  mounted.
+                                type: boolean
+                              containers:
+                                description: List of containers belonging to the pod.
+                                  Containers cannot currently be added or removed.
+                                  There must be at least one container in a Pod. Cannot
+                                  be updated.
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        container image''s CMD is used if this is
+                                        not provided. Variable references $(VAR_NAME)
+                                        are expanded using the container''s environment.
+                                        If a variable cannot be resolved, the reference
+                                        in the input string will be unchanged. Double
+                                        $$ are reduced to a single $, which allows
+                                        for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal
+                                        "$(VAR_NAME)". Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The container image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previously defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Container image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level
+                                        config management to default or override container
+                                        images in workload controllers like Deployments
+                                        and StatefulSets.'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                        Possible enum values:
+                                         - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                         - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                         - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                      type: string
+                                    lifecycle:
+                                      description: Actions that the management system
+                                        should take in response to container lifecycle
+                                        events. Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The Pod''s termination grace
+                                            period countdown begins before the PreStop
+                                            hook is executed. Regardless of the outcome
+                                            of the handler, the container will eventually
+                                            terminate within the Pod''s termination
+                                            grace period (unless delayed by finalizers).
+                                            Other management of the container blocks
+                                            until the hook completes or until the
+                                            termination grace period is reached. More
+                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: 'Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the container specified
+                                        as a DNS_LABEL. Each container in a pod must
+                                        have a unique name (DNS_LABEL). Cannot be
+                                        updated.
+                                      type: string
+                                    ports:
+                                      description: List of ports to expose from the
+                                        container. Not specifying a port here DOES
+                                        NOT prevent that port from being exposed.
+                                        Any port which is listening on the default
+                                        "0.0.0.0" address inside a container will
+                                        be accessible from the network. Modifying
+                                        this array with strategic merge patch may
+                                        corrupt the data. For more information See
+                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                              Possible enum values:
+                                               - `"SCTP"` is the SCTP protocol.
+                                               - `"TCP"` is the TCP protocol.
+                                               - `"UDP"` is the UDP protocol.
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: 'Periodic probe of container service
+                                        readiness. Container will be removed from
+                                        service endpoints if the probe fails. Cannot
+                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: 'Compute Resources required by
+                                        this container. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'SecurityContext defines the security
+                                        options the container should be run with.
+                                        If set, the fields of SecurityContext override
+                                        the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when
+                                            spec.os.name is windows.'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime. Note that this
+                                            field cannot be set when spec.os.name
+                                            is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false. Note that
+                                            this field cannot be set when spec.os.name
+                                            is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled. Note that this field cannot
+                                            be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false. Note that this field cannot be
+                                            set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                                Possible enum values:
+                                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence. Note
+                                            that this field cannot be set when spec.os.name
+                                            is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: 'StartupProbe indicates that the
+                                        Pod has successfully initialized. If specified,
+                                        no other probes are executed until this completes
+                                        successfully. If this probe fails, the Pod
+                                        will be restarted, just as if the livenessProbe
+                                        failed. This can be used to provide different
+                                        probe parameters at the beginning of a Pod''s
+                                        lifecycle, when it might take a long time
+                                        to load data or warm a cache, than during
+                                        steady-state operation. This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                        Possible enum values:
+                                         - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                         - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                description: Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the
+                                  generated DNS configuration based on DNSPolicy.
+                                properties:
+                                  nameservers:
+                                    description: A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers
+                                      generated from DNSPolicy. Duplicated nameservers
+                                      will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                  options:
+                                    description: A list of DNS resolver options. This
+                                      will be merged with the base options generated
+                                      from DNSPolicy. Duplicated entries will be removed.
+                                      Resolution options given in Options will override
+                                      those that appear in the base DNSPolicy.
+                                    items:
+                                      description: PodDNSConfigOption defines DNS
+                                        resolver options of a pod.
+                                      properties:
+                                        name:
+                                          description: Required.
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  searches:
+                                    description: A list of DNS search domains for
+                                      host-name lookup. This will be appended to the
+                                      base search paths generated from DNSPolicy.
+                                      Duplicated search paths will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              dnsPolicy:
+                                description: |-
+                                  Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                                  Possible enum values:
+                                   - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                                   - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                                   - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                                   - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                                type: string
+                              enableServiceLinks:
+                                description: 'EnableServiceLinks indicates whether
+                                  information about services should be injected into
+                                  pod''s environment variables, matching the syntax
+                                  of Docker links. Optional: Defaults to true.'
+                                type: boolean
+                              ephemeralContainers:
+                                description: List of ephemeral containers run in this
+                                  pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging.
+                                  This list cannot be specified when creating a pod,
+                                  and it cannot be modified by updating the pod spec.
+                                  In order to add an ephemeral container to an existing
+                                  pod, use the pod's ephemeralcontainers subresource.
+                                items:
+                                  description: |-
+                                    An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                                    To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        image''s CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The image''s ENTRYPOINT is
+                                        used if this is not provided. Variable references
+                                        $(VAR_NAME) are expanded using the container''s
+                                        environment. If a variable cannot be resolved,
+                                        the reference in the input string will be
+                                        unchanged. Double $$ are reduced to a single
+                                        $, which allows for escaping the $(VAR_NAME)
+                                        syntax: i.e. "$$(VAR_NAME)" will produce the
+                                        string literal "$(VAR_NAME)". Escaped references
+                                        will never be expanded, regardless of whether
+                                        the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previously defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Container image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                        Possible enum values:
+                                         - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                         - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                         - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                      type: string
+                                    lifecycle:
+                                      description: Lifecycle is not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The Pod''s termination grace
+                                            period countdown begins before the PreStop
+                                            hook is executed. Regardless of the outcome
+                                            of the handler, the container will eventually
+                                            terminate within the Pod''s termination
+                                            grace period (unless delayed by finalizers).
+                                            Other management of the container blocks
+                                            until the hook completes or until the
+                                            termination grace period is reached. More
+                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the ephemeral container
+                                        specified as a DNS_LABEL. This name must be
+                                        unique among all containers, init containers
+                                        and ephemeral containers.
+                                      type: string
+                                    ports:
+                                      description: Ports are not allowed for ephemeral
+                                        containers.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                              Possible enum values:
+                                               - `"SCTP"` is the SCTP protocol.
+                                               - `"TCP"` is the TCP protocol.
+                                               - `"UDP"` is the UDP protocol.
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: Resources are not allowed for ephemeral
+                                        containers. Ephemeral containers use spare
+                                        resources already allocated to the pod.
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'Optional: SecurityContext defines
+                                        the security options the ephemeral container
+                                        should be run with. If set, the fields of
+                                        SecurityContext override the equivalent fields
+                                        of PodSecurityContext.'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when
+                                            spec.os.name is windows.'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime. Note that this
+                                            field cannot be set when spec.os.name
+                                            is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false. Note that
+                                            this field cannot be set when spec.os.name
+                                            is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled. Note that this field cannot
+                                            be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false. Note that this field cannot be
+                                            set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                                Possible enum values:
+                                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence. Note
+                                            that this field cannot be set when spec.os.name
+                                            is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    targetContainerName:
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                        The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                                      type: string
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                        Possible enum values:
+                                         - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                         - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Subpath mounts are not allowed
+                                        for ephemeral containers. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                description: HostAliases is an optional list of hosts
+                                  and IPs that will be injected into the pod's hosts
+                                  file if specified. This is only valid for non-hostNetwork
+                                  pods.
+                                items:
+                                  description: HostAlias holds the mapping between
+                                    IP and hostnames that will be injected as an entry
+                                    in the pod's hosts file.
+                                  properties:
+                                    hostnames:
+                                      description: Hostnames for the above IP address.
+                                      items:
+                                        type: string
+                                      type: array
+                                    ip:
+                                      description: IP address of the host file entry.
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                description: 'Use the host''s ipc namespace. Optional:
+                                  Default to false.'
+                                type: boolean
+                              hostNetwork:
+                                description: Host networking requested for this pod.
+                                  Use the host's network namespace. If this option
+                                  is set, the ports that will be used must be specified.
+                                  Default to false.
+                                type: boolean
+                              hostPID:
+                                description: 'Use the host''s pid namespace. Optional:
+                                  Default to false.'
+                                type: boolean
+                              hostUsers:
+                                description: 'Use the host''s user namespace. Optional:
+                                  Default to true. If set to true or not present,
+                                  the pod will be run in the host user namespace,
+                                  useful for when the pod needs a feature only available
+                                  to the host user namespace, such as loading a kernel
+                                  module with CAP_SYS_MODULE. When set to false, a
+                                  new userns is created for the pod. Setting false
+                                  is useful for mitigating container breakout vulnerabilities
+                                  even allowing users to run their containers as root
+                                  without actually having root privileges on the host.
+                                  This field is alpha-level and is only honored by
+                                  servers that enable the UserNamespacesSupport feature.'
+                                type: boolean
+                              hostname:
+                                description: Specifies the hostname of the Pod If
+                                  not specified, the pod's hostname will be set to
+                                  a system-defined value.
+                                type: string
+                              imagePullSecrets:
+                                description: 'ImagePullSecrets is an optional list
+                                  of references to secrets in the same namespace to
+                                  use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual
+                                  puller implementations for them to use. More info:
+                                  https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                items:
+                                  description: LocalObjectReference contains enough
+                                    information to let you locate the referenced object
+                                    inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                description: 'List of initialization containers belonging
+                                  to the pod. Init containers are executed in order
+                                  prior to containers being started. If any init container
+                                  fails, the pod is considered to have failed and
+                                  is handled according to its restartPolicy. The name
+                                  for an init container or normal container must be
+                                  unique among all containers. Init containers may
+                                  not have Lifecycle actions, Readiness probes, Liveness
+                                  probes, or Startup probes. The resourceRequirements
+                                  of an init container are taken into account during
+                                  scheduling by finding the highest request/limit
+                                  for each resource type, and then using the max of
+                                  of that value or the sum of the normal containers.
+                                  Limits are applied to init containers in a similar
+                                  fashion. Init containers cannot currently be added
+                                  or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: 'Arguments to the entrypoint. The
+                                        container image''s CMD is used if this is
+                                        not provided. Variable references $(VAR_NAME)
+                                        are expanded using the container''s environment.
+                                        If a variable cannot be resolved, the reference
+                                        in the input string will be unchanged. Double
+                                        $$ are reduced to a single $, which allows
+                                        for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal
+                                        "$(VAR_NAME)". Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    command:
+                                      description: 'Entrypoint array. Not executed
+                                        within a shell. The container image''s ENTRYPOINT
+                                        is used if this is not provided. Variable
+                                        references $(VAR_NAME) are expanded using
+                                        the container''s environment. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      items:
+                                        type: string
+                                      type: array
+                                    env:
+                                      description: List of environment variables to
+                                        set in the container. Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: Name of the environment variable.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          value:
+                                            description: 'Variable references $(VAR_NAME)
+                                              are expanded using the previously defined
+                                              environment variables in the container
+                                              and any service environment variables.
+                                              If a variable cannot be resolved, the
+                                              reference in the input string will be
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded,
+                                              regardless of whether the variable exists
+                                              or not. Defaults to "".'
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                              fieldRef:
+                                                description: 'Selects a field of the
+                                                  pod: supports metadata.name, metadata.namespace,
+                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                  spec.nodeName, spec.serviceAccountName,
+                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  limits.ephemeral-storage, requests.cpu,
+                                                  requests.memory and requests.ephemeral-storage)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: List of sources to populate environment
+                                        variables in the container. The keys defined
+                                        within a source must be a C_IDENTIFIER. All
+                                        invalid keys will be reported as an event
+                                        when the container is starting. When a key
+                                        exists in multiple sources, the value associated
+                                        with the last source will take precedence.
+                                        Values defined by an Env with a duplicate
+                                        key will take precedence. Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                          prefix:
+                                            description: An optional identifier to
+                                              prepend to each key in the ConfigMap.
+                                              Must be a C_IDENTIFIER.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                description: 'Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                      type: array
+                                    image:
+                                      description: 'Container image name. More info:
+                                        https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level
+                                        config management to default or override container
+                                        images in workload controllers like Deployments
+                                        and StatefulSets.'
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                        Possible enum values:
+                                         - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                         - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                         - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                      type: string
+                                    lifecycle:
+                                      description: Actions that the management system
+                                        should take in response to container lifecycle
+                                        events. Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: 'PostStart is called immediately
+                                            after a container is created. If the handler
+                                            fails, the container is terminated and
+                                            restarted according to its restart policy.
+                                            Other management of the container blocks
+                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: 'PreStop is called immediately
+                                            before a container is terminated due to
+                                            an API request or management event such
+                                            as liveness/startup probe failure, preemption,
+                                            resource contention, etc. The handler
+                                            is not called if the container crashes
+                                            or exits. The Pod''s termination grace
+                                            period countdown begins before the PreStop
+                                            hook is executed. Regardless of the outcome
+                                            of the handler, the container will eventually
+                                            terminate within the Pod''s termination
+                                            grace period (unless delayed by finalizers).
+                                            Other management of the container blocks
+                                            until the hook completes or until the
+                                            termination grace period is reached. More
+                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          properties:
+                                            exec:
+                                              description: Exec specifies the action
+                                                to take.
+                                              properties:
+                                                command:
+                                                  description: Command is the command
+                                                    line to execute inside the container,
+                                                    the working directory for the
+                                                    command  is root ('/') in the
+                                                    container's filesystem. The command
+                                                    is simply exec'd, it is not run
+                                                    inside a shell, so traditional
+                                                    shell instructions ('|', etc)
+                                                    won't work. To use a shell, you
+                                                    need to explicitly call out to
+                                                    that shell. Exit status of 0 is
+                                                    treated as live/healthy and non-zero
+                                                    is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies the http
+                                                request to perform.
+                                              properties:
+                                                host:
+                                                  description: Host name to connect
+                                                    to, defaults to the pod IP. You
+                                                    probably want to set "Host" in
+                                                    httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: The header field
+                                                          name
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Name or number of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                    Possible enum values:
+                                                     - `"HTTP"` means that the scheme used will be http://
+                                                     - `"HTTPS"` means that the scheme used will be https://
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            tcpSocket:
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Number or name of the
+                                                    port to access on the container.
+                                                    Number must be in the range 1
+                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                      type: object
+                                    livenessProbe:
+                                      description: 'Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: Name of the container specified
+                                        as a DNS_LABEL. Each container in a pod must
+                                        have a unique name (DNS_LABEL). Cannot be
+                                        updated.
+                                      type: string
+                                    ports:
+                                      description: List of ports to expose from the
+                                        container. Not specifying a port here DOES
+                                        NOT prevent that port from being exposed.
+                                        Any port which is listening on the default
+                                        "0.0.0.0" address inside a container will
+                                        be accessible from the network. Modifying
+                                        this array with strategic merge patch may
+                                        corrupt the data. For more information See
+                                        https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: Number of port to expose
+                                              on the pod's IP address. This must be
+                                              a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: Number of port to expose
+                                              on the host. If specified, this must
+                                              be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must
+                                              match ContainerPort. Most containers
+                                              do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: If specified, this must be
+                                              an IANA_SVC_NAME and unique within the
+                                              pod. Each named port in a pod must have
+                                              a unique name. Name for the port that
+                                              can be referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                              Possible enum values:
+                                               - `"SCTP"` is the SCTP protocol.
+                                               - `"TCP"` is the TCP protocol.
+                                               - `"UDP"` is the UDP protocol.
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: 'Periodic probe of container service
+                                        readiness. Container will be removed from
+                                        service endpoints if the probe fails. Cannot
+                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resources:
+                                      description: 'Compute Resources required by
+                                        this container. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: 'SecurityContext defines the security
+                                        options the container should be run with.
+                                        If set, the fields of SecurityContext override
+                                        the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: 'AllowPrivilegeEscalation controls
+                                            whether a process can gain more privileges
+                                            than its parent process. This bool directly
+                                            controls if the no_new_privs flag will
+                                            be set on the container process. AllowPrivilegeEscalation
+                                            is true always when the container is:
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when
+                                            spec.os.name is windows.'
+                                          type: boolean
+                                        capabilities:
+                                          description: The capabilities to add/drop
+                                            when running containers. Defaults to the
+                                            default set of capabilities granted by
+                                            the container runtime. Note that this
+                                            field cannot be set when spec.os.name
+                                            is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        privileged:
+                                          description: Run container in privileged
+                                            mode. Processes in privileged containers
+                                            are essentially equivalent to root on
+                                            the host. Defaults to false. Note that
+                                            this field cannot be set when spec.os.name
+                                            is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: procMount denotes the type
+                                            of proc mount to use for the containers.
+                                            The default is DefaultProcMount which
+                                            uses the container runtime defaults for
+                                            readonly paths and masked paths. This
+                                            requires the ProcMountType feature flag
+                                            to be enabled. Note that this field cannot
+                                            be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: Whether this container has
+                                            a read-only root filesystem. Default is
+                                            false. Note that this field cannot be
+                                            set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: The GID to run the entrypoint
+                                            of the container process. Uses runtime
+                                            default if unset. May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: Indicates that the container
+                                            must run as a non-root user. If true,
+                                            the Kubelet will validate the image at
+                                            runtime to ensure that it does not run
+                                            as UID 0 (root) and fail to start the
+                                            container if it does. If unset or false,
+                                            no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: The UID to run the entrypoint
+                                            of the container process. Defaults to
+                                            user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: The SELinux context to be applied
+                                            to the container. If unspecified, the
+                                            container runtime will allocate a random
+                                            SELinux context for each container.  May
+                                            also be set in PodSecurityContext.  If
+                                            set in both SecurityContext and PodSecurityContext,
+                                            the value specified in SecurityContext
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: The seccomp options to use
+                                            by this container. If seccomp options
+                                            are provided at both the pod & container
+                                            level, the container options override
+                                            the pod options. Note that this field
+                                            cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: localhostProfile indicates
+                                                a profile defined in a file on the
+                                                node should be used. The profile must
+                                                be preconfigured on the node to work.
+                                                Must be a descending path, relative
+                                                to the kubelet's configured seccomp
+                                                profile location. Must only be set
+                                                if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                                Possible enum values:
+                                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: The Windows specific settings
+                                            applied to all containers. If unspecified,
+                                            the options from the PodSecurityContext
+                                            will be used. If set in both SecurityContext
+                                            and PodSecurityContext, the value specified
+                                            in SecurityContext takes precedence. Note
+                                            that this field cannot be set when spec.os.name
+                                            is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: GMSACredentialSpec is where
+                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                                inlines the contents of the GMSA credential
+                                                spec named by the GMSACredentialSpecName
+                                                field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: The UserName in Windows
+                                                to run the entrypoint of the container
+                                                process. Defaults to the user specified
+                                                in image metadata if unspecified.
+                                                May also be set in PodSecurityContext.
+                                                If set in both SecurityContext and
+                                                PodSecurityContext, the value specified
+                                                in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: 'StartupProbe indicates that the
+                                        Pod has successfully initialized. If specified,
+                                        no other probes are executed until this completes
+                                        successfully. If this probe fails, the Pod
+                                        will be restarted, just as if the livenessProbe
+                                        failed. This can be used to provide different
+                                        probe parameters at the beginning of a Pod''s
+                                        lifecycle, when it might take a long time
+                                        to load data or warm a cache, than during
+                                        steady-state operation. This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      properties:
+                                        exec:
+                                          description: Exec specifies the action to
+                                            take.
+                                          properties:
+                                            command:
+                                              description: Command is the command
+                                                line to execute inside the container,
+                                                the working directory for the command  is
+                                                root ('/') in the container's filesystem.
+                                                The command is simply exec'd, it is
+                                                not run inside a shell, so traditional
+                                                shell instructions ('|', etc) won't
+                                                work. To use a shell, you need to
+                                                explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy
+                                                and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        failureThreshold:
+                                          description: Minimum consecutive failures
+                                            for the probe to be considered failed
+                                            after having succeeded. Defaults to 3.
+                                            Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies the http
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: Host name to connect to,
+                                                defaults to the pod IP. You probably
+                                                want to set "Host" in httpHeaders
+                                                instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: The header field
+                                                      name
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Name or number of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                Possible enum values:
+                                                 - `"HTTP"` means that the scheme used will be http://
+                                                 - `"HTTPS"` means that the scheme used will be https://
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: 'Number of seconds after the
+                                            container has started before liveness
+                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: How often (in seconds) to perform
+                                            the probe. Default to 10 seconds. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: Minimum consecutive successes
+                                            for the probe to be considered successful
+                                            after having failed. Defaults to 1. Must
+                                            be 1 for liveness and startup. Minimum
+                                            value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Number or name of the port
+                                                to access on the container. Number
+                                                must be in the range 1 to 65535. Name
+                                                must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: Optional duration in seconds
+                                            the pod needs to terminate gracefully
+                                            upon probe failure. The grace period is
+                                            the duration in seconds after the processes
+                                            running in the pod are sent a termination
+                                            signal and the time when the processes
+                                            are forcibly halted with a kill signal.
+                                            Set this value longer than the expected
+                                            cleanup time for your process. If this
+                                            value is nil, the pod's terminationGracePeriodSeconds
+                                            will be used. Otherwise, this value overrides
+                                            the value provided by the pod spec. Value
+                                            must be non-negative integer. The value
+                                            zero indicates stop immediately via the
+                                            kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling
+                                            ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: 'Number of seconds after which
+                                            the probe times out. Defaults to 1 second.
+                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: Whether this container should allocate
+                                        a buffer for stdin in the container runtime.
+                                        If this is not set, reads from stdin in the
+                                        container will always result in EOF. Default
+                                        is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: Whether the container runtime should
+                                        close the stdin channel after it has been
+                                        opened by a single attach. When stdin is true
+                                        the stdin stream will remain open across multiple
+                                        attach sessions. If stdinOnce is set to true,
+                                        stdin is opened on container start, is empty
+                                        until the first client attaches to stdin,
+                                        and then remains open and accepts data until
+                                        the client disconnects, at which time stdin
+                                        is closed and remains closed until the container
+                                        is restarted. If this flag is false, a container
+                                        processes that reads from stdin will never
+                                        receive an EOF. Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: 'Optional: Path at which the file
+                                        to which the container''s termination message
+                                        will be written is mounted into the container''s
+                                        filesystem. Message written is intended to
+                                        be brief final status, such as an assertion
+                                        failure message. Will be truncated by the
+                                        node if greater than 4096 bytes. The total
+                                        message length across all containers will
+                                        be limited to 12kb. Defaults to /dev/termination-log.
+                                        Cannot be updated.'
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                        Possible enum values:
+                                         - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                         - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                      type: string
+                                    tty:
+                                      description: Whether this container should allocate
+                                        a TTY for itself, also requires 'stdin' to
+                                        be true. Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: Pod volumes to mount into the container's
+                                        filesystem. Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: Path within the container
+                                              at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: mountPropagation determines
+                                              how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is
+                                              used. This field is beta in 1.10.
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: Mounted read-only if true,
+                                              read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          subPath:
+                                            description: Path within the volume from
+                                              which the container's volume should
+                                              be mounted. Defaults to "" (volume's
+                                              root).
+                                            type: string
+                                          subPathExpr:
+                                            description: Expanded path within the
+                                              volume from which the container's volume
+                                              should be mounted. Behaves similarly
+                                              to SubPath but environment variable
+                                              references $(VAR_NAME) are expanded
+                                              using the container's environment. Defaults
+                                              to "" (volume's root). SubPathExpr and
+                                              SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: Container's working directory.
+                                        If not specified, the container runtime's
+                                        default will be used, which might be configured
+                                        in the container image. Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                description: NodeName is a request to schedule this
+                                  pod onto a specific node. If it is non-empty, the
+                                  scheduler simply schedules this pod onto that node,
+                                  assuming that it fits resource requirements.
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: 'NodeSelector is a selector which must
+                                  be true for the pod to fit on a node. Selector which
+                                  must match a node''s labels for the pod to be scheduled
+                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                type: object
+                              os:
+                                description: |-
+                                  Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                                  If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                                  If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                                properties:
+                                  name:
+                                    description: 'Name is the name of the operating
+                                      system. The currently supported values are linux
+                                      and windows. Additional value may be defined
+                                      in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values
+                                      and treat unrecognized values in this field
+                                      as os: null'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Overhead represents the resource overhead
+                                  associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time
+                                  by the RuntimeClass admission controller. If the
+                                  RuntimeClass admission controller is enabled, overhead
+                                  must not be set in Pod create requests. The RuntimeClass
+                                  admission controller will reject Pod create requests
+                                  which have the overhead already set. If RuntimeClass
+                                  is configured and selected in the PodSpec, Overhead
+                                  will be set to the value defined in the corresponding
+                                  RuntimeClass, otherwise it will remain unset and
+                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                                type: object
+                              preemptionPolicy:
+                                description: PreemptionPolicy is the Policy for preempting
+                                  pods with lower priority. One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset.
+                                type: string
+                              priority:
+                                description: The priority value. Various system components
+                                  use this field to find the priority of the pod.
+                                  When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission
+                                  controller populates this field from PriorityClassName.
+                                  The higher the value, the higher the priority.
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                description: If specified, indicates the pod's priority.
+                                  "system-node-critical" and "system-cluster-critical"
+                                  are two special keywords which indicate the highest
+                                  priorities with the former being the highest priority.
+                                  Any other name must be defined by creating a PriorityClass
+                                  object with that name. If not specified, the pod
+                                  priority will be default or zero if there is no
+                                  default.
+                                type: string
+                              readinessGates:
+                                description: 'If specified, all readiness gates will
+                                  be evaluated for pod readiness. A pod is ready when
+                                  all its containers are ready AND all conditions
+                                  specified in the readiness gates have status equal
+                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                                items:
+                                  description: PodReadinessGate contains the reference
+                                    to a pod condition
+                                  properties:
+                                    conditionType:
+                                      description: ConditionType refers to a condition
+                                        in the pod's condition list with matching
+                                        type.
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                              restartPolicy:
+                                description: |-
+                                  Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                                  Possible enum values:
+                                   - `"Always"`
+                                   - `"Never"`
+                                   - `"OnFailure"`
+                                type: string
+                              runtimeClassName:
+                                description: 'RuntimeClassName refers to a RuntimeClass
+                                  object in the node.k8s.io group, which should be
+                                  used to run this pod.  If no RuntimeClass resource
+                                  matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will
+                                  be used, which is an implicit class with an empty
+                                  definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                                type: string
+                              schedulerName:
+                                description: If specified, the pod will be dispatched
+                                  by specified scheduler. If not specified, the pod
+                                  will be dispatched by default scheduler.
+                                type: string
+                              securityContext:
+                                description: 'SecurityContext holds pod-level security
+                                  attributes and common container settings. Optional:
+                                  Defaults to empty.  See type description for default
+                                  values of each field.'
+                                properties:
+                                  fsGroup:
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                                      1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    description: 'fsGroupChangePolicy defines behavior
+                                      of changing ownership and permission of the
+                                      volume before being exposed inside Pod. This
+                                      field will only apply to volume types which
+                                      support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types
+                                      such as: secret, configmaps and emptydir. Valid
+                                      values are "OnRootMismatch" and "Always". If
+                                      not specified, "Always" is used. Note that this
+                                      field cannot be set when spec.os.name is windows.'
+                                    type: string
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container. Note that this
+                                      field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in SecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence for that
+                                      container. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied
+                                      to all containers. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in SecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence for that container. Note that this
+                                      field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by the
+                                      containers in this pod. Note that this field
+                                      cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a
+                                          profile defined in a file on the node should
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                          Possible enum values:
+                                           - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                           - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                           - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    description: A list of groups applied to the first
+                                      process run in each container, in addition to
+                                      the container's primary GID.  If unspecified,
+                                      no groups will be added to any container. Note
+                                      that this field cannot be set when spec.os.name
+                                      is windows.
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                  sysctls:
+                                    description: Sysctls hold a list of namespaced
+                                      sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail
+                                      to launch. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    items:
+                                      description: Sysctl defines a kernel parameter
+                                        to be set
+                                      properties:
+                                        name:
+                                          description: Name of a property to set
+                                          type: string
+                                        value:
+                                          description: Value of a property to set
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      within a container's SecurityContext will be
+                                      used. If set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only
+                                          be honored by components that enable the
+                                          WindowsHostProcessContainers feature flag.
+                                          Setting this field without the feature flag
+                                          will result in errors when validating the
+                                          Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it
+                                          is not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).  In
+                                          addition, if HostProcess is true then HostNetwork
+                                          must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                description: 'DeprecatedServiceAccount is a depreciated
+                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                  instead.'
+                                type: string
+                              serviceAccountName:
+                                description: 'ServiceAccountName is the name of the
+                                  ServiceAccount to use to run this pod. More info:
+                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                type: string
+                              setHostnameAsFQDN:
+                                description: If true the pod's hostname will be configured
+                                  as the pod's FQDN, rather than the leaf name (the
+                                  default). In Linux containers, this means setting
+                                  the FQDN in the hostname field of the kernel (the
+                                  nodename field of struct utsname). In Windows containers,
+                                  this means setting the registry value of hostname
+                                  for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                                  to FQDN. If a pod does not have FQDN, this has no
+                                  effect. Default to false.
+                                type: boolean
+                              shareProcessNamespace:
+                                description: 'Share a single process namespace between
+                                  all of the containers in a pod. When this is set
+                                  containers will be able to view and signal processes
+                                  from other containers in the same pod, and the first
+                                  process in each container will not be assigned PID
+                                  1. HostPID and ShareProcessNamespace cannot both
+                                  be set. Optional: Default to false.'
+                                type: boolean
+                              subdomain:
+                                description: If specified, the fully qualified Pod
+                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                  domain>". If not specified, the pod will not have
+                                  a domainname at all.
+                                type: string
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully. May be decreased
+                                  in delete request. Value must be non-negative integer.
+                                  The value zero indicates stop immediately via the
+                                  kill signal (no opportunity to shut down). If this
+                                  value is nil, the default grace period will be used
+                                  instead. The grace period is the duration in seconds
+                                  after the processes running in the pod are sent
+                                  a termination signal and the time when the processes
+                                  are forcibly halted with a kill signal. Set this
+                                  value longer than the expected cleanup time for
+                                  your process. Defaults to 30 seconds.
+                                format: int64
+                                type: integer
+                              tolerations:
+                                description: If specified, the pod's tolerations.
+                                items:
+                                  description: The pod this Toleration is attached
+                                    to tolerates any taint that matches the triple
+                                    <key,value,effect> using the matching operator
+                                    <operator>.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                        Possible enum values:
+                                         - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                         - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                         - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                                      type: string
+                                    key:
+                                      description: Key is the taint key that the toleration
+                                        applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists;
+                                        this combination means to match all values
+                                        and all keys.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                        Possible enum values:
+                                         - `"Equal"`
+                                         - `"Exists"`
+                                      type: string
+                                    tolerationSeconds:
+                                      description: TolerationSeconds represents the
+                                        period of time the toleration (which must
+                                        be of effect NoExecute, otherwise this field
+                                        is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint
+                                        forever (do not evict). Zero and negative
+                                        values will be treated as 0 (evict immediately)
+                                        by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: Value is the taint value the toleration
+                                        matches to. If the operator is Exists, the
+                                        value should be empty, otherwise just a regular
+                                        string.
+                                      type: string
+                                  type: object
+                                type: array
+                              topologySpreadConstraints:
+                                description: TopologySpreadConstraints describes how
+                                  a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which
+                                  abides by the constraints. All topologySpreadConstraints
+                                  are ANDed.
+                                items:
+                                  description: TopologySpreadConstraint specifies
+                                    how to spread matching pods among the given topology.
+                                  properties:
+                                    labelSelector:
+                                      description: LabelSelector is used to find matching
+                                        pods. Pods that match this label selector
+                                        are counted to determine the number of pods
+                                        in their corresponding topology domain.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    matchLabelKeys:
+                                      description: MatchLabelKeys is a set of pod
+                                        label keys to select the pods over which spreading
+                                        will be calculated. The keys are used to lookup
+                                        values from the incoming pod labels, those
+                                        key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over
+                                        which spreading will be calculated for the
+                                        incoming pod. Keys that don't exist in the
+                                        incoming pod labels will be ignored. A null
+                                        or empty list means only match against labelSelector.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      description: 'MaxSkew describes the degree to
+                                        which pods may be unevenly distributed. When
+                                        `whenUnsatisfiable=DoNotSchedule`, it is the
+                                        maximum permitted difference between the number
+                                        of matching pods in the target topology and
+                                        the global minimum. The global minimum is
+                                        the minimum number of matching pods in an
+                                        eligible domain or zero if the number of eligible
+                                        domains is less than MinDomains. For example,
+                                        in a 3-zone cluster, MaxSkew is set to 1,
+                                        and pods with the same labelSelector spread
+                                        as 2/2/1: In this case, the global minimum
+                                        is 1. | zone1 | zone2 | zone3 | |  P P  |  P
+                                        P  |   P   | - if MaxSkew is 1, incoming pod
+                                        can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make
+                                        the ActualSkew(3-1) on zone1(zone2) violate
+                                        MaxSkew(1). - if MaxSkew is 2, incoming pod
+                                        can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                        it is used to give higher precedence to topologies
+                                        that satisfy it. It''s a required field. Default
+                                        value is 1 and 0 is not allowed.'
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      description: |-
+                                        MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                        This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      description: |-
+                                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                        If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      description: |-
+                                        NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                        If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                      type: string
+                                    topologyKey:
+                                      description: TopologyKey is the key of node
+                                        labels. Nodes that have a label with this
+                                        key and identical values are considered to
+                                        be in the same topology. We consider each
+                                        <key, value> as a "bucket", and try to put
+                                        balanced number of pods into each bucket.
+                                        We define a domain as a particular instance
+                                        of a topology. Also, we define an eligible
+                                        domain as a domain whose nodes meet the requirements
+                                        of nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname",
+                                        each Node is a domain of that topology. And,
+                                        if TopologyKey is "topology.kubernetes.io/zone",
+                                        each zone is a domain of that topology. It's
+                                        a required field.
+                                      type: string
+                                    whenUnsatisfiable:
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                        Possible enum values:
+                                         - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                         - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                description: 'List of volumes that can be mounted
+                                  by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: 'awsElasticBlockStore represents
+                                        an AWS Disk resource that is attached to a
+                                        kubelet''s host machine and then exposed to
+                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly value true will force
+                                            the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: boolean
+                                        volumeID:
+                                          description: 'volumeID is unique ID of the
+                                            persistent disk resource in AWS (Amazon
+                                            EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: azureDisk represents an Azure Data
+                                        Disk mount on the host and bind mount to the
+                                        pod.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching
+                                            mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the
+                                            data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data
+                                            disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          description: fsType is Filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared:
+                                            multiple blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: azureFile represents an Azure File
+                                        Service mount on the host and bind mount to
+                                        the pod.
+                                      properties:
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of
+                                            secret that contains Azure Storage Account
+                                            Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share
+                                            Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: cephFS represents a Ceph FS mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        monitors:
+                                          description: 'monitors is Required: Monitors
+                                            is a collection of Ceph monitors More
+                                            info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        path:
+                                          description: 'path is Optional: Used as
+                                            the mounted root, rather than the full
+                                            Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretFile:
+                                          description: 'secretFile is Optional: SecretFile
+                                            is the path to key ring for User, default
+                                            is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                        secretRef:
+                                          description: 'secretRef is Optional: SecretRef
+                                            is reference to the authentication secret
+                                            for User, default is empty. More info:
+                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is optional: User is
+                                            the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: 'cinder represents a cinder volume
+                                        attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Examples:
+                                            "ext4", "xfs", "ntfs". Implicitly inferred
+                                            to be "ext4" if unspecified. More info:
+                                            https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is optional: points
+                                            to a secret object containing parameters
+                                            used to connect to OpenStack.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        volumeID:
+                                          description: 'volumeID used to identify
+                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    csi:
+                                      description: csi (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers (Beta feature).
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the CSI
+                                            driver that handles this volume. Consult
+                                            with your admin for the correct name as
+                                            registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: fsType to mount. Ex. "ext4",
+                                            "xfs", "ntfs". If not provided, the empty
+                                            value is passed to the associated CSI
+                                            driver which will determine the default
+                                            filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: nodePublishSecretRef is a reference
+                                            to the secret object containing sensitive
+                                            information to pass to the CSI driver
+                                            to complete the CSI NodePublishVolume
+                                            and NodeUnpublishVolume calls. This field
+                                            is optional, and  may be empty if no secret
+                                            is required. If the secret object contains
+                                            more than one secret, all secret references
+                                            are passed.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        readOnly:
+                                          description: readOnly specifies a read-only
+                                            configuration for the volume. Defaults
+                                            to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: volumeAttributes stores driver-specific
+                                            properties that are passed to the CSI
+                                            driver. Consult your driver's documentation
+                                            for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: 'Optional: mode bits to use
+                                            on created files by default. Must be a
+                                            Optional: mode bits used to set permissions
+                                            on created files by default. Must be an
+                                            octal value between 0000 and 0777 or a
+                                            decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. Defaults to 0644. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    emptyDir:
+                                      description: 'emptyDir represents a temporary
+                                        directory that shares a pod''s lifetime. More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      properties:
+                                        medium:
+                                          description: 'medium represents what type
+                                            of storage medium should back this directory.
+                                            The default is "" which means to use the
+                                            node''s default medium. Must be an empty
+                                            string (default) or Memory. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: 'sizeLimit is the total amount
+                                            of local storage required for this EmptyDir
+                                            volume. The size limit is also applicable
+                                            for memory medium. The maximum usage on
+                                            memory medium EmptyDir would be the minimum
+                                            value between the SizeLimit specified
+                                            here and the sum of memory limits of all
+                                            containers in a pod. The default is nil
+                                            which means that the limit is undefined.
+                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: |-
+                                        ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                        Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                        A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                            An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                            This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                            Required, must not be nil.
+                                          properties:
+                                            metadata:
+                                              description: May contain labels and
+                                                annotations that will be copied into
+                                                the PVC when creating it. No other
+                                                fields are allowed and will be rejected
+                                                during validation.
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            spec:
+                                              description: The specification for the
+                                                PersistentVolumeClaim. The entire
+                                                content is copied unchanged into the
+                                                PVC that gets created from this template.
+                                                The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: 'accessModes contains
+                                                    the desired access modes the volume
+                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dataSource:
+                                                  description: 'dataSource field can
+                                                    be used to specify either: * An
+                                                    existing VolumeSnapshot object
+                                                    (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    If the provisioner or an external
+                                                    controller can support the specified
+                                                    data source, it will create a
+                                                    new volume based on the contents
+                                                    of the specified data source.
+                                                    If the AnyVolumeDataSource feature
+                                                    gate is enabled, this field will
+                                                    always have the same contents
+                                                    as the DataSourceRef field.'
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                dataSourceRef:
+                                                  description: |-
+                                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                    * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                                      preserves all values, and generates an error if a disallowed value is
+                                                      specified.
+                                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                  properties:
+                                                    apiGroup:
+                                                      description: APIGroup is the
+                                                        group for the resource being
+                                                        referenced. If APIGroup is
+                                                        not specified, the specified
+                                                        Kind must be in the core API
+                                                        group. For any other third-party
+                                                        types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  description: 'resources represents
+                                                    the minimum resources the volume
+                                                    should have. If RecoverVolumeExpansionFailure
+                                                    feature is enabled users are allowed
+                                                    to specify resource requirements
+                                                    that are lower than previous value
+                                                    but must still be higher than
+                                                    capacity recorded in the status
+                                                    field of the claim. More info:
+                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Limits describes
+                                                        the maximum amount of compute
+                                                        resources allowed. More info:
+                                                        https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: 'Requests describes
+                                                        the minimum amount of compute
+                                                        resources required. If Requests
+                                                        is omitted for a container,
+                                                        it defaults to Limits if that
+                                                        is explicitly specified, otherwise
+                                                        to an implementation-defined
+                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label
+                                                    query over volumes to consider
+                                                    for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: A label selector
+                                                          requirement is a selector
+                                                          that contains values, a
+                                                          key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: operator
+                                                              represents a key's relationship
+                                                              to a set of values.
+                                                              Valid operators are
+                                                              In, NotIn, Exists and
+                                                              DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: values is
+                                                              an array of string values.
+                                                              If the operator is In
+                                                              or NotIn, the values
+                                                              array must be non-empty.
+                                                              If the operator is Exists
+                                                              or DoesNotExist, the
+                                                              values array must be
+                                                              empty. This array is
+                                                              replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: matchLabels is
+                                                        a map of {key,value} pairs.
+                                                        A single {key,value} in the
+                                                        matchLabels map is equivalent
+                                                        to an element of matchExpressions,
+                                                        whose key field is "key",
+                                                        the operator is "In", and
+                                                        the values array contains
+                                                        only "value". The requirements
+                                                        are ANDed.
+                                                      type: object
+                                                  type: object
+                                                storageClassName:
+                                                  description: 'storageClassName is
+                                                    the name of the StorageClass required
+                                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  type: string
+                                                volumeMode:
+                                                  description: volumeMode defines
+                                                    what type of volume is required
+                                                    by the claim. Value of Filesystem
+                                                    is implied when not included in
+                                                    claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target
+                                            lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: 'readOnly is Optional: Defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC
+                                            target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                        wwids:
+                                          description: 'wwids Optional: FC volume
+                                            world wide identifiers (wwids) Either
+                                            wwids or combination of targetWWNs and
+                                            lun must be set, but not both simultaneously.'
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    flexVolume:
+                                      description: flexVolume represents a generic
+                                        volume resource that is provisioned/attached
+                                        using an exec based plugin.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". The default filesystem
+                                            depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this
+                                            field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: 'readOnly is Optional: defaults
+                                            to false (read/write). ReadOnly here will
+                                            force the ReadOnly setting in VolumeMounts.'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is Optional: secretRef
+                                            is reference to the secret object containing
+                                            sensitive information to pass to the plugin
+                                            scripts. This may be empty if no secret
+                                            object is specified. If the secret object
+                                            contains more than one secret, all secrets
+                                            are passed to the plugin scripts.'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: flocker represents a Flocker volume
+                                        attached to a kubelet's host machine. This
+                                        depends on the Flocker control service being
+                                        running
+                                      properties:
+                                        datasetName:
+                                          description: datasetName is Name of the
+                                            dataset stored as metadata -> name on
+                                            the dataset for Flocker should be considered
+                                            as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of
+                                            the dataset. This is unique identifier
+                                            of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: 'gcePersistentDisk represents a
+                                        GCE Disk resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        partition:
+                                          description: 'partition is the partition
+                                            in the volume that you want to mount.
+                                            If omitted, the default is to mount by
+                                            volume name. Examples: For volume /dev/sda1,
+                                            you specify the partition as "1". Similarly,
+                                            the volume partition for /dev/sda is "0"
+                                            (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: 'pdName is unique name of the
+                                            PD resource in GCE. Used to identify the
+                                            disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: 'gitRepo represents a git repository
+                                        at a particular revision. DEPRECATED: GitRepo
+                                        is deprecated. To provision a container with
+                                        a git repo, mount an EmptyDir into an InitContainer
+                                        that clones the repo using git, then mount
+                                        the EmptyDir into the Pod''s container.'
+                                      properties:
+                                        directory:
+                                          description: directory is the target directory
+                                            name. Must not contain or start with '..'.  If
+                                            '.' is supplied, the volume directory
+                                            will be the git repository.  Otherwise,
+                                            if specified, the volume will contain
+                                            the git repository in the subdirectory
+                                            with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash
+                                            for the specified revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: 'glusterfs represents a Glusterfs
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      properties:
+                                        endpoints:
+                                          description: 'endpoints is the endpoint
+                                            name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        path:
+                                          description: 'path is the Glusterfs volume
+                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            Glusterfs volume to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: 'hostPath represents a pre-existing
+                                        file or directory on the host machine that
+                                        is directly exposed to the container. This
+                                        is generally used for system agents or other
+                                        privileged things that are allowed to see
+                                        the host machine. Most containers will NOT
+                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                      properties:
+                                        path:
+                                          description: 'path of the directory on the
+                                            host. If the path is a symlink, it will
+                                            follow the link to the real path. More
+                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                        type:
+                                          description: 'type for HostPath Volume Defaults
+                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    iscsi:
+                                      description: 'iscsi represents an ISCSI Disk
+                                        resource that is attached to a kubelet''s
+                                        host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether
+                                            support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether
+                                            support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                          type: string
+                                        initiatorName:
+                                          description: initiatorName is the custom
+                                            iSCSI Initiator Name. If initiatorName
+                                            is specified with iscsiInterface simultaneously,
+                                            new iSCSI interface <target portal>:<volume
+                                            name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified
+                                            Name.
+                                          type: string
+                                        iscsiInterface:
+                                          description: iscsiInterface is the interface
+                                            Name that uses an iSCSI transport. Defaults
+                                            to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target
+                                            Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: portals is the iSCSI Target
+                                            Portal List. The portal is either an IP
+                                            or ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret
+                                            for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        targetPortal:
+                                          description: targetPortal is iSCSI Target
+                                            Portal. The Portal is either an IP or
+                                            ip_addr:port if the port is other than
+                                            default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - targetPortal
+                                      - iqn
+                                      - lun
+                                      type: object
+                                    name:
+                                      description: 'name of the volume. Must be a
+                                        DNS_LABEL and unique within the pod. More
+                                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    nfs:
+                                      description: 'nfs represents an NFS mount on
+                                        the host that shares a pod''s lifetime More
+                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      properties:
+                                        path:
+                                          description: 'path that is exported by the
+                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            NFS export to be mounted with read-only
+                                            permissions. Defaults to false. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: boolean
+                                        server:
+                                          description: 'server is the hostname or
+                                            IP address of the NFS server. More info:
+                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          type: string
+                                      required:
+                                      - server
+                                      - path
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: 'persistentVolumeClaimVolumeSource
+                                        represents a reference to a PersistentVolumeClaim
+                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      properties:
+                                        claimName:
+                                          description: 'claimName is the name of a
+                                            PersistentVolumeClaim in the same namespace
+                                            as the pod using this volume. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Will force the ReadOnly
+                                            setting in VolumeMounts. Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: photonPersistentDisk represents
+                                        a PhotonController persistent disk attached
+                                        and mounted on kubelets host machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies
+                                            Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: portworxVolume represents a portworx
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fSType represents the filesystem
+                                            type to mount Must be a filesystem type
+                                            supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred
+                                            to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one
+                                        resources secrets, configmaps, and downward
+                                        API
+                                      properties:
+                                        defaultMode:
+                                          description: defaultMode are the mode bits
+                                            used to set permissions on created files
+                                            by default. Must be an octal value between
+                                            0000 and 0777 or a decimal value between
+                                            0 and 511. YAML accepts both octal and
+                                            decimal values, JSON requires decimal
+                                            values for mode bits. Directories within
+                                            the path are not affected by this setting.
+                                            This might be in conflict with other options
+                                            that affect the file mode, like fsGroup,
+                                            and the result can be other mode bits
+                                            set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: sources is the list of volume
+                                            projections
+                                          items:
+                                            description: Projection that may be projected
+                                              along with other supported volume types
+                                            properties:
+                                              configMap:
+                                                description: configMap information
+                                                  about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced ConfigMap
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the ConfigMap, the volume
+                                                      setup will error unless it is
+                                                      marked optional. Paths must
+                                                      be relative and may not contain
+                                                      the '..' path or start with
+                                                      '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify
+                                                      whether the ConfigMap or its
+                                                      keys must be defined
+                                                    type: boolean
+                                                type: object
+                                              downwardAPI:
+                                                description: downwardAPI information
+                                                  about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name and namespace
+                                                            are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                        mode:
+                                                          description: 'Optional:
+                                                            mode bits used to set
+                                                            permissions on this file,
+                                                            must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: 'Selects a
+                                                            resource of the container:
+                                                            only resources limits
+                                                            and requests (limits.cpu,
+                                                            limits.memory, requests.cpu
+                                                            and requests.memory) are
+                                                            currently supported.'
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                type: object
+                                              secret:
+                                                description: secret information about
+                                                  the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: items if unspecified,
+                                                      each key-value pair in the Data
+                                                      field of the referenced Secret
+                                                      will be projected into the volume
+                                                      as a file whose name is the
+                                                      key and content is the value.
+                                                      If specified, the listed keys
+                                                      will be projected into the specified
+                                                      paths, and unlisted keys will
+                                                      not be present. If a key is
+                                                      specified which is not present
+                                                      in the Secret, the volume setup
+                                                      will error unless it is marked
+                                                      optional. Paths must be relative
+                                                      and may not contain the '..'
+                                                      path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: 'mode is Optional:
+                                                            mode bits used to set
+                                                            permissions on this file.
+                                                            Must be an octal value
+                                                            between 0000 and 0777
+                                                            or a decimal value between
+                                                            0 and 511. YAML accepts
+                                                            both octal and decimal
+                                                            values, JSON requires
+                                                            decimal values for mode
+                                                            bits. If not specified,
+                                                            the volume defaultMode
+                                                            will be used. This might
+                                                            be in conflict with other
+                                                            options that affect the
+                                                            file mode, like fsGroup,
+                                                            and the result can be
+                                                            other mode bits set.'
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: path is the
+                                                            relative path of the file
+                                                            to map the key to. May
+                                                            not be an absolute path.
+                                                            May not contain the path
+                                                            element '..'. May not
+                                                            start with the string
+                                                            '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                  name:
+                                                    description: 'Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify
+                                                      whether the Secret or its key
+                                                      must be defined
+                                                    type: boolean
+                                                type: object
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is
+                                                  information about the serviceAccountToken
+                                                  data to project
+                                                properties:
+                                                  audience:
+                                                    description: audience is the intended
+                                                      audience of the token. A recipient
+                                                      of a token must identify itself
+                                                      with an identifier specified
+                                                      in the audience of the token,
+                                                      and otherwise should reject
+                                                      the token. The audience defaults
+                                                      to the identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: expirationSeconds
+                                                      is the requested duration of
+                                                      validity of the service account
+                                                      token. As the token approaches
+                                                      expiration, the kubelet volume
+                                                      plugin will proactively rotate
+                                                      the service account token. The
+                                                      kubelet will start trying to
+                                                      rotate the token if the token
+                                                      is older than 80 percent of
+                                                      its time to live or if the token
+                                                      is older than 24 hours.Defaults
+                                                      to 1 hour and must be at least
+                                                      10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: path is the path
+                                                      relative to the mount point
+                                                      of the file to project the token
+                                                      into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    quobyte:
+                                      description: quobyte represents a Quobyte mount
+                                        on the host that shares a pod's lifetime
+                                      properties:
+                                        group:
+                                          description: group to map volume access
+                                            to Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: readOnly here will force the
+                                            Quobyte volume to be mounted with read-only
+                                            permissions. Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: registry represents a single
+                                            or multiple Quobyte Registry services
+                                            specified as a string as host:port pair
+                                            (multiple entries are separated with commas)
+                                            which acts as the central registry for
+                                            volumes
+                                          type: string
+                                        tenant:
+                                          description: tenant owning the given Quobyte
+                                            volume in the Backend Used with dynamically
+                                            provisioned Quobyte volumes, value is
+                                            set by the plugin
+                                          type: string
+                                        user:
+                                          description: user to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: 'rbd represents a Rados Block Device
+                                        mount on the host that shares a pod''s lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      properties:
+                                        fsType:
+                                          description: 'fsType is the filesystem type
+                                            of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is
+                                            supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly
+                                            inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                          type: string
+                                        image:
+                                          description: 'image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        keyring:
+                                          description: 'keyring is the path to key
+                                            ring for RBDUser. Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        monitors:
+                                          description: 'monitors is a collection of
+                                            Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          items:
+                                            type: string
+                                          type: array
+                                        pool:
+                                          description: 'pool is the rados pool name.
+                                            Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                        readOnly:
+                                          description: 'readOnly here will force the
+                                            ReadOnly setting in VolumeMounts. Defaults
+                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: boolean
+                                        secretRef:
+                                          description: 'secretRef is name of the authentication
+                                            secret for RBDUser. If provided overrides
+                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        user:
+                                          description: 'user is the rados user name.
+                                            Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          type: string
+                                      required:
+                                      - monitors
+                                      - image
+                                      type: object
+                                    scaleIO:
+                                      description: scaleIO represents a ScaleIO persistent
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address
+                                            of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name
+                                            of the ScaleIO Protection Domain for the
+                                            configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly Defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef references to the
+                                            secret for ScaleIO user and other sensitive
+                                            information. If this is not provided,
+                                            Login operation will fail.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable
+                                            SSL communication with Gateway, default
+                                            false
+                                          type: boolean
+                                        storageMode:
+                                          description: storageMode indicates whether
+                                            the storage for a volume should be ThickProvisioned
+                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO
+                                            Storage Pool associated with the protection
+                                            domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage
+                                            system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the name of a
+                                            volume already created in the ScaleIO
+                                            system that is associated with this volume
+                                            source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - system
+                                      - secretRef
+                                      type: object
+                                    secret:
+                                      description: 'secret represents a secret that
+                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      properties:
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: 'secretName is the name of
+                                            the secret in the pod''s namespace to
+                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: storageOS represents a StorageOS
+                                        volume attached and mounted on Kubernetes
+                                        nodes.
+                                      properties:
+                                        fsType:
+                                          description: fsType is the filesystem type
+                                            to mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly defaults to false
+                                            (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef specifies the secret
+                                            to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default
+                                            values will be attempted.
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                          type: object
+                                        volumeName:
+                                          description: volumeName is the human-readable
+                                            name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: volumeNamespace specifies the
+                                            scope of the volume within StorageOS.  If
+                                            no namespace is specified then the Pod's
+                                            namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored
+                                            within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override
+                                            the default behaviour. Set to "default"
+                                            if you are not using namespaces within
+                                            StorageOS. Namespaces that do not pre-exist
+                                            within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: vsphereVolume represents a vSphere
+                                        volume attached and mounted on kubelets host
+                                        machine
+                                      properties:
+                                        fsType:
+                                          description: fsType is filesystem type to
+                                            mount. Must be a filesystem type supported
+                                            by the host operating system. Ex. "ext4",
+                                            "xfs", "ntfs". Implicitly inferred to
+                                            be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage
+                                            Policy Based Management (SPBM) profile
+                                            ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage
+                                            Policy Based Management (SPBM) profile
+                                            name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that
+                                            identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        description: ttlSecondsAfterFinished limits the lifetime of
+                          a Job that has finished execution (either Complete or Failed).
+                          If this field is set, ttlSecondsAfterFinished after the
+                          Job finishes, it is eligible to be automatically deleted.
+                          When the Job is being deleted, its lifecycle guarantees
+                          (e.g. finalizers) will be honored. If this field is unset,
+                          the Job won't be automatically deleted. If this field is
+                          set to zero, the Job becomes eligible to be deleted immediately
+                          after it finishes.
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              schedule:
+                description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+              startingDeadlineSeconds:
+                description: Optional deadline in seconds for starting the job if
+                  it misses scheduled time for any reason.  Missed jobs executions
+                  will be counted as failed ones.
+                format: int64
+                type: integer
+              successfulJobsHistoryLimit:
+                description: The number of successful finished jobs to retain. Value
+                  must be non-negative integer. Defaults to 3.
+                format: int32
+                type: integer
+              suspend:
+                description: This flag tells the controller to suspend subsequent
+                  executions, it does not apply to already started executions.  Defaults
+                  to false.
+                type: boolean
+              timeZone:
+                description: The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+                  If not specified, this will default to the time zone of the kube-controller-manager
+                  process. The set of valid time zone names and the time zone offset
+                  is loaded from the system-wide time zone database by the API server
+                  during CronJob validation and the controller manager during execution.
+                  If no system-wide time zone database can be found a bundled version
+                  of the database is used instead. If the time zone name becomes invalid
+                  during the lifetime of a CronJob or due to a change in host configuration,
+                  the controller will stop creating new new Jobs and will create a
+                  system event with the reason UnknownTimeZone. More information can
+                  be found in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+                  This is beta field and must be enabled via the `CronJobTimeZone`
+                  feature gate.
+                type: string
+            required:
+            - schedule
+            - jobTemplate
+            type: object
+          status:
+            description: 'Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              active:
+                description: A list of pointers to currently running jobs.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              lastScheduleTime:
+                description: Information when was the last time the job was successfully
+                  scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: Information when was the last time the job successfully
+                  completed.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/batch_jobs.yaml
+++ b/config/kube/crds/namespaced/batch_jobs.yaml
@@ -1,0 +1,7507 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: jobs.batch
+spec:
+  conversion:
+    strategy: None
+  group: batch
+  names:
+    categories:
+    - all
+    kind: Job
+    listKind: JobList
+    plural: jobs
+    singular: job
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Job represents the configuration of a single job.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of a job. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              activeDeadlineSeconds:
+                description: Specifies the duration in seconds relative to the startTime
+                  that the job may be continuously active before the system tries
+                  to terminate it; value must be positive integer. If a Job is suspended
+                  (at creation or through an update), this timer will effectively
+                  be stopped and reset when the Job is resumed again.
+                format: int64
+                type: integer
+              backoffLimit:
+                description: Specifies the number of retries before marking this job
+                  failed. Defaults to 6
+                format: int32
+                type: integer
+              completionMode:
+                description: |-
+                  CompletionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+                  `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+                  `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                  More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+                type: string
+              completions:
+                description: 'Specifies the desired number of successfully finished
+                  pods the job should be run with.  Setting to nil means that the
+                  success of any pod signals the success of all pods, and allows parallelism
+                  to have any positive value.  Setting to 1 means that parallelism
+                  is limited to 1 and the success of that pod signals the success
+                  of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                format: int32
+                type: integer
+              manualSelector:
+                description: 'manualSelector controls generation of pod labels and
+                  pod selectors. Leave `manualSelector` unset unless you are certain
+                  what you are doing. When false or unset, the system pick labels
+                  unique to this job and appends those labels to the pod template.  When
+                  true, the user is responsible for picking unique labels and specifying
+                  the selector.  Failure to pick a unique label may cause this and
+                  other jobs to not function correctly.  However, You may see `manualSelector=true`
+                  in jobs that were created with the old `extensions/v1beta1` API.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+                type: boolean
+              parallelism:
+                description: 'Specifies the maximum desired number of pods the job
+                  should run at any given time. The actual number of pods running
+                  in steady state will be less than this number when ((.spec.completions
+                  - .status.successful) < .spec.parallelism), i.e. when the work left
+                  to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                format: int32
+                type: integer
+              podFailurePolicy:
+                description: |-
+                  Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+                  This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+                properties:
+                  rules:
+                    description: A list of pod failure policy rules. The rules are
+                      evaluated in order. Once a rule matches a Pod failure, the remaining
+                      of the rules are ignored. When no rule matches the Pod failure,
+                      the default handling applies - the counter of pod failures is
+                      incremented and it is checked against the backoffLimit. At most
+                      20 elements are allowed.
+                    items:
+                      description: PodFailurePolicyRule describes how a pod failure
+                        is handled when the requirements are met. One of OnExitCodes
+                        and onPodConditions, but not both, can be used in each rule.
+                      properties:
+                        action:
+                          description: |-
+                            Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: - FailJob: indicates that the pod's job is marked as Failed and all
+                              running pods are terminated.
+                            - Ignore: indicates that the counter towards the .backoffLimit is not
+                              incremented and a replacement pod is created.
+                            - Count: indicates that the pod is handled in the default way - the
+                              counter towards the .backoffLimit is incremented.
+                            Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+
+                            Possible enum values:
+                             - `"Count"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.
+                             - `"FailJob"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.
+                             - `"Ignore"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.
+                          type: string
+                        onExitCodes:
+                          description: Represents the requirement on the container
+                            exit codes.
+                          properties:
+                            containerName:
+                              description: Restricts the check for exit codes to the
+                                container with the specified name. When null, the
+                                rule applies to all containers. When specified, it
+                                should match one the container or initContainer names
+                                in the pod template.
+                              type: string
+                            operator:
+                              description: |-
+                                Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: - In: the requirement is satisfied if at least one container exit code
+                                  (might be multiple if there are multiple containers not restricted
+                                  by the 'containerName' field) is in the set of specified values.
+                                - NotIn: the requirement is satisfied if at least one container exit code
+                                  (might be multiple if there are multiple containers not restricted
+                                  by the 'containerName' field) is not in the set of specified values.
+                                Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+
+                                Possible enum values:
+                                 - `"In"`
+                                 - `"NotIn"`
+                              type: string
+                            values:
+                              description: Specifies the set of values. Each returned
+                                container exit code (might be multiple in case of
+                                multiple containers) is checked against this set of
+                                values with respect to the operator. The list of values
+                                must be ordered and must not contain duplicates. Value
+                                '0' cannot be used for the In operator. At least one
+                                element is required. At most 255 elements are allowed.
+                              items:
+                                format: int32
+                                type: integer
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                          - operator
+                          - values
+                          type: object
+                        onPodConditions:
+                          description: Represents the requirement on the pod conditions.
+                            The requirement is represented as a list of pod condition
+                            patterns. The requirement is satisfied if at least one
+                            pattern matches an actual pod condition. At most 20 elements
+                            are allowed.
+                          items:
+                            description: PodFailurePolicyOnPodConditionsPattern describes
+                              a pattern for matching an actual pod condition type.
+                            properties:
+                              status:
+                                description: Specifies the required Pod condition
+                                  status. To match a pod condition it is required
+                                  that the specified status equals the pod condition
+                                  status. Defaults to True.
+                                type: string
+                              type:
+                                description: Specifies the required Pod condition
+                                  type. To match a pod condition it is required that
+                                  specified type equals the pod condition type.
+                                type: string
+                            required:
+                            - type
+                            - status
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - action
+                      - onPodConditions
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - rules
+                type: object
+              selector:
+                description: 'A label query over pods that should match the pod count.
+                  Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              suspend:
+                description: Suspend specifies whether the Job controller should create
+                  Pods or not. If a Job is created with suspend set to true, no Pods
+                  are created by the Job controller. If a Job is suspended after creation
+                  (i.e. the flag goes from false to true), the Job controller will
+                  delete all active Pods associated with this Job. Users must design
+                  their workload to gracefully handle this. Suspending a Job will
+                  reset the StartTime field of the Job, effectively resetting the
+                  ActiveDeadlineSeconds timer too. Defaults to false.
+                type: boolean
+              template:
+                description: 'Describes the pod that will be created when executing
+                  a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - preference
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                          Possible enum values:
+                           - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                           - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Optional: SecurityContext defines the
+                                security options the ephemeral container should be
+                                run with. If set, the fields of SecurityContext override
+                                the equivalent fields of PodSecurityContext.'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Subpath mounts are not allowed for ephemeral
+                                containers. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostUsers:
+                        description: 'Use the host''s user namespace. Optional: Default
+                          to true. If set to true or not present, the pod will be
+                          run in the host user namespace, useful for when the pod
+                          needs a feature only available to the host user namespace,
+                          such as loading a kernel module with CAP_SYS_MODULE. When
+                          set to false, a new userns is created for the pod. Setting
+                          false is useful for mitigating container breakout vulnerabilities
+                          even allowing users to run their containers as root without
+                          actually having root privileges on the host. This field
+                          is alpha-level and is only honored by servers that enable
+                          the UserNamespacesSupport feature.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                          Possible enum values:
+                           - `"Always"`
+                           - `"Never"`
+                           - `"OnFailure"`
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      setHostnameAsFQDN:
+                        description: If true the pod's hostname will be configured
+                          as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                Possible enum values:
+                                 - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                 - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                 - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                Possible enum values:
+                                 - `"Equal"`
+                                 - `"Exists"`
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                Possible enum values:
+                                 - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                 - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - targetPortal
+                              - iqn
+                              - lun
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - server
+                              - path
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              - image
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - system
+                              - secretRef
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+              ttlSecondsAfterFinished:
+                description: ttlSecondsAfterFinished limits the lifetime of a Job
+                  that has finished execution (either Complete or Failed). If this
+                  field is set, ttlSecondsAfterFinished after the Job finishes, it
+                  is eligible to be automatically deleted. When the Job is being deleted,
+                  its lifecycle guarantees (e.g. finalizers) will be honored. If this
+                  field is unset, the Job won't be automatically deleted. If this
+                  field is set to zero, the Job becomes eligible to be deleted immediately
+                  after it finishes.
+                format: int32
+                type: integer
+            required:
+            - template
+            type: object
+          status:
+            description: 'Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              active:
+                description: The number of pending and running pods.
+                format: int32
+                type: integer
+              completedIndexes:
+                description: CompletedIndexes holds the completed indexes when .spec.completionMode
+                  = "Indexed" in a text format. The indexes are represented as decimal
+                  integers separated by commas. The numbers are listed in increasing
+                  order. Three or more consecutive numbers are compressed and represented
+                  by the first and last element of the series, separated by a hyphen.
+                  For example, if the completed indexes are 1, 3, 4, 5 and 7, they
+                  are represented as "1,3-5,7".
+                type: string
+              completionTime:
+                description: Represents time when the job was completed. It is not
+                  guaranteed to be set in happens-before order across separate operations.
+                  It is represented in RFC3339 form and is in UTC. The completion
+                  time is only set when the job finishes successfully.
+                format: date-time
+                type: string
+              conditions:
+                description: 'The latest available observations of an object''s current
+                  state. When a Job fails, one of the conditions will have type "Failed"
+                  and status true. When a Job is suspended, one of the conditions
+                  will have type "Suspended" and status true; when the Job is resumed,
+                  the status of this condition will become false. When a Job is completed,
+                  one of the conditions will have type "Complete" and status true.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                items:
+                  description: JobCondition describes current state of a job.
+                  properties:
+                    lastProbeTime:
+                      description: Last time the condition was checked.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of job condition, Complete or Failed.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failed:
+                description: The number of pods which reached phase Failed.
+                format: int32
+                type: integer
+              ready:
+                description: |-
+                  The number of pods which have a Ready condition.
+
+                  This field is beta-level. The job controller populates the field when the feature gate JobReadyPods is enabled (enabled by default).
+                format: int32
+                type: integer
+              startTime:
+                description: Represents time when the job controller started processing
+                  a job. When a Job is created in the suspended state, this field
+                  is not set until the first time it is resumed. This field is reset
+                  every time a Job is resumed from suspension. It is represented in
+                  RFC3339 form and is in UTC.
+                format: date-time
+                type: string
+              succeeded:
+                description: The number of pods which reached phase Succeeded.
+                format: int32
+                type: integer
+              uncountedTerminatedPods:
+                description: |-
+                  UncountedTerminatedPods holds the UIDs of Pods that have terminated but the job controller hasn't yet accounted for in the status counters.
+
+                  The job controller creates pods with a finalizer. When a pod terminates (succeeded or failed), the controller does three steps to account for it in the job status: (1) Add the pod UID to the arrays in this field. (2) Remove the pod finalizer. (3) Remove the pod UID from the arrays while increasing the corresponding
+                      counter.
+
+                  This field is beta-level. The job controller only makes use of this field when the feature gate JobTrackingWithFinalizers is enabled (enabled by default). Old jobs might not be tracked using this field, in which case the field remains null.
+                properties:
+                  failed:
+                    description: Failed holds UIDs of failed Pods.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  succeeded:
+                    description: Succeeded holds UIDs of succeeded Pods.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/core.k8s.io_endpoints.yaml
+++ b/config/kube/crds/namespaced/core.k8s.io_endpoints.yaml
@@ -1,0 +1,228 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: endpoints.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    kind: Endpoints
+    listKind: EndpointsList
+    plural: endpoints
+    shortNames:
+    - ep
+    singular: endpoints
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Endpoints is a collection of endpoints that implement the actual
+          service. Example:\n\n\t Name: \"mysvc\",\n\t Subsets: [\n\t   {\n\t     Addresses:
+          [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n\t     Ports: [{\"name\":
+          \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n\t   },\n\t   {\n\t
+          \    Addresses: [{\"ip\": \"10.10.3.3\"}],\n\t     Ports: [{\"name\": \"a\",
+          \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n\t   },\n\t]"
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          subsets:
+            description: The set of all endpoints is the union of all subsets. Addresses
+              are placed into subsets according to the IPs they share. A single address
+              with multiple ports, some of which are ready and some of which are not
+              (because they come from different containers) will result in the address
+              being displayed in different subsets for the different ports. No address
+              will appear in both Addresses and NotReadyAddresses in the same subset.
+              Sets of addresses and ports that comprise a service.
+            items:
+              description: "EndpointSubset is a group of addresses with a common set
+                of ports. The expanded set of endpoints is the Cartesian product of
+                Addresses x Ports. For example, given:\n\n\t{\n\t  Addresses: [{\"ip\":
+                \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n\t  Ports:     [{\"name\":
+                \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n\t}\n\nThe
+                resulting set of endpoints can be viewed as:\n\n\ta: [ 10.10.1.1:8675,
+                10.10.2.2:8675 ],\n\tb: [ 10.10.1.1:309, 10.10.2.2:309 ]"
+              properties:
+                addresses:
+                  description: IP addresses which offer the related ports that are
+                    marked as ready. These endpoints should be considered safe for
+                    load balancers and clients to utilize.
+                  items:
+                    description: EndpointAddress is a tuple that describes single
+                      IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: The IP of this endpoint. May not be loopback
+                          (127.0.0.0/8), link-local (169.254.0.0/16), or link-local
+                          multicast ((224.0.0.0/24). IPv6 is also accepted but not
+                          fully supported on all platforms. Also, certain kubernetes
+                          components, like kube-proxy, are not IPv6 ready.
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can
+                          be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                notReadyAddresses:
+                  description: IP addresses which offer the related ports but are
+                    not currently marked as ready because they have not yet finished
+                    starting, have recently failed a readiness check, or have recently
+                    failed a liveness check.
+                  items:
+                    description: EndpointAddress is a tuple that describes single
+                      IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: The IP of this endpoint. May not be loopback
+                          (127.0.0.0/8), link-local (169.254.0.0/16), or link-local
+                          multicast ((224.0.0.0/24). IPv6 is also accepted but not
+                          fully supported on all platforms. Also, certain kubernetes
+                          components, like kube-proxy, are not IPv6 ready.
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can
+                          be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead
+                              of an entire object, this string should contain a valid
+                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container
+                              within a pod, this would take on a value like: "spec.containers{name}"
+                              (where "name" refers to the name of the container that
+                              triggered the event) or if no container name is specified
+                              "spec.containers[2]" (container with index 2 in this
+                              pod). This syntax is chosen only to have some well-defined
+                              way of referencing a part of an object.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference
+                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                ports:
+                  description: Port numbers available on the related IP addresses.
+                  items:
+                    description: EndpointPort is a tuple that describes a single port.
+                    properties:
+                      appProtocol:
+                        description: The application protocol for this port. This
+                          field follows standard Kubernetes label syntax. Un-prefixed
+                          names are reserved for IANA standard service names (as per
+                          RFC-6335 and https://www.iana.org/assignments/service-names).
+                          Non-standard protocols should use prefixed names such as
+                          mycompany.com/my-custom-protocol.
+                        type: string
+                      name:
+                        description: The name of this port.  This must match the 'name'
+                          field in the corresponding ServicePort. Must be a DNS_LABEL.
+                          Optional only if one port is defined.
+                        type: string
+                      port:
+                        description: The port number of the endpoint.
+                        format: int32
+                        type: integer
+                      protocol:
+                        description: |-
+                          The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+
+                          Possible enum values:
+                           - `"SCTP"` is the SCTP protocol.
+                           - `"TCP"` is the TCP protocol.
+                           - `"UDP"` is the UDP protocol.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  type: array
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/core.k8s.io_persistentvolumeclaims.yaml
+++ b/config/kube/crds/namespaced/core.k8s.io_persistentvolumeclaims.yaml
@@ -1,0 +1,293 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: persistentvolumeclaims.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    kind: PersistentVolumeClaim
+    listKind: PersistentVolumeClaimList
+    plural: persistentvolumeclaims
+    shortNames:
+    - pvc
+    singular: persistentvolumeclaim
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PersistentVolumeClaim is a user's request for and claim to a
+          persistent volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'spec defines the desired characteristics of a volume requested
+              by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+            properties:
+              accessModes:
+                description: 'accessModes contains the desired access modes the volume
+                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                items:
+                  type: string
+                type: array
+              dataSource:
+                description: 'dataSource field can be used to specify either: * An
+                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                  * An existing PVC (PersistentVolumeClaim) If the provisioner or
+                  an external controller can support the specified data source, it
+                  will create a new volume based on the contents of the specified
+                  data source. If the AnyVolumeDataSource feature gate is enabled,
+                  this field will always have the same contents as the DataSourceRef
+                  field.'
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              dataSourceRef:
+                description: |-
+                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                  * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                    preserves all values, and generates an error if a disallowed value is
+                    specified.
+                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              resources:
+                description: 'resources represents the minimum resources the volume
+                  should have. If RecoverVolumeExpansionFailure feature is enabled
+                  users are allowed to specify resource requirements that are lower
+                  than previous value but must still be higher than capacity recorded
+                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              selector:
+                description: selector is a label query over volumes to consider for
+                  binding.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              storageClassName:
+                description: 'storageClassName is the name of the StorageClass required
+                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                type: string
+              volumeMode:
+                description: volumeMode defines what type of volume is required by
+                  the claim. Value of Filesystem is implied when not included in claim
+                  spec.
+                type: string
+              volumeName:
+                description: volumeName is the binding reference to the PersistentVolume
+                  backing this claim.
+                type: string
+            type: object
+          status:
+            description: 'status represents the current information/status of a persistent
+              volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+            properties:
+              accessModes:
+                description: 'accessModes contains the actual access modes the volume
+                  backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                items:
+                  type: string
+                type: array
+              allocatedResources:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: allocatedResources is the storage resource within AllocatedResources
+                  tracks the capacity allocated to a PVC. It may be larger than the
+                  actual capacity when a volume expansion operation is requested.
+                  For storage quota, the larger value from allocatedResources and
+                  PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources
+                  alone is used for quota calculation. If a volume expansion capacity
+                  request is lowered, allocatedResources is only lowered if there
+                  are no expansion operations in progress and if the actual volume
+                  capacity is equal or lower than the requested capacity. This is
+                  an alpha field and requires enabling RecoverVolumeExpansionFailure
+                  feature.
+                type: object
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: capacity represents the actual resources of the underlying
+                  volume.
+                type: object
+              conditions:
+                description: conditions is the current Condition of persistent volume
+                  claim. If underlying persistent volume is being resized then the
+                  Condition will be set to 'ResizeStarted'.
+                items:
+                  description: PersistentVolumeClaimCondition contails details about
+                    state of pvc
+                  properties:
+                    lastProbeTime:
+                      description: lastProbeTime is the time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time the condition transitioned
+                        from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is the human-readable message indicating
+                        details about last transition.
+                      type: string
+                    reason:
+                      description: reason is a unique, this should be a short, machine
+                        understandable string that gives the reason for condition's
+                        last transition. If it reports "ResizeStarted" that means
+                        the underlying persistent volume is being resized.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              phase:
+                description: |-
+                  phase represents the current phase of PersistentVolumeClaim.
+
+                  Possible enum values:
+                   - `"Bound"` used for PersistentVolumeClaims that are bound
+                   - `"Lost"` used for PersistentVolumeClaims that lost their underlying PersistentVolume. The claim was bound to a PersistentVolume and this volume does not exist any longer and all data on it was lost.
+                   - `"Pending"` used for PersistentVolumeClaims that are not yet bound
+                type: string
+              resizeStatus:
+                description: resizeStatus stores status of resize operation. ResizeStatus
+                  is not set by default but when expansion is complete resizeStatus
+                  is set to empty string by resize controller or kubelet. This is
+                  an alpha field and requires enabling RecoverVolumeExpansionFailure
+                  feature.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/core.k8s.io_podtemplates.yaml
+++ b/config/kube/crds/namespaced/core.k8s.io_podtemplates.yaml
@@ -1,0 +1,6915 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: podtemplates.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    kind: PodTemplate
+    listKind: PodTemplateList
+    plural: podtemplates
+    singular: podtemplate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PodTemplate describes a template for creating copies of a predefined
+          pod.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          template:
+            description: Template defines the pods that will be created from this
+              pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              metadata:
+                description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              spec:
+                description: 'Specification of the desired behavior of the pod. More
+                  info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                properties:
+                  activeDeadlineSeconds:
+                    description: Optional duration in seconds the pod may be active
+                      on the node relative to StartTime before the system will actively
+                      try to mark it failed and kill associated containers. Value
+                      must be a positive integer.
+                    format: int64
+                    type: integer
+                  affinity:
+                    description: If specified, the pod's scheduling constraints
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - preference
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                              Possible enum values:
+                                               - `"DoesNotExist"`
+                                               - `"Exists"`
+                                               - `"Gt"`
+                                               - `"In"`
+                                               - `"Lt"`
+                                               - `"NotIn"`
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - weight
+                              - podAffinityTerm
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  automountServiceAccountToken:
+                    description: AutomountServiceAccountToken indicates whether a
+                      service account token should be automatically mounted.
+                    type: boolean
+                  containers:
+                    description: List of containers belonging to the pod. Containers
+                      cannot currently be added or removed. There must be at least
+                      one container in a Pod. Cannot be updated.
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  dnsConfig:
+                    description: Specifies the DNS parameters of a pod. Parameters
+                      specified here will be merged to the generated DNS configuration
+                      based on DNSPolicy.
+                    properties:
+                      nameservers:
+                        description: A list of DNS name server IP addresses. This
+                          will be appended to the base nameservers generated from
+                          DNSPolicy. Duplicated nameservers will be removed.
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        description: A list of DNS resolver options. This will be
+                          merged with the base options generated from DNSPolicy. Duplicated
+                          entries will be removed. Resolution options given in Options
+                          will override those that appear in the base DNSPolicy.
+                        items:
+                          description: PodDNSConfigOption defines DNS resolver options
+                            of a pod.
+                          properties:
+                            name:
+                              description: Required.
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      searches:
+                        description: A list of DNS search domains for host-name lookup.
+                          This will be appended to the base search paths generated
+                          from DNSPolicy. Duplicated search paths will be removed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  dnsPolicy:
+                    description: |-
+                      Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                      Possible enum values:
+                       - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                       - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                       - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                    type: string
+                  enableServiceLinks:
+                    description: 'EnableServiceLinks indicates whether information
+                      about services should be injected into pod''s environment variables,
+                      matching the syntax of Docker links. Optional: Defaults to true.'
+                    type: boolean
+                  ephemeralContainers:
+                    description: List of ephemeral containers run in this pod. Ephemeral
+                      containers may be run in an existing pod to perform user-initiated
+                      actions such as debugging. This list cannot be specified when
+                      creating a pod, and it cannot be modified by updating the pod
+                      spec. In order to add an ephemeral container to an existing
+                      pod, use the pod's ephemeralcontainers subresource.
+                    items:
+                      description: |-
+                        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The image''s
+                            CMD is used if this is not provided. Variable references
+                            $(VAR_NAME) are expanded using the container''s environment.
+                            If a variable cannot be resolved, the reference in the
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Lifecycle is not allowed for ephemeral containers.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the ephemeral container specified as
+                            a DNS_LABEL. This name must be unique among all containers,
+                            init containers and ephemeral containers.
+                          type: string
+                        ports:
+                          description: Ports are not allowed for ephemeral containers.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Resources are not allowed for ephemeral containers.
+                            Ephemeral containers use spare resources already allocated
+                            to the pod.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Probes are not allowed for ephemeral containers.
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        targetContainerName:
+                          description: |-
+                            If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                            The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                          type: string
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  hostAliases:
+                    description: HostAliases is an optional list of hosts and IPs
+                      that will be injected into the pod's hosts file if specified.
+                      This is only valid for non-hostNetwork pods.
+                    items:
+                      description: HostAlias holds the mapping between IP and hostnames
+                        that will be injected as an entry in the pod's hosts file.
+                      properties:
+                        hostnames:
+                          description: Hostnames for the above IP address.
+                          items:
+                            type: string
+                          type: array
+                        ip:
+                          description: IP address of the host file entry.
+                          type: string
+                      required:
+                      - ip
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - ip
+                    x-kubernetes-list-type: map
+                  hostIPC:
+                    description: 'Use the host''s ipc namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostNetwork:
+                    description: Host networking requested for this pod. Use the host's
+                      network namespace. If this option is set, the ports that will
+                      be used must be specified. Default to false.
+                    type: boolean
+                  hostPID:
+                    description: 'Use the host''s pid namespace. Optional: Default
+                      to false.'
+                    type: boolean
+                  hostUsers:
+                    description: 'Use the host''s user namespace. Optional: Default
+                      to true. If set to true or not present, the pod will be run
+                      in the host user namespace, useful for when the pod needs a
+                      feature only available to the host user namespace, such as loading
+                      a kernel module with CAP_SYS_MODULE. When set to false, a new
+                      userns is created for the pod. Setting false is useful for mitigating
+                      container breakout vulnerabilities even allowing users to run
+                      their containers as root without actually having root privileges
+                      on the host. This field is alpha-level and is only honored by
+                      servers that enable the UserNamespacesSupport feature.'
+                    type: boolean
+                  hostname:
+                    description: Specifies the hostname of the Pod If not specified,
+                      the pod's hostname will be set to a system-defined value.
+                    type: string
+                  imagePullSecrets:
+                    description: 'ImagePullSecrets is an optional list of references
+                      to secrets in the same namespace to use for pulling any of the
+                      images used by this PodSpec. If specified, these secrets will
+                      be passed to individual puller implementations for them to use.
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  initContainers:
+                    description: 'List of initialization containers belonging to the
+                      pod. Init containers are executed in order prior to containers
+                      being started. If any init container fails, the pod is considered
+                      to have failed and is handled according to its restartPolicy.
+                      The name for an init container or normal container must be unique
+                      among all containers. Init containers may not have Lifecycle
+                      actions, Readiness probes, Liveness probes, or Startup probes.
+                      The resourceRequirements of an init container are taken into
+                      account during scheduling by finding the highest request/limit
+                      for each resource type, and then using the max of of that value
+                      or the sum of the normal containers. Limits are applied to init
+                      containers in a similar fashion. Init containers cannot currently
+                      be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                            Possible enum values:
+                             - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                             - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                             - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                  Possible enum values:
+                                   - `"SCTP"` is the SCTP protocol.
+                                   - `"TCP"` is the TCP protocol.
+                                   - `"UDP"` is the UDP protocol.
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                    Possible enum values:
+                                     - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                     - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                     - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                    Possible enum values:
+                                     - `"HTTP"` means that the scheme used will be http://
+                                     - `"HTTPS"` means that the scheme used will be https://
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                            Possible enum values:
+                             - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                             - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  nodeName:
+                    description: NodeName is a request to schedule this pod onto a
+                      specific node. If it is non-empty, the scheduler simply schedules
+                      this pod onto that node, assuming that it fits resource requirements.
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is a selector which must be true for
+                      the pod to fit on a node. Selector which must match a node''s
+                      labels for the pod to be scheduled on that node. More info:
+                      https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  os:
+                    description: |-
+                      Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                      If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                      If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  overhead:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Overhead represents the resource overhead associated
+                      with running a pod for a given RuntimeClass. This field will
+                      be autopopulated at admission time by the RuntimeClass admission
+                      controller. If the RuntimeClass admission controller is enabled,
+                      overhead must not be set in Pod create requests. The RuntimeClass
+                      admission controller will reject Pod create requests which have
+                      the overhead already set. If RuntimeClass is configured and
+                      selected in the PodSpec, Overhead will be set to the value defined
+                      in the corresponding RuntimeClass, otherwise it will remain
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                    type: object
+                  preemptionPolicy:
+                    description: PreemptionPolicy is the Policy for preempting pods
+                      with lower priority. One of Never, PreemptLowerPriority. Defaults
+                      to PreemptLowerPriority if unset.
+                    type: string
+                  priority:
+                    description: The priority value. Various system components use
+                      this field to find the priority of the pod. When Priority Admission
+                      Controller is enabled, it prevents users from setting this field.
+                      The admission controller populates this field from PriorityClassName.
+                      The higher the value, the higher the priority.
+                    format: int32
+                    type: integer
+                  priorityClassName:
+                    description: If specified, indicates the pod's priority. "system-node-critical"
+                      and "system-cluster-critical" are two special keywords which
+                      indicate the highest priorities with the former being the highest
+                      priority. Any other name must be defined by creating a PriorityClass
+                      object with that name. If not specified, the pod priority will
+                      be default or zero if there is no default.
+                    type: string
+                  readinessGates:
+                    description: 'If specified, all readiness gates will be evaluated
+                      for pod readiness. A pod is ready when all its containers are
+                      ready AND all conditions specified in the readiness gates have
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                    items:
+                      description: PodReadinessGate contains the reference to a pod
+                        condition
+                      properties:
+                        conditionType:
+                          description: ConditionType refers to a condition in the
+                            pod's condition list with matching type.
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    type: array
+                  restartPolicy:
+                    description: |-
+                      Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                      Possible enum values:
+                       - `"Always"`
+                       - `"Never"`
+                       - `"OnFailure"`
+                    type: string
+                  runtimeClassName:
+                    description: 'RuntimeClassName refers to a RuntimeClass object
+                      in the node.k8s.io group, which should be used to run this pod.  If
+                      no RuntimeClass resource matches the named class, the pod will
+                      not be run. If unset or empty, the "legacy" RuntimeClass will
+                      be used, which is an implicit class with an empty definition
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                    type: string
+                  schedulerName:
+                    description: If specified, the pod will be dispatched by specified
+                      scheduler. If not specified, the pod will be dispatched by default
+                      scheduler.
+                    type: string
+                  securityContext:
+                    description: 'SecurityContext holds pod-level security attributes
+                      and common container settings. Optional: Defaults to empty.  See
+                      type description for default values of each field.'
+                    properties:
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in SecurityContext.  If set
+                          in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                              Possible enum values:
+                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process
+                          run in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers. If unspecified, the options within a container's
+                          SecurityContext will be used. If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in
+                              PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccount:
+                    description: 'DeprecatedServiceAccount is a depreciated alias
+                      for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                    type: string
+                  serviceAccountName:
+                    description: 'ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                    type: string
+                  setHostnameAsFQDN:
+                    description: If true the pod's hostname will be configured as
+                      the pod's FQDN, rather than the leaf name (the default). In
+                      Linux containers, this means setting the FQDN in the hostname
+                      field of the kernel (the nodename field of struct utsname).
+                      In Windows containers, this means setting the registry value
+                      of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                      to FQDN. If a pod does not have FQDN, this has no effect. Default
+                      to false.
+                    type: boolean
+                  shareProcessNamespace:
+                    description: 'Share a single process namespace between all of
+                      the containers in a pod. When this is set containers will be
+                      able to view and signal processes from other containers in the
+                      same pod, and the first process in each container will not be
+                      assigned PID 1. HostPID and ShareProcessNamespace cannot both
+                      be set. Optional: Default to false.'
+                    type: boolean
+                  subdomain:
+                    description: If specified, the fully qualified Pod hostname will
+                      be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                      If not specified, the pod will not have a domainname at all.
+                    type: string
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully. May be decreased in delete request. Value must be
+                      non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). If this value
+                      is nil, the default grace period will be used instead. The grace
+                      period is the duration in seconds after the processes running
+                      in the pod are sent a termination signal and the time when the
+                      processes are forcibly halted with a kill signal. Set this value
+                      longer than the expected cleanup time for your process. Defaults
+                      to 30 seconds.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: If specified, the pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                            Possible enum values:
+                             - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                             - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                             - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                            Possible enum values:
+                             - `"Equal"`
+                             - `"Exists"`
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how a group of
+                      pods ought to spread across topology domains. Scheduler will
+                      schedule pods in a way which abides by the constraints. All
+                      topologySpreadConstraints are ANDed.
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                            This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                            Possible enum values:
+                             - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                             - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                    x-kubernetes-list-type: map
+                  volumes:
+                    description: 'List of volumes that can be mounted by containers
+                      belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk
+                            resource that is attached to a kubelet''s host machine
+                            and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached
+                            and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta feature).
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume. Consult with your admin for the
+                                correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to
+                                the secret object containing sensitive information
+                                to pass to the CSI driver to complete the CSI NodePublishVolume
+                                and NodeUnpublishVolume calls. This field is optional,
+                                and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret
+                                references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific
+                                properties that are passed to the CSI driver. Consult
+                                your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name and namespace
+                                      are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set
+                                      permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, requests.cpu and requests.memory)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory
+                            that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations
+                                    that will be copied into the PVC when creating
+                                    it. No other fields are allowed and will be rejected
+                                    during validation.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim.
+                                    The entire content is copied unchanged into the
+                                    PVC that gets created from this template. The
+                                    same fields as in a PersistentVolumeClaim are
+                                    also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired
+                                        access modes the volume should have. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum
+                                            amount of compute resources allowed. More
+                                            info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum
+                                            amount of compute resources required.
+                                            If Requests is omitted for a container,
+                                            it defaults to Limits if that is explicitly
+                                            specified, otherwise to an implementation-defined
+                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim. Value of
+                                        Filesystem is implied when not included in
+                                        claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers
+                                (wwids) Either wwids or combination of targetWWNs
+                                and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: flexVolume represents a generic volume resource
+                            that is provisioned/attached using an exec based plugin.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine. This depends on the Flocker
+                            control service being running
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource
+                            that is attached to a kubelet''s host machine and then
+                            exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular
+                            revision. DEPRECATED: GitRepo is deprecated. To provision
+                            a container with a git repo, mount an EmptyDir into an
+                            InitContainer that clones the repo using git, then mount
+                            the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
+                                if specified, the volume will contain the git repository
+                                in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on
+                            the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                          properties:
+                            endpoints:
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More
+                                info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs
+                                volume to be mounted with read-only permissions. Defaults
+                                to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or
+                            directory on the host machine that is directly exposed
+                            to the container. This is generally used for system agents
+                            or other privileged things that are allowed to see the
+                            host machine. Most containers will NOT need this. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If
+                                the path is a symlink, it will follow the link to
+                                the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that
+                            is attached to a kubelet''s host machine and then exposed
+                            to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting
+                                in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
+                              type: string
+                          required:
+                          - targetPortal
+                          - iqn
+                          - lun
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that
+                            shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export
+                                to be mounted with read-only permissions. Defaults
+                                to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of
+                                the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - server
+                          - path
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to
+                                mount Must be a filesystem type supported by the host
+                                operating system. Ex. "ext4", "xfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections
+                              items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
+                                properties:
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience
+                                          of the token. A recipient of a token must
+                                          identify itself with an identifier specified
+                                          in the audience of the token, and otherwise
+                                          should reject the token. The audience defaults
+                                          to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested
+                                          duration of validity of the service account
+                                          token. As the token approaches expiration,
+                                          the kubelet volume plugin will proactively
+                                          rotate the service account token. The kubelet
+                                          will start trying to rotate the token if
+                                          the token is older than 80 percent of its
+                                          time to live or if the token is older than
+                                          24 hours.Defaults to 1 hour and must be
+                                          at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to
+                                          the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
+                          properties:
+                            group:
+                              description: group to map volume access to Default is
+                                no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume
+                                to be mounted with read-only permissions. Defaults
+                                to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple
+                                Quobyte Registry services specified as a string as
+                                host:port pair (multiple entries are separated with
+                                commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume
+                                in the Backend Used with dynamically provisioned Quobyte
+                                volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to
+                                serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount
+                            on the host that shares a pod''s lifetime. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
+                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                                if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly
+                                setting in VolumeMounts. Defaults to false. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication
+                                secret for RBDUser. If provided overrides keyring.
+                                Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          - image
+                          type: object
+                        scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for
+                                ScaleIO user and other sensitive information. If this
+                                is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - system
+                          - secretRef
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate
+                            this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for
+                                obtaining the StorageOS API credentials.  If not specified,
+                                default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of
+                                the StorageOS volume.  Volume names are only unique
+                                within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.  If no namespace is specified
+                                then the Pod's namespace will be used.  This allows
+                                the Kubernetes name scoping to be mirrored within
+                                StorageOS for tighter integration. Set VolumeName
+                                to any name to override the default behaviour. Set
+                                to "default" if you are not using namespaces within
+                                StorageOS. Namespaces that do not pre-exist within
+                                StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - containers
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/core.k8s.io_replicationcontrollers.yaml
+++ b/config/kube/crds/namespaced/core.k8s.io_replicationcontrollers.yaml
@@ -1,0 +1,7261 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: replicationcontrollers.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    categories:
+    - all
+    kind: ReplicationController
+    listKind: ReplicationControllerList
+    plural: replicationcontrollers
+    shortNames:
+    - rc
+    singular: replicationcontroller
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ReplicationController represents the configuration of a replication
+          controller.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Spec defines the specification of the desired behavior of
+              the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created pod
+                  should be ready without any of its container crashing, for it to
+                  be considered available. Defaults to 0 (pod will be considered available
+                  as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: 'Replicas is the number of desired replicas. This is
+                  a pointer to distinguish between explicit zero and unspecified.
+                  Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller'
+                format: int32
+                type: integer
+              selector:
+                additionalProperties:
+                  type: string
+                description: 'Selector is a label query over pods that should match
+                  the Replicas count. If Selector is empty, it is defaulted to the
+                  labels present on the Pod template. Label keys and values that must
+                  match in order to be controlled by this replication controller,
+                  if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                type: object
+              template:
+                description: 'Template is the object that describes the pod that will
+                  be created if insufficient replicas are detected. This takes precedence
+                  over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Optional duration in seconds the pod may be active
+                          on the node relative to StartTime before the system will
+                          actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term
+                                    matches all objects with implicit weight 0 (i.e.
+                                    it's a no-op). A null preferred scheduling term
+                                    matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - preference
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to an update), the system may or may not try
+                                  to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                  Possible enum values:
+                                                   - `"DoesNotExist"`
+                                                   - `"Exists"`
+                                                   - `"Gt"`
+                                                   - `"In"`
+                                                   - `"Lt"`
+                                                   - `"NotIn"`
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty.
+                                                  If the operator is Gt or Lt, the
+                                                  values array must have a single
+                                                  element, which will be interpreted
+                                                  as an integer. This array is replaced
+                                                  during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if
+                                  the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  affinity requirements specified by this field cease
+                                  to be met at some point during pod execution (e.g.
+                                  due to a pod label update), the system may or may
+                                  not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes
+                                  corresponding to each podAffinityTerm are intersected,
+                                  i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule
+                                  pods to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the
+                                  greatest sum of weights, i.e. for each node that
+                                  meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity
+                                  expressions, etc.), compute a sum by iterating through
+                                  the elements of this field and adding "weight" to
+                                  the sum if the node has pods which matches the corresponding
+                                  podAffinityTerm; the node(s) with the highest sum
+                                  are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of
+                                            resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaceSelector:
+                                          description: A label query over the set
+                                            of namespaces that the term applies to.
+                                            The term is applied to the union of the
+                                            namespaces selected by this field and
+                                            the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces
+                                            list means "this pod's namespace". An
+                                            empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies a static
+                                            list of namespace names that the term
+                                            applies to. The term is applied to the
+                                            union of the namespaces listed in this
+                                            field and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null
+                                            namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose
+                                            value of the label with key topologyKey
+                                            matches that of any node on which any
+                                            of the selected pods is running. Empty
+                                            topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching
+                                        the corresponding podAffinityTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - weight
+                                  - podAffinityTerm
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the
+                                  anti-affinity requirements specified by this field
+                                  cease to be met at some point during pod execution
+                                  (e.g. due to a pod label update), the system may
+                                  or may not try to eventually evict the pod from
+                                  its node. When there are multiple elements, the
+                                  lists of nodes corresponding to each podAffinityTerm
+                                  are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those
+                                    matching the labelSelector relative to the given
+                                    namespace(s)) that this pod should be co-located
+                                    (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key <topologyKey>
+                                    matches that of any node on which a pod of the
+                                    set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: List of containers belonging to the pod. Containers
+                          cannot currently be added or removed. There must be at least
+                          one container in a Pod. Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: Specifies the DNS parameters of a pod. Parameters
+                          specified here will be merged to the generated DNS configuration
+                          based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: A list of DNS name server IP addresses. This
+                              will be appended to the base nameservers generated from
+                              DNSPolicy. Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: A list of DNS resolver options. This will
+                              be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options
+                              given in Options will override those that appear in
+                              the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: Required.
+                                  type: string
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          searches:
+                            description: A list of DNS search domains for host-name
+                              lookup. This will be appended to the base search paths
+                              generated from DNSPolicy. Duplicated search paths will
+                              be removed.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                          Possible enum values:
+                           - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                           - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                           - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                        type: string
+                      enableServiceLinks:
+                        description: 'EnableServiceLinks indicates whether information
+                          about services should be injected into pod''s environment
+                          variables, matching the syntax of Docker links. Optional:
+                          Defaults to true.'
+                        type: boolean
+                      ephemeralContainers:
+                        description: List of ephemeral containers run in this pod.
+                          Ephemeral containers may be run in an existing pod to perform
+                          user-initiated actions such as debugging. This list cannot
+                          be specified when creating a pod, and it cannot be modified
+                          by updating the pod spec. In order to add an ephemeral container
+                          to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the ephemeral container specified
+                                as a DNS_LABEL. This name must be unique among all
+                                containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Resources are not allowed for ephemeral
+                                containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Optional: SecurityContext defines the
+                                security options the ephemeral container should be
+                                run with. If set, the fields of SecurityContext override
+                                the equivalent fields of PodSecurityContext.'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Subpath mounts are not allowed for ephemeral
+                                containers. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: 'Use the host''s ipc namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostNetwork:
+                        description: Host networking requested for this pod. Use the
+                          host's network namespace. If this option is set, the ports
+                          that will be used must be specified. Default to false.
+                        type: boolean
+                      hostPID:
+                        description: 'Use the host''s pid namespace. Optional: Default
+                          to false.'
+                        type: boolean
+                      hostUsers:
+                        description: 'Use the host''s user namespace. Optional: Default
+                          to true. If set to true or not present, the pod will be
+                          run in the host user namespace, useful for when the pod
+                          needs a feature only available to the host user namespace,
+                          such as loading a kernel module with CAP_SYS_MODULE. When
+                          set to false, a new userns is created for the pod. Setting
+                          false is useful for mitigating container breakout vulnerabilities
+                          even allowing users to run their containers as root without
+                          actually having root privileges on the host. This field
+                          is alpha-level and is only honored by servers that enable
+                          the UserNamespacesSupport feature.'
+                        type: boolean
+                      hostname:
+                        description: Specifies the hostname of the Pod If not specified,
+                          the pod's hostname will be set to a system-defined value.
+                        type: string
+                      imagePullSecrets:
+                        description: 'ImagePullSecrets is an optional list of references
+                          to secrets in the same namespace to use for pulling any
+                          of the images used by this PodSpec. If specified, these
+                          secrets will be passed to individual puller implementations
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        items:
+                          description: LocalObjectReference contains enough information
+                            to let you locate the referenced object inside the same
+                            namespace.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: 'List of initialization containers belonging
+                          to the pod. Init containers are executed in order prior
+                          to containers being started. If any init container fails,
+                          the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or
+                          normal container must be unique among all containers. Init
+                          containers may not have Lifecycle actions, Readiness probes,
+                          Liveness probes, or Startup probes. The resourceRequirements
+                          of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type,
+                          and then using the max of of that value or the sum of the
+                          normal containers. Limits are applied to init containers
+                          in a similar fashion. Init containers cannot currently be
+                          added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The container
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. Double
+                                $$ are reduced to a single $, which allows for escaping
+                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Cannot be updated. More info:
+                                https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME)
+                                syntax: i.e. "$$(VAR_NAME)" will produce the string
+                                literal "$(VAR_NAME)". Escaped references will never
+                                be expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previously defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Defaults
+                                      to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                Possible enum values:
+                                 - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                 - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                 - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness/startup probe
+                                    failure, preemption, resource contention, etc.
+                                    The handler is not called if the container crashes
+                                    or exits. The Pod''s termination grace period
+                                    countdown begins before the PreStop hook is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period (unless delayed
+                                    by finalizers). Other management of the container
+                                    blocks until the hook completes or until the termination
+                                    grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: Exec specifies the action to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                            Possible enum values:
+                                             - `"HTTP"` means that the scheme used will be http://
+                                             - `"HTTPS"` means that the scheme used will be https://
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: Deprecated. TCPSocket is NOT supported
+                                        as a LifecycleHandler and kept for the backward
+                                        compatibility. There are no validation of
+                                        this field and lifecycle hooks will fail in
+                                        runtime when tcp handler is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Not specifying a port here DOES NOT prevent that port
+                                from being exposed. Any port which is listening on
+                                the default "0.0.0.0" address inside a container will
+                                be accessible from the network. Modifying this array
+                                with strategic merge patch may corrupt the data. For
+                                more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                      Possible enum values:
+                                       - `"SCTP"` is the SCTP protocol.
+                                       - `"TCP"` is the TCP protocol.
+                                       - `"UDP"` is the UDP protocol.
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'SecurityContext defines the security options
+                                the container should be run with. If set, the fields
+                                of SecurityContext override the equivalent fields
+                                of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN Note that this field cannot
+                                    be set when spec.os.name is windows.'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false. Note that
+                                    this field cannot be set when spec.os.name is
+                                    windows.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by this
+                                    container. If seccomp options are provided at
+                                    both the pod & container level, the container
+                                    options override the pod options. Note that this
+                                    field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    from the PodSecurityContext will be used. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: 'StartupProbe indicates that the Pod has
+                                successfully initialized. If specified, no other probes
+                                are executed until this completes successfully. If
+                                this probe fails, the Pod will be restarted, just
+                                as if the livenessProbe failed. This can be used to
+                                provide different probe parameters at the beginning
+                                of a Pod''s lifecycle, when it might take a long time
+                                to load data or warm a cache, than during steady-state
+                                operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies an action involving
+                                    a GRPC port. This is a beta field and requires
+                                    enabling GRPCContainerProbe feature gate.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                        Possible enum values:
+                                         - `"HTTP"` means that the scheme used will be http://
+                                         - `"HTTPS"` means that the scheme used will be https://
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness
+                                    and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies an action involving
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod
+                                    needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after
+                                    the processes running in the pod are sent a termination
+                                    signal and the time when the processes are forcibly
+                                    halted with a kill signal. Set this value longer
+                                    than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds
+                                    will be used. Otherwise, this value overrides
+                                    the value provided by the pod spec. Value must
+                                    be non-negative integer. The value zero indicates
+                                    stop immediately via the kill signal (no opportunity
+                                    to shut down). This is a beta field and requires
+                                    enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds
+                                    is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                Possible enum values:
+                                 - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                 - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: NodeName is a request to schedule this pod onto
+                          a specific node. If it is non-empty, the scheduler simply
+                          schedules this pod onto that node, assuming that it fits
+                          resource requirements.
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: 'NodeSelector is a selector which must be true
+                          for the pod to fit on a node. Selector which must match
+                          a node''s labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                        type: object
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: 'Name is the name of the operating system.
+                              The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be
+                              one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and
+                              treat unrecognized values in this field as os: null'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Overhead represents the resource overhead associated
+                          with running a pod for a given RuntimeClass. This field
+                          will be autopopulated at admission time by the RuntimeClass
+                          admission controller. If the RuntimeClass admission controller
+                          is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create
+                          requests which have the overhead already set. If RuntimeClass
+                          is configured and selected in the PodSpec, Overhead will
+                          be set to the value defined in the corresponding RuntimeClass,
+                          otherwise it will remain unset and treated as zero. More
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                        type: object
+                      preemptionPolicy:
+                        description: PreemptionPolicy is the Policy for preempting
+                          pods with lower priority. One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: The priority value. Various system components
+                          use this field to find the priority of the pod. When Priority
+                          Admission Controller is enabled, it prevents users from
+                          setting this field. The admission controller populates this
+                          field from PriorityClassName. The higher the value, the
+                          higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: If specified, indicates the pod's priority. "system-node-critical"
+                          and "system-cluster-critical" are two special keywords which
+                          indicate the highest priorities with the former being the
+                          highest priority. Any other name must be defined by creating
+                          a PriorityClass object with that name. If not specified,
+                          the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: 'If specified, all readiness gates will be evaluated
+                          for pod readiness. A pod is ready when all its containers
+                          are ready AND all conditions specified in the readiness
+                          gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                          Possible enum values:
+                           - `"Always"`
+                           - `"Never"`
+                           - `"OnFailure"`
+                        type: string
+                      runtimeClassName:
+                        description: 'RuntimeClassName refers to a RuntimeClass object
+                          in the node.k8s.io group, which should be used to run this
+                          pod.  If no RuntimeClass resource matches the named class,
+                          the pod will not be run. If unset or empty, the "legacy"
+                          RuntimeClass will be used, which is an implicit class with
+                          an empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                        type: string
+                      schedulerName:
+                        description: If specified, the pod will be dispatched by specified
+                          scheduler. If not specified, the pod will be dispatched
+                          by default scheduler.
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext holds pod-level security attributes
+                          and common container settings. Optional: Defaults to empty.  See
+                          type description for default values of each field.'
+                        properties:
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified,
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in SecurityContext.  If set
+                              in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all
+                              containers. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls
+                              used for the pod. Pods with unsupported sysctls (by
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options within a
+                              container's SecurityContext will be used. If set in
+                              both SecurityContext and PodSecurityContext, the value
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: 'DeprecatedServiceAccount is a depreciated alias
+                          for ServiceAccountName. Deprecated: Use serviceAccountName
+                          instead.'
+                        type: string
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      setHostnameAsFQDN:
+                        description: If true the pod's hostname will be configured
+                          as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the
+                          hostname field of the kernel (the nodename field of struct
+                          utsname). In Windows containers, this means setting the
+                          registry value of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                          to FQDN. If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: 'Share a single process namespace between all
+                          of the containers in a pod. When this is set containers
+                          will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container
+                          will not be assigned PID 1. HostPID and ShareProcessNamespace
+                          cannot both be set. Optional: Default to false.'
+                        type: boolean
+                      subdomain:
+                        description: If specified, the fully qualified Pod hostname
+                          will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                          domain>". If not specified, the pod will not have a domainname
+                          at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates
+                          stop immediately via the kill signal (no opportunity to
+                          shut down). If this value is nil, the default grace period
+                          will be used instead. The grace period is the duration in
+                          seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are
+                          forcibly halted with a kill signal. Set this value longer
+                          than the expected cleanup time for your process. Defaults
+                          to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                Possible enum values:
+                                 - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                 - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                 - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                Possible enum values:
+                                 - `"Equal"`
+                                 - `"Exists"`
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                      topologySpreadConstraints:
+                        description: TopologySpreadConstraints describes how a group
+                          of pods ought to spread across topology domains. Scheduler
+                          will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: LabelSelector is used to find matching
+                                pods. Pods that match this label selector are counted
+                                to determine the number of pods in their corresponding
+                                topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            matchLabelKeys:
+                              description: MatchLabelKeys is a set of pod label keys
+                                to select the pods over which spreading will be calculated.
+                                The keys are used to lookup values from the incoming
+                                pod labels, those key-value labels are ANDed with
+                                labelSelector to select the group of existing pods
+                                over which spreading will be calculated for the incoming
+                                pod. Keys that don't exist in the incoming pod labels
+                                will be ignored. A null or empty list means only match
+                                against labelSelector.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: 'MaxSkew describes the degree to which
+                                pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                it is the maximum permitted difference between the
+                                number of matching pods in the target topology and
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                it is used to give higher precedence to topologies
+                                that satisfy it. It''s a required field. Default value
+                                is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                              type: string
+                            topologyKey:
+                              description: TopologyKey is the key of node labels.
+                                Nodes that have a label with this key and identical
+                                values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes meet the requirements of nodeAffinityPolicy
+                                and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                each Node is a domain of that topology. And, if TopologyKey
+                                is "topology.kubernetes.io/zone", each zone is a domain
+                                of that topology. It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                Possible enum values:
+                                 - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                 - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: 'List of volumes that can be mounted by containers
+                          belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - targetPortal
+                              - iqn
+                              - lun
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - server
+                              - path
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              - image
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - system
+                              - secretRef
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  type: object
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - containers
+                    type: object
+                type: object
+            type: object
+          status:
+            description: 'Status is the most recently observed status of the replication
+              controller. This data may be out of date by some window of time. Populated
+              by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this replication controller.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a replication
+                  controller's current state.
+                items:
+                  description: ReplicationControllerCondition describes the state
+                    of a replication controller at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of replication controller condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              fullyLabeledReplicas:
+                description: The number of pods that have labels matching the labels
+                  of the pod template of the replication controller.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed replication controller.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this replication controller.
+                format: int32
+                type: integer
+              replicas:
+                description: 'Replicas is the most recently oberved number of replicas.
+                  More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller'
+                format: int32
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/discovery.k8s.io_endpointslices.yaml
+++ b/config/kube/crds/namespaced/discovery.k8s.io_endpointslices.yaml
@@ -1,0 +1,231 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: endpointslices.discovery.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: discovery.k8s.io
+  names:
+    kind: EndpointSlice
+    listKind: EndpointSliceList
+    plural: endpointslices
+    singular: endpointslice
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: EndpointSlice represents a subset of the endpoints that implement
+          a service. For a given service there may be multiple EndpointSlice objects,
+          selected by labels, which must be joined to produce the full set of endpoints.
+        properties:
+          addressType:
+            description: |-
+              addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+
+              Possible enum values:
+               - `"FQDN"` represents a FQDN.
+               - `"IPv4"` represents an IPv4 Address.
+               - `"IPv6"` represents an IPv6 Address.
+            type: string
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          endpoints:
+            description: endpoints is a list of unique endpoints in this slice. Each
+              slice may include a maximum of 1000 endpoints.
+            items:
+              description: Endpoint represents a single logical "backend" implementing
+                a service.
+              properties:
+                addresses:
+                  description: 'addresses of this endpoint. The contents of this field
+                    are interpreted according to the corresponding EndpointSlice addressType
+                    field. Consumers must handle different types of addresses in the
+                    context of their own capabilities. This must contain at least
+                    one address but no more than 100. These are all assumed to be
+                    fungible and clients may choose to only use the first element.
+                    Refer to: https://issue.k8s.io/106267'
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                conditions:
+                  description: conditions contains information about the current status
+                    of the endpoint.
+                  properties:
+                    ready:
+                      description: ready indicates that this endpoint is prepared
+                        to receive traffic, according to whatever system is managing
+                        the endpoint. A nil value indicates an unknown state. In most
+                        cases consumers should interpret this unknown state as ready.
+                        For compatibility reasons, ready should never be "true" for
+                        terminating endpoints.
+                      type: boolean
+                    serving:
+                      description: serving is identical to ready except that it is
+                        set regardless of the terminating state of endpoints. This
+                        condition should be set to true for a ready endpoint that
+                        is terminating. If nil, consumers should defer to the ready
+                        condition. This field can be enabled with the EndpointSliceTerminatingCondition
+                        feature gate.
+                      type: boolean
+                    terminating:
+                      description: terminating indicates that this endpoint is terminating.
+                        A nil value indicates an unknown state. Consumers should interpret
+                        this unknown state to mean that the endpoint is not terminating.
+                        This field can be enabled with the EndpointSliceTerminatingCondition
+                        feature gate.
+                      type: boolean
+                  type: object
+                deprecatedTopology:
+                  additionalProperties:
+                    type: string
+                  description: deprecatedTopology contains topology information part
+                    of the v1beta1 API. This field is deprecated, and will be removed
+                    when the v1beta1 API is removed (no sooner than kubernetes v1.24).  While
+                    this field can hold values, it is not writable through the v1
+                    API, and any attempts to write to it will be silently ignored.
+                    Topology information can be found in the zone and nodeName fields
+                    instead.
+                  type: object
+                hints:
+                  description: hints contains information associated with how an endpoint
+                    should be consumed.
+                  properties:
+                    forZones:
+                      description: forZones indicates the zone(s) this endpoint should
+                        be consumed by to enable topology aware routing.
+                      items:
+                        description: ForZone provides information about which zones
+                          should consume this endpoint.
+                        properties:
+                          name:
+                            description: name represents the name of the zone.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                hostname:
+                  description: hostname of this endpoint. This field may be used by
+                    consumers of endpoints to distinguish endpoints from each other
+                    (e.g. in DNS names). Multiple endpoints which use the same hostname
+                    should be considered fungible (e.g. multiple A values in DNS).
+                    Must be lowercase and pass DNS Label (RFC 1123) validation.
+                  type: string
+                nodeName:
+                  description: nodeName represents the name of the Node hosting this
+                    endpoint. This can be used to determine endpoints local to a Node.
+                  type: string
+                targetRef:
+                  description: targetRef is a reference to a Kubernetes object that
+                    represents this endpoint.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                zone:
+                  description: zone is the name of the Zone this endpoint exists in.
+                  type: string
+              required:
+              - addresses
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          ports:
+            description: ports specifies the list of network ports exposed by each
+              endpoint in this slice. Each port must have a unique name. When ports
+              is empty, it indicates that there are no defined ports. When a port
+              is defined with a nil port value, it indicates "all ports". Each slice
+              may include a maximum of 100 ports.
+            items:
+              description: EndpointPort represents a Port used by an EndpointSlice
+              properties:
+                appProtocol:
+                  description: The application protocol for this port. This field
+                    follows standard Kubernetes label syntax. Un-prefixed names are
+                    reserved for IANA standard service names (as per RFC-6335 and
+                    https://www.iana.org/assignments/service-names). Non-standard
+                    protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                  type: string
+                name:
+                  description: 'The name of this port. All ports in an EndpointSlice
+                    must have a unique name. If the EndpointSlice is dervied from
+                    a Kubernetes service, this corresponds to the Service.ports[].name.
+                    Name must either be an empty string or pass DNS_LABEL validation:
+                    * must be no more than 63 characters long. * must consist of lower
+                    case alphanumeric characters or ''-''. * must start and end with
+                    an alphanumeric character. Default is empty string.'
+                  type: string
+                port:
+                  description: The port number of the endpoint. If this is not specified,
+                    ports are not restricted and must be interpreted in the context
+                    of the specific consumer.
+                  format: int32
+                  type: integer
+                protocol:
+                  description: The IP protocol for this port. Must be UDP, TCP, or
+                    SCTP. Default is TCP.
+                  type: string
+              type: object
+            type: array
+            x-kubernetes-list-type: atomic
+        required:
+        - addressType
+        - endpoints
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/networking.k8s.io_networkpolicies.yaml
+++ b/config/kube/crds/namespaced/networking.k8s.io_networkpolicies.yaml
@@ -1,0 +1,545 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: networkpolicies.networking.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: networking.k8s.io
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkPolicy describes what network traffic is allowed for a
+          set of Pods
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior for this NetworkPolicy.
+            properties:
+              egress:
+                description: List of egress rules to be applied to the selected pods.
+                  Outgoing traffic is allowed if there are no NetworkPolicies selecting
+                  the pod (and cluster policy otherwise allows the traffic), OR if
+                  the traffic matches at least one egress rule across all of the NetworkPolicy
+                  objects whose podSelector matches the pod. If this field is empty
+                  then this NetworkPolicy limits all outgoing traffic (and serves
+                  solely to ensure that the pods it selects are isolated by default).
+                  This field is beta-level in 1.8
+                items:
+                  description: NetworkPolicyEgressRule describes a particular set
+                    of traffic that is allowed out of pods matched by a NetworkPolicySpec's
+                    podSelector. The traffic must match both ports and to. This type
+                    is beta-level in 1.8
+                  properties:
+                    ports:
+                      description: List of destination ports for outgoing traffic.
+                        Each item in this list is combined using a logical OR. If
+                        this field is empty or missing, this rule matches all ports
+                        (traffic not restricted by port). If this field is present
+                        and contains at least one item, then this rule allows traffic
+                        only if the traffic matches at least one port in the list.
+                      items:
+                        description: NetworkPolicyPort describes a port to allow traffic
+                          on
+                        properties:
+                          endPort:
+                            description: If set, indicates that the range of ports
+                              from port to endPort, inclusive, should be allowed by
+                              the policy. This field cannot be defined if the port
+                              field is not defined or if the port field is defined
+                              as a named (string) port. The endPort must be equal
+                              or greater than port.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can
+                              either be a numerical or named port on a pod. If this
+                              field is not provided, this matches all port names and
+                              numbers. If present, only traffic on the specified protocol
+                              AND port will be matched.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            description: The protocol (TCP, UDP, or SCTP) which traffic
+                              must match. If not specified, this field defaults to
+                              TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: List of destinations for outgoing traffic of pods
+                        selected for this rule. Items in this list are combined using
+                        a logical OR operation. If this field is empty or missing,
+                        this rule matches all destinations (traffic not restricted
+                        by destination). If this field is present and contains at
+                        least one item, this rule allows traffic only if the traffic
+                        matches at least one item in the to list.
+                      items:
+                        description: NetworkPolicyPeer describes a peer to allow traffic
+                          to/from. Only certain combinations of fields are allowed
+                        properties:
+                          ipBlock:
+                            description: IPBlock defines policy on a particular IPBlock.
+                              If this field is set then neither of the other fields
+                              can be.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP
+                                  Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should
+                                  not be included within an IP Block Valid examples
+                                  are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                  will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: |-
+                              Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                              If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          podSelector:
+                            description: |-
+                              This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                              If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ingress:
+                description: List of ingress rules to be applied to the selected pods.
+                  Traffic is allowed to a pod if there are no NetworkPolicies selecting
+                  the pod (and cluster policy otherwise allows the traffic), OR if
+                  the traffic source is the pod's local node, OR if the traffic matches
+                  at least one ingress rule across all of the NetworkPolicy objects
+                  whose podSelector matches the pod. If this field is empty then this
+                  NetworkPolicy does not allow any traffic (and serves solely to ensure
+                  that the pods it selects are isolated by default)
+                items:
+                  description: NetworkPolicyIngressRule describes a particular set
+                    of traffic that is allowed to the pods matched by a NetworkPolicySpec's
+                    podSelector. The traffic must match both ports and from.
+                  properties:
+                    from:
+                      description: List of sources which should be able to access
+                        the pods selected for this rule. Items in this list are combined
+                        using a logical OR operation. If this field is empty or missing,
+                        this rule matches all sources (traffic not restricted by source).
+                        If this field is present and contains at least one item, this
+                        rule allows traffic only if the traffic matches at least one
+                        item in the from list.
+                      items:
+                        description: NetworkPolicyPeer describes a peer to allow traffic
+                          to/from. Only certain combinations of fields are allowed
+                        properties:
+                          ipBlock:
+                            description: IPBlock defines policy on a particular IPBlock.
+                              If this field is set then neither of the other fields
+                              can be.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP
+                                  Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should
+                                  not be included within an IP Block Valid examples
+                                  are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                  will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: |-
+                              Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                              If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          podSelector:
+                            description: |-
+                              This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                              If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: List of ports which should be made accessible on
+                        the pods selected for this rule. Each item in this list is
+                        combined using a logical OR. If this field is empty or missing,
+                        this rule matches all ports (traffic not restricted by port).
+                        If this field is present and contains at least one item, then
+                        this rule allows traffic only if the traffic matches at least
+                        one port in the list.
+                      items:
+                        description: NetworkPolicyPort describes a port to allow traffic
+                          on
+                        properties:
+                          endPort:
+                            description: If set, indicates that the range of ports
+                              from port to endPort, inclusive, should be allowed by
+                              the policy. This field cannot be defined if the port
+                              field is not defined or if the port field is defined
+                              as a named (string) port. The endPort must be equal
+                              or greater than port.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can
+                              either be a numerical or named port on a pod. If this
+                              field is not provided, this matches all port names and
+                              numbers. If present, only traffic on the specified protocol
+                              AND port will be matched.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            description: The protocol (TCP, UDP, or SCTP) which traffic
+                              must match. If not specified, this field defaults to
+                              TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              podSelector:
+                description: Selects the pods to which this NetworkPolicy object applies.
+                  The array of ingress rules is applied to any pods selected by this
+                  field. Multiple network policies can select the same set of pods.
+                  In this case, the ingress rules for each are combined additively.
+                  This field is NOT optional and follows standard label selector semantics.
+                  An empty podSelector matches all pods in this namespace.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              policyTypes:
+                description: List of rule types that the NetworkPolicy relates to.
+                  Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                  If this field is not specified, it will default based on the existence
+                  of Ingress or Egress rules; policies that contain an Egress section
+                  are assumed to affect Egress, and all policies (whether or not they
+                  contain an Ingress section) are assumed to affect Ingress. If you
+                  want to write an egress-only policy, you must explicitly specify
+                  policyTypes [ "Egress" ]. Likewise, if you want to write a policy
+                  that specifies that no egress is allowed, you must specify a policyTypes
+                  value that include "Egress" (since such a policy would not include
+                  an Egress section and would otherwise default to just [ "Ingress"
+                  ]). This field is beta-level in 1.8
+                items:
+                  type: string
+                type: array
+            required:
+            - podSelector
+            type: object
+          status:
+            description: 'Status is the current state of the NetworkPolicy. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              conditions:
+                description: Conditions holds an array of metav1.Condition that describe
+                  the state of the NetworkPolicy. Current service state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/policy_poddisruptionbudgets.yaml
+++ b/config/kube/crds/namespaced/policy_poddisruptionbudgets.yaml
@@ -1,0 +1,225 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: poddisruptionbudgets.policy
+spec:
+  conversion:
+    strategy: None
+  group: policy
+  names:
+    kind: PodDisruptionBudget
+    listKind: PodDisruptionBudgetList
+    plural: poddisruptionbudgets
+    shortNames:
+    - pdb
+    singular: poddisruptionbudget
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PodDisruptionBudget is an object to define the max disruption
+          that can be caused to a collection of pods
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the PodDisruptionBudget.
+            properties:
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: An eviction is allowed if at most "maxUnavailable" pods
+                  selected by "selector" are unavailable after the eviction, i.e.
+                  even in absence of the evicted pod. For example, one can prevent
+                  all voluntary evictions by specifying 0. This is a mutually exclusive
+                  setting with "minAvailable".
+                x-kubernetes-int-or-string: true
+              minAvailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: An eviction is allowed if at least "minAvailable" pods
+                  selected by "selector" will still be available after the eviction,
+                  i.e. even in the absence of the evicted pod.  So for example you
+                  can prevent all voluntary evictions by specifying "100%".
+                x-kubernetes-int-or-string: true
+              selector:
+                description: Label query over pods whose evictions are managed by
+                  the disruption budget. A null selector will match no pods, while
+                  an empty ({}) selector will select all pods within the namespace.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+            type: object
+          status:
+            description: Most recently observed status of the PodDisruptionBudget.
+            properties:
+              conditions:
+                description: |-
+                  Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute
+                                the number of allowed disruptions. Therefore no disruptions are
+                                allowed and the status of the condition will be False.
+                  - InsufficientPods: The number of pods are either at or below the number
+                                      required by the PodDisruptionBudget. No disruptions are
+                                      allowed and the status of the condition will be False.
+                  - SufficientPods: There are more pods than required by the PodDisruptionBudget.
+                                    The condition will be True, and the number of allowed
+                                    disruptions are provided by the disruptionsAllowed property.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentHealthy:
+                description: current number of healthy pods
+                format: int32
+                type: integer
+              desiredHealthy:
+                description: minimum desired number of healthy pods
+                format: int32
+                type: integer
+              disruptedPods:
+                additionalProperties:
+                  format: date-time
+                  type: string
+                description: DisruptedPods contains information about pods whose eviction
+                  was processed by the API server eviction subresource handler but
+                  has not yet been observed by the PodDisruptionBudget controller.
+                  A pod will be in this map from the time when the API server processed
+                  the eviction request to the time when the pod is seen by PDB controller
+                  as having been marked for deletion (or after a timeout). The key
+                  in the map is the name of the pod and the value is the time when
+                  the API server processed the eviction request. If the deletion didn't
+                  occur and a pod is still there it will be removed from the list
+                  automatically by PodDisruptionBudget controller after some time.
+                  If everything goes smooth this map should be empty for the most
+                  of the time. Large number of entries in the map may indicate problems
+                  with pod deletions.
+                type: object
+              disruptionsAllowed:
+                description: Number of pod disruptions that are currently allowed.
+                format: int32
+                type: integer
+              expectedPods:
+                description: total number of pods counted by this disruption budget
+                format: int32
+                type: integer
+              observedGeneration:
+                description: Most recent generation observed when updating this PDB
+                  status. DisruptionsAllowed and other status information is valid
+                  only if observedGeneration equals to PDB's object generation.
+                format: int64
+                type: integer
+            required:
+            - disruptionsAllowed
+            - currentHealthy
+            - desiredHealthy
+            - expectedPods
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/crds/namespaced/storage.k8s.io_csistoragecapacities.yaml
+++ b/config/kube/crds/namespaced/storage.k8s.io_csistoragecapacities.yaml
@@ -1,0 +1,128 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: csistoragecapacities.storage.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: storage.k8s.io
+  names:
+    kind: CSIStorageCapacity
+    listKind: CSIStorageCapacityList
+    plural: csistoragecapacities
+    singular: csistoragecapacity
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
+
+          For example this can express things like: - StorageClass "standard" has "1234 GiB" available in "topology.kubernetes.io/zone=us-east1" - StorageClass "localssd" has "10 GiB" available in "kubernetes.io/hostname=knode-abc123"
+
+          The following three cases all imply that no capacity is available for a certain combination: - no object exists with suitable topology and storage class name - such an object exists, but the capacity is unset - such an object exists, but the capacity is zero
+
+          The producer of these objects can decide which approach is more suitable.
+
+          They are consumed by the kube-scheduler when a CSI driver opts into capacity-aware scheduling with CSIDriverSpec.StorageCapacity. The scheduler compares the MaximumVolumeSize against the requested size of pending volumes to filter out unsuitable nodes. If MaximumVolumeSize is unset, it falls back to a comparison against the less precise Capacity. If that is also unset, the scheduler assumes that capacity is insufficient and tries some other node.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          capacity:
+            anyOf:
+            - type: integer
+            - type: string
+            description: |-
+              Capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+              The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
+            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+            x-kubernetes-int-or-string: true
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          maximumVolumeSize:
+            anyOf:
+            - type: integer
+            - type: string
+            description: |-
+              MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+              This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
+            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+            x-kubernetes-int-or-string: true
+          metadata:
+            type: object
+          nodeTopology:
+            description: NodeTopology defines which nodes have access to the storage
+              for which capacity was reported. If not set, the storage is not accessible
+              from any node in the cluster. If empty, the storage is accessible from
+              all nodes. This field is immutable.
+            properties:
+              matchExpressions:
+                description: matchExpressions is a list of label selector requirements.
+                  The requirements are ANDed.
+                items:
+                  description: A label selector requirement is a selector that contains
+                    values, a key, and an operator that relates the key and values.
+                  properties:
+                    key:
+                      description: key is the label key that the selector applies
+                        to.
+                      type: string
+                    operator:
+                      description: operator represents a key's relationship to a set
+                        of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                      type: string
+                    values:
+                      description: values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty. If the
+                        operator is Exists or DoesNotExist, the values array must
+                        be empty. This array is replaced during a strategic merge
+                        patch.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - operator
+                  type: object
+                type: array
+              matchLabels:
+                additionalProperties:
+                  type: string
+                description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                  in the matchLabels map is equivalent to an element of matchExpressions,
+                  whose key field is "key", the operator is "In", and the values array
+                  contains only "value". The requirements are ANDed.
+                type: object
+            type: object
+          storageClassName:
+            description: The name of the StorageClass that the reported capacity applies
+              to. It must meet the same requirements as the name of a StorageClass
+              object (non-empty, DNS subdomain). If that object no longer exists,
+              the CSIStorageCapacity object is obsolete and should be removed by its
+              creator. This field is immutable.
+            type: string
+        required:
+        - storageClassName
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/config/kube/exports/cluster-scoped/apiexport-core.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-core.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: core.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.persistentvolumes.core
+status: {}

--- a/config/kube/exports/cluster-scoped/apiexport-flowcontrol.apiserver.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-flowcontrol.apiserver.k8s.io.yaml
@@ -1,0 +1,10 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: flowcontrol.apiserver.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.flowschemas.flowcontrol.apiserver.k8s.io
+  - v230615-d48020c8.prioritylevelconfigurations.flowcontrol.apiserver.k8s.io
+status: {}

--- a/config/kube/exports/cluster-scoped/apiexport-networking.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-networking.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: networking.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.ingressclasses.networking.k8s.io
+status: {}

--- a/config/kube/exports/cluster-scoped/apiexport-node.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-node.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: node.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.runtimeclasses.node.k8s.io
+status: {}

--- a/config/kube/exports/cluster-scoped/apiexport-scheduling.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-scheduling.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: scheduling.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.priorityclasses.scheduling.k8s.io
+status: {}

--- a/config/kube/exports/cluster-scoped/apiexport-storage.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiexport-storage.k8s.io.yaml
@@ -1,0 +1,12 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: storage.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.csidrivers.storage.k8s.io
+  - v230615-d48020c8.csinodes.storage.k8s.io
+  - v230615-d48020c8.storageclasses.storage.k8s.io
+  - v230615-d48020c8.volumeattachments.storage.k8s.io
+status: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-csidrivers.storage.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-csidrivers.storage.k8s.io.yaml
@@ -1,0 +1,133 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.csidrivers.storage.k8s.io
+spec:
+  group: storage.k8s.io
+  names:
+    kind: CSIDriver
+    listKind: CSIDriverList
+    plural: csidrivers
+    singular: csidriver
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: CSIDriver captures information about a Container Storage Interface
+        (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller
+        uses this object to determine whether attach is required. Kubelet uses this
+        object to determine whether pod information needs to be passed on mount. CSIDriver
+        objects are non-namespaced.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the CSI Driver.
+          properties:
+            attachRequired:
+              description: |-
+                attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+
+                This field is immutable.
+              type: boolean
+            fsGroupPolicy:
+              description: |-
+                Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details.
+
+                This field is immutable.
+
+                Defaults to ReadWriteOnceWithFSType, which will examine each volume to determine if Kubernetes should modify ownership and permissions of the volume. With the default policy the defined fsGroup will only be applied if a fstype is defined and the volume's access mode contains ReadWriteOnce.
+              type: string
+            podInfoOnMount:
+              description: |-
+                If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" if the volume is an ephemeral inline volume
+                                                defined by a CSIVolumeSource, otherwise "false"
+
+                "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+
+                This field is immutable.
+              type: boolean
+            requiresRepublish:
+              description: |-
+                RequiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+                Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+              type: boolean
+            seLinuxMount:
+              description: |-
+                SELinuxMount specifies if the CSI driver supports "-o context" mount option.
+
+                When "true", the CSI driver must ensure that all volumes provided by this CSI driver can be mounted separately with different `-o context` options. This is typical for storage backends that provide volumes as filesystems on block devices or as independent shared volumes. Kubernetes will call NodeStage / NodePublish with "-o context=xyz" mount option when mounting a ReadWriteOncePod volume used in Pod that has explicitly set SELinux context. In the future, it may be expanded to other volume AccessModes. In any case, Kubernetes will ensure that the volume is mounted only with a single SELinux context.
+
+                When "false", Kubernetes won't pass any special SELinux mount options to the driver. This is typical for volumes that represent subdirectories of a bigger shared filesystem.
+
+                Default is "false".
+              type: boolean
+            storageCapacity:
+              description: |-
+                If set to true, storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information.
+
+                The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+                Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+                This field was immutable in Kubernetes <= 1.22 and now is mutable.
+              type: boolean
+            tokenRequests:
+              description: |-
+                TokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+                  "<audience>": {
+                    "token": <token>,
+                    "expirationTimestamp": <expiration timestamp in RFC3339>,
+                  },
+                  ...
+                }
+
+                Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+              items:
+                description: TokenRequest contains parameters of a service account
+                  token.
+                properties:
+                  audience:
+                    description: Audience is the intended audience of the token in
+                      "TokenRequestSpec". It will default to the audiences of kube
+                      apiserver.
+                    type: string
+                  expirationSeconds:
+                    description: ExpirationSeconds is the duration of validity of
+                      the token in "TokenRequestSpec". It has the same default value
+                      of "ExpirationSeconds" in "TokenRequestSpec".
+                    format: int64
+                    type: integer
+                required:
+                - audience
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            volumeLifecycleModes:
+              description: |-
+                volumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism. The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume. For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future. This field is beta.
+
+                This field is immutable.
+              items:
+                type: string
+              type: array
+              x-kubernetes-list-type: set
+          type: object
+      required:
+      - spec
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-csinodes.storage.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-csinodes.storage.k8s.io.yaml
@@ -1,0 +1,111 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.csinodes.storage.k8s.io
+spec:
+  group: storage.k8s.io
+  names:
+    kind: CSINode
+    listKind: CSINodeList
+    plural: csinodes
+    singular: csinode
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: CSINode holds information about all CSI drivers installed on a
+        node. CSI drivers do not need to create the CSINode object directly. As long
+        as they use the node-driver-registrar sidecar container, the kubelet will
+        automatically populate the CSINode object for the CSI driver as part of kubelet
+        plugin registration. CSINode has the same name as a node. If the object is
+        missing, it means either there are no CSI Drivers available on the node, or
+        the Kubelet version is low enough that it doesn't create this object. CSINode
+        has an OwnerReference that points to the corresponding node object.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: spec is the specification of CSINode
+          properties:
+            drivers:
+              description: drivers is a list of information of all CSI Drivers existing
+                on a node. If all drivers in the list are uninstalled, this can become
+                empty.
+              items:
+                description: CSINodeDriver holds information about the specification
+                  of one CSI driver installed on a node
+                properties:
+                  allocatable:
+                    description: allocatable represents the volume resources of a
+                      node that are available for scheduling. This field is beta.
+                    properties:
+                      count:
+                        description: Maximum number of unique volumes managed by the
+                          CSI driver that can be used on a node. A volume that is
+                          both attached and mounted on a node is considered to be
+                          used once, not twice. The same rule applies for a unique
+                          volume that is shared among multiple pods on the same node.
+                          If this field is not specified, then the supported number
+                          of volumes on this node is unbounded.
+                        format: int32
+                        type: integer
+                    type: object
+                  name:
+                    description: This is the name of the CSI driver that this object
+                      refers to. This MUST be the same name returned by the CSI GetPluginName()
+                      call for that driver.
+                    type: string
+                  nodeID:
+                    description: nodeID of the node from the driver point of view.
+                      This field enables Kubernetes to communicate with storage systems
+                      that do not share the same nomenclature for nodes. For example,
+                      Kubernetes may refer to a given node as "node1", but the storage
+                      system may refer to the same node as "nodeA". When Kubernetes
+                      issues a command to the storage system to attach a volume to
+                      a specific node, it can use this field to refer to the node
+                      name using the ID that the storage system will understand, e.g.
+                      "nodeA" instead of "node1". This field is required.
+                    type: string
+                  topologyKeys:
+                    description: topologyKeys is the list of keys supported by the
+                      driver. When a driver is initialized on a cluster, it provides
+                      a set of topology keys that it understands (e.g. "company.com/zone",
+                      "company.com/region"). When a driver is initialized on a node,
+                      it provides the same topology keys along with values. Kubelet
+                      will expose these topology keys as labels on its own node object.
+                      When Kubernetes does topology aware provisioning, it can use
+                      this list to determine which labels it should retrieve from
+                      the node object and pass back to the driver. It is possible
+                      for different nodes to use different topology keys. This can
+                      be empty if driver does not support topology.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - name
+                - nodeID
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - name
+              x-kubernetes-list-type: map
+          required:
+          - drivers
+          type: object
+      required:
+      - spec
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-flowschemas.flowcontrol.apiserver.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-flowschemas.flowcontrol.apiserver.k8s.io.yaml
@@ -1,0 +1,300 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.flowschemas.flowcontrol.apiserver.k8s.io
+spec:
+  group: flowcontrol.apiserver.k8s.io
+  names:
+    kind: FlowSchema
+    listKind: FlowSchemaList
+    plural: flowschemas
+    singular: flowschema
+  scope: Cluster
+  versions:
+  - name: v1beta2
+    schema:
+      description: 'FlowSchema defines the schema of a group of flows. Note that a
+        flow is made up of a set of inbound API requests with similar attributes and
+        is identified by a pair of strings: the name of the FlowSchema and a "flow
+        distinguisher".'
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: '`spec` is the specification of the desired behavior of a FlowSchema.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            distinguisherMethod:
+              description: '`distinguisherMethod` defines how to compute the flow
+                distinguisher for requests that match this schema. `nil` specifies
+                that the distinguisher is disabled and thus will always be the empty
+                string.'
+              properties:
+                type:
+                  description: '`type` is the type of flow distinguisher method The
+                    supported types are "ByUser" and "ByNamespace". Required.'
+                  type: string
+              required:
+              - type
+              type: object
+            matchingPrecedence:
+              description: '`matchingPrecedence` is used to choose among the FlowSchemas
+                that match a given request. The chosen FlowSchema is among those with
+                the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each
+                MatchingPrecedence value must be ranged in [1,10000]. Note that if
+                the precedence is not specified, it will be set to 1000 as default.'
+              format: int32
+              type: integer
+            priorityLevelConfiguration:
+              description: '`priorityLevelConfiguration` should reference a PriorityLevelConfiguration
+                in the cluster. If the reference cannot be resolved, the FlowSchema
+                will be ignored and marked as invalid in its status. Required.'
+              properties:
+                name:
+                  description: '`name` is the name of the priority level configuration
+                    being referenced Required.'
+                  type: string
+              required:
+              - name
+              type: object
+            rules:
+              description: '`rules` describes which requests will match this flow
+                schema. This FlowSchema matches a request if and only if at least
+                one member of rules matches the request. if it is an empty slice,
+                there will be no requests matching the FlowSchema.'
+              items:
+                description: PolicyRulesWithSubjects prescribes a test that applies
+                  to a request to an apiserver. The test considers the subject making
+                  the request, the verb being requested, and the resource to be acted
+                  upon. This PolicyRulesWithSubjects matches a request if and only
+                  if both (a) at least one member of subjects matches the request
+                  and (b) at least one member of resourceRules or nonResourceRules
+                  matches the request.
+                properties:
+                  nonResourceRules:
+                    description: '`nonResourceRules` is a list of NonResourcePolicyRules
+                      that identify matching requests according to their verb and
+                      the target non-resource URL.'
+                    items:
+                      description: NonResourcePolicyRule is a predicate that matches
+                        non-resource requests according to their verb and the target
+                        non-resource URL. A NonResourcePolicyRule matches a request
+                        if and only if both (a) at least one member of verbs matches
+                        the request and (b) at least one member of nonResourceURLs
+                        matches the request.
+                      properties:
+                        nonResourceURLs:
+                          description: |-
+                            `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+                              - "/healthz" is legal
+                              - "/hea*" is illegal
+                              - "/hea" is legal but matches nothing
+                              - "/hea/*" also matches nothing
+                              - "/healthz/*" matches all per-component health checks.
+                            "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        verbs:
+                          description: '`verbs` is a list of matching verbs and may
+                            not be empty. "*" matches all verbs. If it is present,
+                            it must be the only entry. Required.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      required:
+                      - verbs
+                      - nonResourceURLs
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resourceRules:
+                    description: '`resourceRules` is a slice of ResourcePolicyRules
+                      that identify matching requests according to their verb and
+                      the target resource. At least one of `resourceRules` and `nonResourceRules`
+                      has to be non-empty.'
+                    items:
+                      description: 'ResourcePolicyRule is a predicate that matches
+                        some resource requests, testing the request''s verb and the
+                        target resource. A ResourcePolicyRule matches a resource request
+                        if and only if: (a) at least one member of verbs matches the
+                        request, (b) at least one member of apiGroups matches the
+                        request, (c) at least one member of resources matches the
+                        request, and (d) either (d1) the request does not specify
+                        a namespace (i.e., `Namespace==""`) and clusterScope is true
+                        or (d2) the request specifies a namespace and least one member
+                        of namespaces matches the request''s namespace.'
+                      properties:
+                        apiGroups:
+                          description: '`apiGroups` is a list of matching API groups
+                            and may not be empty. "*" matches all API groups and,
+                            if present, must be the only entry. Required.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        clusterScope:
+                          description: '`clusterScope` indicates whether to match
+                            requests that do not specify a namespace (which happens
+                            either because the resource is not namespaced or the request
+                            targets all namespaces). If this field is omitted or false
+                            then the `namespaces` field must contain a non-empty list.'
+                          type: boolean
+                        namespaces:
+                          description: '`namespaces` is a list of target namespaces
+                            that restricts matches.  A request that specifies a target
+                            namespace matches only if either (a) this list contains
+                            that target namespace or (b) this list contains "*".  Note
+                            that "*" matches any specified namespace but does not
+                            match a request that _does not specify_ a namespace (see
+                            the `clusterScope` field for that). This list may be empty,
+                            but only if `clusterScope` is true.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        resources:
+                          description: '`resources` is a list of matching resources
+                            (i.e., lowercase and plural) with, if desired, subresource.  For
+                            example, [ "services", "nodes/status" ].  This list may
+                            not be empty. "*" matches all resources and, if present,
+                            must be the only entry. Required.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        verbs:
+                          description: '`verbs` is a list of matching verbs and may
+                            not be empty. "*" matches all verbs and, if present, must
+                            be the only entry. Required.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                      required:
+                      - verbs
+                      - apiGroups
+                      - resources
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  subjects:
+                    description: subjects is the list of normal user, serviceaccount,
+                      or group that this rule cares about. There must be at least
+                      one member in this slice. A slice that includes both the system:authenticated
+                      and system:unauthenticated user groups matches every request.
+                      Required.
+                    items:
+                      description: Subject matches the originator of a request, as
+                        identified by the request authentication system. There are
+                        three ways of matching an originator; by user, group, or service
+                        account.
+                      properties:
+                        group:
+                          description: '`group` matches based on user group name.'
+                          properties:
+                            name:
+                              description: name is the user group that matches, or
+                                "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go
+                                for some well-known group names. Required.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        kind:
+                          description: '`kind` indicates which one of the other fields
+                            is non-empty. Required'
+                          type: string
+                        serviceAccount:
+                          description: '`serviceAccount` matches ServiceAccounts.'
+                          properties:
+                            name:
+                              description: '`name` is the name of matching ServiceAccount
+                                objects, or "*" to match regardless of name. Required.'
+                              type: string
+                            namespace:
+                              description: '`namespace` is the namespace of matching
+                                ServiceAccount objects. Required.'
+                              type: string
+                          required:
+                          - namespace
+                          - name
+                          type: object
+                        user:
+                          description: '`user` matches based on username.'
+                          properties:
+                            name:
+                              description: '`name` is the username that matches, or
+                                "*" to match all usernames. Required.'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - kind
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - subjects
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+          required:
+          - priorityLevelConfiguration
+          type: object
+        status:
+          description: '`status` is the current status of a FlowSchema. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            conditions:
+              description: '`conditions` is a list of the current states of FlowSchema.'
+              items:
+                description: FlowSchemaCondition describes conditions for a FlowSchema.
+                properties:
+                  lastTransitionTime:
+                    description: '`lastTransitionTime` is the last time the condition
+                      transitioned from one status to another.'
+                    format: date-time
+                    type: string
+                  message:
+                    description: '`message` is a human-readable message indicating
+                      details about last transition.'
+                    type: string
+                  reason:
+                    description: '`reason` is a unique, one-word, CamelCase reason
+                      for the condition''s last transition.'
+                    type: string
+                  status:
+                    description: '`status` is the status of the condition. Can be
+                      True, False, Unknown. Required.'
+                    type: string
+                  type:
+                    description: '`type` is the type of the condition. Required.'
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-ingressclasses.networking.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-ingressclasses.networking.k8s.io.yaml
@@ -1,0 +1,80 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.ingressclasses.networking.k8s.io
+spec:
+  group: networking.k8s.io
+  names:
+    kind: IngressClass
+    listKind: IngressClassList
+    plural: ingressclasses
+    singular: ingressclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: IngressClass represents the class of the Ingress, referenced by
+        the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation
+        can be used to indicate that an IngressClass should be considered default.
+        When a single IngressClass resource has this annotation set to true, new Ingress
+        resources without a class specified will be assigned this default class.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'Spec is the desired state of the IngressClass. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            controller:
+              description: Controller refers to the name of the controller that should
+                handle this class. This allows for different "flavors" that are controlled
+                by the same controller. For example, you may have different Parameters
+                for the same implementing controller. This should be specified as
+                a domain-prefixed path no more than 250 characters in length, e.g.
+                "acme.io/ingress-controller". This field is immutable.
+              type: string
+            parameters:
+              description: Parameters is a link to a custom resource containing additional
+                configuration for the controller. This is optional if the controller
+                does not require extra parameters.
+              properties:
+                apiGroup:
+                  description: APIGroup is the group for the resource being referenced.
+                    If APIGroup is not specified, the specified Kind must be in the
+                    core API group. For any other third-party types, APIGroup is required.
+                  type: string
+                kind:
+                  description: Kind is the type of resource being referenced.
+                  type: string
+                name:
+                  description: Name is the name of resource being referenced.
+                  type: string
+                namespace:
+                  description: Namespace is the namespace of the resource being referenced.
+                    This field is required when scope is set to "Namespace" and must
+                    be unset when scope is set to "Cluster".
+                  type: string
+                scope:
+                  description: Scope represents if this refers to a cluster or namespace
+                    scoped resource. This may be set to "Cluster" (default) or "Namespace".
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-persistentvolumes.core.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-persistentvolumes.core.k8s.io.yaml
@@ -1,0 +1,1068 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.persistentvolumes.core
+spec:
+  group: ""
+  names:
+    kind: PersistentVolume
+    listKind: PersistentVolumeList
+    plural: persistentvolumes
+    shortNames:
+    - pv
+    singular: persistentvolume
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: 'PersistentVolume (PV) is a storage resource provisioned by an
+        administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes'
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'spec defines a specification of a persistent volume owned
+            by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes'
+          properties:
+            accessModes:
+              description: 'accessModes contains all ways the volume can be mounted.
+                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
+              items:
+                type: string
+              type: array
+            awsElasticBlockStore:
+              description: 'awsElasticBlockStore represents an AWS Disk resource that
+                is attached to a kubelet''s host machine and then exposed to the pod.
+                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+              properties:
+                fsType:
+                  description: 'fsType is the filesystem type of the volume that you
+                    want to mount. Tip: Ensure that the filesystem type is supported
+                    by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                    Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  type: string
+                partition:
+                  description: 'partition is the partition in the volume that you
+                    want to mount. If omitted, the default is to mount by volume name.
+                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                    Similarly, the volume partition for /dev/sda is "0" (or you can
+                    leave the property empty).'
+                  format: int32
+                  type: integer
+                readOnly:
+                  description: 'readOnly value true will force the readOnly setting
+                    in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  type: boolean
+                volumeID:
+                  description: 'volumeID is unique ID of the persistent disk resource
+                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                  type: string
+              required:
+              - volumeID
+              type: object
+            azureDisk:
+              description: azureDisk represents an Azure Data Disk mount on the host
+                and bind mount to the pod.
+              properties:
+                cachingMode:
+                  description: 'cachingMode is the Host Caching mode: None, Read Only,
+                    Read Write.'
+                  type: string
+                diskName:
+                  description: diskName is the Name of the data disk in the blob storage
+                  type: string
+                diskURI:
+                  description: diskURI is the URI of data disk in the blob storage
+                  type: string
+                fsType:
+                  description: fsType is Filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                kind:
+                  description: 'kind expected values are Shared: multiple blob disks
+                    per storage account  Dedicated: single blob disk per storage account  Managed:
+                    azure managed data disk (only in managed availability set). defaults
+                    to shared'
+                  type: string
+                readOnly:
+                  description: readOnly Defaults to false (read/write). ReadOnly here
+                    will force the ReadOnly setting in VolumeMounts.
+                  type: boolean
+              required:
+              - diskName
+              - diskURI
+              type: object
+            azureFile:
+              description: azureFile represents an Azure File Service mount on the
+                host and bind mount to the pod.
+              properties:
+                readOnly:
+                  description: readOnly defaults to false (read/write). ReadOnly here
+                    will force the ReadOnly setting in VolumeMounts.
+                  type: boolean
+                secretName:
+                  description: secretName is the name of secret that contains Azure
+                    Storage Account Name and Key
+                  type: string
+                secretNamespace:
+                  description: secretNamespace is the namespace of the secret that
+                    contains Azure Storage Account Name and Key default is the same
+                    as the Pod
+                  type: string
+                shareName:
+                  description: shareName is the azure Share Name
+                  type: string
+              required:
+              - secretName
+              - shareName
+              type: object
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: 'capacity is the description of the persistent volume''s
+                resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
+              type: object
+            cephfs:
+              description: cephFS represents a Ceph FS mount on the host that shares
+                a pod's lifetime
+              properties:
+                monitors:
+                  description: 'monitors is Required: Monitors is a collection of
+                    Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                  items:
+                    type: string
+                  type: array
+                path:
+                  description: 'path is Optional: Used as the mounted root, rather
+                    than the full Ceph tree, default is /'
+                  type: string
+                readOnly:
+                  description: 'readOnly is Optional: Defaults to false (read/write).
+                    ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                  type: boolean
+                secretFile:
+                  description: 'secretFile is Optional: SecretFile is the path to
+                    key ring for User, default is /etc/ceph/user.secret More info:
+                    https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                  type: string
+                secretRef:
+                  description: 'secretRef is Optional: SecretRef is reference to the
+                    authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                user:
+                  description: 'user is Optional: User is the rados user name, default
+                    is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                  type: string
+              required:
+              - monitors
+              type: object
+            cinder:
+              description: 'cinder represents a cinder volume attached and mounted
+                on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+              properties:
+                fsType:
+                  description: 'fsType Filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Examples: "ext4",
+                    "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  type: string
+                readOnly:
+                  description: 'readOnly is Optional: Defaults to false (read/write).
+                    ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  type: boolean
+                secretRef:
+                  description: 'secretRef is Optional: points to a secret object containing
+                    parameters used to connect to OpenStack.'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                volumeID:
+                  description: 'volumeID used to identify the volume in cinder. More
+                    info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                  type: string
+              required:
+              - volumeID
+              type: object
+            claimRef:
+              description: 'claimRef is part of a bi-directional binding between PersistentVolume
+                and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName
+                is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            csi:
+              description: csi represents storage that is handled by an external CSI
+                driver (Beta feature).
+              properties:
+                controllerExpandSecretRef:
+                  description: controllerExpandSecretRef is a reference to the secret
+                    object containing sensitive information to pass to the CSI driver
+                    to complete the CSI ControllerExpandVolume call. This is an beta
+                    field and requires enabling ExpandCSIVolumes feature gate. This
+                    field is optional, and may be empty if no secret is required.
+                    If the secret object contains more than one secret, all secrets
+                    are passed.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                controllerPublishSecretRef:
+                  description: controllerPublishSecretRef is a reference to the secret
+                    object containing sensitive information to pass to the CSI driver
+                    to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume
+                    calls. This field is optional, and may be empty if no secret is
+                    required. If the secret object contains more than one secret,
+                    all secrets are passed.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                driver:
+                  description: driver is the name of the driver to use for this volume.
+                    Required.
+                  type: string
+                fsType:
+                  description: fsType to mount. Must be a filesystem type supported
+                    by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                  type: string
+                nodeExpandSecretRef:
+                  description: nodeExpandSecretRef is a reference to the secret object
+                    containing sensitive information to pass to the CSI driver to
+                    complete the CSI NodeExpandVolume call. This is an alpha field
+                    and requires enabling CSINodeExpandSecret feature gate. This field
+                    is optional, may be omitted if no secret is required. If the secret
+                    object contains more than one secret, all secrets are passed.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                nodePublishSecretRef:
+                  description: nodePublishSecretRef is a reference to the secret object
+                    containing sensitive information to pass to the CSI driver to
+                    complete the CSI NodePublishVolume and NodeUnpublishVolume calls.
+                    This field is optional, and may be empty if no secret is required.
+                    If the secret object contains more than one secret, all secrets
+                    are passed.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                nodeStageSecretRef:
+                  description: nodeStageSecretRef is a reference to the secret object
+                    containing sensitive information to pass to the CSI driver to
+                    complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume
+                    calls. This field is optional, and may be empty if no secret is
+                    required. If the secret object contains more than one secret,
+                    all secrets are passed.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                readOnly:
+                  description: readOnly value to pass to ControllerPublishVolumeRequest.
+                    Defaults to false (read/write).
+                  type: boolean
+                volumeAttributes:
+                  additionalProperties:
+                    type: string
+                  description: volumeAttributes of the volume to publish.
+                  type: object
+                volumeHandle:
+                  description: volumeHandle is the unique volume name returned by
+                    the CSI volume plugin’s CreateVolume to refer to the volume on
+                    all subsequent calls. Required.
+                  type: string
+              required:
+              - driver
+              - volumeHandle
+              type: object
+            fc:
+              description: fc represents a Fibre Channel resource that is attached
+                to a kubelet's host machine and then exposed to the pod.
+              properties:
+                fsType:
+                  description: fsType is the filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                lun:
+                  description: 'lun is Optional: FC target lun number'
+                  format: int32
+                  type: integer
+                readOnly:
+                  description: 'readOnly is Optional: Defaults to false (read/write).
+                    ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                  type: boolean
+                targetWWNs:
+                  description: 'targetWWNs is Optional: FC target worldwide names
+                    (WWNs)'
+                  items:
+                    type: string
+                  type: array
+                wwids:
+                  description: 'wwids Optional: FC volume world wide identifiers (wwids)
+                    Either wwids or combination of targetWWNs and lun must be set,
+                    but not both simultaneously.'
+                  items:
+                    type: string
+                  type: array
+              type: object
+            flexVolume:
+              description: flexVolume represents a generic volume resource that is
+                provisioned/attached using an exec based plugin.
+              properties:
+                driver:
+                  description: driver is the name of the driver to use for this volume.
+                  type: string
+                fsType:
+                  description: fsType is the Filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". The default filesystem depends on FlexVolume script.
+                  type: string
+                options:
+                  additionalProperties:
+                    type: string
+                  description: 'options is Optional: this field holds extra command
+                    options if any.'
+                  type: object
+                readOnly:
+                  description: 'readOnly is Optional: defaults to false (read/write).
+                    ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                  type: boolean
+                secretRef:
+                  description: 'secretRef is Optional: SecretRef is reference to the
+                    secret object containing sensitive information to pass to the
+                    plugin scripts. This may be empty if no secret object is specified.
+                    If the secret object contains more than one secret, all secrets
+                    are passed to the plugin scripts.'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+              required:
+              - driver
+              type: object
+            flocker:
+              description: flocker represents a Flocker volume attached to a kubelet's
+                host machine and exposed to the pod for its usage. This depends on
+                the Flocker control service being running
+              properties:
+                datasetName:
+                  description: datasetName is Name of the dataset stored as metadata
+                    -> name on the dataset for Flocker should be considered as deprecated
+                  type: string
+                datasetUUID:
+                  description: datasetUUID is the UUID of the dataset. This is unique
+                    identifier of a Flocker dataset
+                  type: string
+              type: object
+            gcePersistentDisk:
+              description: 'gcePersistentDisk represents a GCE Disk resource that
+                is attached to a kubelet''s host machine and then exposed to the pod.
+                Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+              properties:
+                fsType:
+                  description: 'fsType is filesystem type of the volume that you want
+                    to mount. Tip: Ensure that the filesystem type is supported by
+                    the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                    inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  type: string
+                partition:
+                  description: 'partition is the partition in the volume that you
+                    want to mount. If omitted, the default is to mount by volume name.
+                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                    Similarly, the volume partition for /dev/sda is "0" (or you can
+                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  format: int32
+                  type: integer
+                pdName:
+                  description: 'pdName is unique name of the PD resource in GCE. Used
+                    to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  type: string
+                readOnly:
+                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts.
+                    Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                  type: boolean
+              required:
+              - pdName
+              type: object
+            glusterfs:
+              description: 'glusterfs represents a Glusterfs volume that is attached
+                to a host and exposed to the pod. Provisioned by an admin. More info:
+                https://examples.k8s.io/volumes/glusterfs/README.md'
+              properties:
+                endpoints:
+                  description: 'endpoints is the endpoint name that details Glusterfs
+                    topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                  type: string
+                endpointsNamespace:
+                  description: 'endpointsNamespace is the namespace that contains
+                    Glusterfs endpoint. If this field is empty, the EndpointNamespace
+                    defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                  type: string
+                path:
+                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                  type: string
+                readOnly:
+                  description: 'readOnly here will force the Glusterfs volume to be
+                    mounted with read-only permissions. Defaults to false. More info:
+                    https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                  type: boolean
+              required:
+              - endpoints
+              - path
+              type: object
+            hostPath:
+              description: 'hostPath represents a directory on the host. Provisioned
+                by a developer or tester. This is useful for single-node development
+                and testing only! On-host storage is not supported in any way and
+                WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+              properties:
+                path:
+                  description: 'path of the directory on the host. If the path is
+                    a symlink, it will follow the link to the real path. More info:
+                    https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  type: string
+                type:
+                  description: 'type for HostPath Volume Defaults to "" More info:
+                    https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                  type: string
+              required:
+              - path
+              type: object
+            iscsi:
+              description: iscsi represents an ISCSI Disk resource that is attached
+                to a kubelet's host machine and then exposed to the pod. Provisioned
+                by an admin.
+              properties:
+                chapAuthDiscovery:
+                  description: chapAuthDiscovery defines whether support iSCSI Discovery
+                    CHAP authentication
+                  type: boolean
+                chapAuthSession:
+                  description: chapAuthSession defines whether support iSCSI Session
+                    CHAP authentication
+                  type: boolean
+                fsType:
+                  description: 'fsType is the filesystem type of the volume that you
+                    want to mount. Tip: Ensure that the filesystem type is supported
+                    by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                    Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                  type: string
+                initiatorName:
+                  description: initiatorName is the custom iSCSI Initiator Name. If
+                    initiatorName is specified with iscsiInterface simultaneously,
+                    new iSCSI interface <target portal>:<volume name> will be created
+                    for the connection.
+                  type: string
+                iqn:
+                  description: iqn is Target iSCSI Qualified Name.
+                  type: string
+                iscsiInterface:
+                  description: iscsiInterface is the interface Name that uses an iSCSI
+                    transport. Defaults to 'default' (tcp).
+                  type: string
+                lun:
+                  description: lun is iSCSI Target Lun number.
+                  format: int32
+                  type: integer
+                portals:
+                  description: portals is the iSCSI Target Portal List. The Portal
+                    is either an IP or ip_addr:port if the port is other than default
+                    (typically TCP ports 860 and 3260).
+                  items:
+                    type: string
+                  type: array
+                readOnly:
+                  description: readOnly here will force the ReadOnly setting in VolumeMounts.
+                    Defaults to false.
+                  type: boolean
+                secretRef:
+                  description: secretRef is the CHAP Secret for iSCSI target and initiator
+                    authentication
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                targetPortal:
+                  description: targetPortal is iSCSI Target Portal. The Portal is
+                    either an IP or ip_addr:port if the port is other than default
+                    (typically TCP ports 860 and 3260).
+                  type: string
+              required:
+              - targetPortal
+              - iqn
+              - lun
+              type: object
+            local:
+              description: local represents directly-attached storage with node affinity
+              properties:
+                fsType:
+                  description: fsType is the filesystem type to mount. It applies
+                    only when the Path is a block device. Must be a filesystem type
+                    supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                    The default value is to auto-select a filesystem if unspecified.
+                  type: string
+                path:
+                  description: path of the full path to the volume on the node. It
+                    can be either a directory or block device (disk, partition, ...).
+                  type: string
+              required:
+              - path
+              type: object
+            mountOptions:
+              description: 'mountOptions is the list of mount options, e.g. ["ro",
+                "soft"]. Not validated - mount will simply fail if one is invalid.
+                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+              items:
+                type: string
+              type: array
+            nfs:
+              description: 'nfs represents an NFS mount on the host. Provisioned by
+                an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+              properties:
+                path:
+                  description: 'path that is exported by the NFS server. More info:
+                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  type: string
+                readOnly:
+                  description: 'readOnly here will force the NFS export to be mounted
+                    with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  type: boolean
+                server:
+                  description: 'server is the hostname or IP address of the NFS server.
+                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                  type: string
+              required:
+              - server
+              - path
+              type: object
+            nodeAffinity:
+              description: nodeAffinity defines constraints that limit what nodes
+                this volume can be accessed from. This field influences the scheduling
+                of pods that use this volume.
+              properties:
+                required:
+                  description: required specifies hard node constraints that must
+                    be met.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms. The terms
+                        are ORed.
+                      items:
+                        description: A null or empty node selector term matches no
+                          objects. The requirements of them are ANDed. The TopologySelectorTerm
+                          type implements a subset of the NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements by node's
+                              labels.
+                            items:
+                              description: A node selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                    Possible enum values:
+                                     - `"DoesNotExist"`
+                                     - `"Exists"`
+                                     - `"Gt"`
+                                     - `"In"`
+                                     - `"Lt"`
+                                     - `"NotIn"`
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the
+                                    values array must be empty. If the operator is
+                                    Gt or Lt, the values array must have a single
+                                    element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements by node's
+                              fields.
+                            items:
+                              description: A node selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                    Possible enum values:
+                                     - `"DoesNotExist"`
+                                     - `"Exists"`
+                                     - `"Gt"`
+                                     - `"In"`
+                                     - `"Lt"`
+                                     - `"NotIn"`
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the
+                                    values array must be empty. If the operator is
+                                    Gt or Lt, the values array must have a single
+                                    element, which will be interpreted as an integer.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+              type: object
+            persistentVolumeReclaimPolicy:
+              description: |-
+                persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+                Possible enum values:
+                 - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+                 - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+                 - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+              type: string
+            photonPersistentDisk:
+              description: photonPersistentDisk represents a PhotonController persistent
+                disk attached and mounted on kubelets host machine
+              properties:
+                fsType:
+                  description: fsType is the filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                pdID:
+                  description: pdID is the ID that identifies Photon Controller persistent
+                    disk
+                  type: string
+              required:
+              - pdID
+              type: object
+            portworxVolume:
+              description: portworxVolume represents a portworx volume attached and
+                mounted on kubelets host machine
+              properties:
+                fsType:
+                  description: fSType represents the filesystem type to mount Must
+                    be a filesystem type supported by the host operating system. Ex.
+                    "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                readOnly:
+                  description: readOnly defaults to false (read/write). ReadOnly here
+                    will force the ReadOnly setting in VolumeMounts.
+                  type: boolean
+                volumeID:
+                  description: volumeID uniquely identifies a Portworx volume
+                  type: string
+              required:
+              - volumeID
+              type: object
+            quobyte:
+              description: quobyte represents a Quobyte mount on the host that shares
+                a pod's lifetime
+              properties:
+                group:
+                  description: group to map volume access to Default is no group
+                  type: string
+                readOnly:
+                  description: readOnly here will force the Quobyte volume to be mounted
+                    with read-only permissions. Defaults to false.
+                  type: boolean
+                registry:
+                  description: registry represents a single or multiple Quobyte Registry
+                    services specified as a string as host:port pair (multiple entries
+                    are separated with commas) which acts as the central registry
+                    for volumes
+                  type: string
+                tenant:
+                  description: tenant owning the given Quobyte volume in the Backend
+                    Used with dynamically provisioned Quobyte volumes, value is set
+                    by the plugin
+                  type: string
+                user:
+                  description: user to map volume access to Defaults to serivceaccount
+                    user
+                  type: string
+                volume:
+                  description: volume is a string that references an already created
+                    Quobyte volume by name.
+                  type: string
+              required:
+              - registry
+              - volume
+              type: object
+            rbd:
+              description: 'rbd represents a Rados Block Device mount on the host
+                that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+              properties:
+                fsType:
+                  description: 'fsType is the filesystem type of the volume that you
+                    want to mount. Tip: Ensure that the filesystem type is supported
+                    by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                    Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                  type: string
+                image:
+                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  type: string
+                keyring:
+                  description: 'keyring is the path to key ring for RBDUser. Default
+                    is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  type: string
+                monitors:
+                  description: 'monitors is a collection of Ceph monitors. More info:
+                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  items:
+                    type: string
+                  type: array
+                pool:
+                  description: 'pool is the rados pool name. Default is rbd. More
+                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  type: string
+                readOnly:
+                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts.
+                    Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  type: boolean
+                secretRef:
+                  description: 'secretRef is name of the authentication secret for
+                    RBDUser. If provided overrides keyring. Default is nil. More info:
+                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                user:
+                  description: 'user is the rados user name. Default is admin. More
+                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                  type: string
+              required:
+              - monitors
+              - image
+              type: object
+            scaleIO:
+              description: scaleIO represents a ScaleIO persistent volume attached
+                and mounted on Kubernetes nodes.
+              properties:
+                fsType:
+                  description: fsType is the filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Default is "xfs"
+                  type: string
+                gateway:
+                  description: gateway is the host address of the ScaleIO API Gateway.
+                  type: string
+                protectionDomain:
+                  description: protectionDomain is the name of the ScaleIO Protection
+                    Domain for the configured storage.
+                  type: string
+                readOnly:
+                  description: readOnly defaults to false (read/write). ReadOnly here
+                    will force the ReadOnly setting in VolumeMounts.
+                  type: boolean
+                secretRef:
+                  description: secretRef references to the secret for ScaleIO user
+                    and other sensitive information. If this is not provided, Login
+                    operation will fail.
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference
+                        a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret
+                        name must be unique.
+                      type: string
+                  type: object
+                sslEnabled:
+                  description: sslEnabled is the flag to enable/disable SSL communication
+                    with Gateway, default false
+                  type: boolean
+                storageMode:
+                  description: storageMode indicates whether the storage for a volume
+                    should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                  type: string
+                storagePool:
+                  description: storagePool is the ScaleIO Storage Pool associated
+                    with the protection domain.
+                  type: string
+                system:
+                  description: system is the name of the storage system as configured
+                    in ScaleIO.
+                  type: string
+                volumeName:
+                  description: volumeName is the name of a volume already created
+                    in the ScaleIO system that is associated with this volume source.
+                  type: string
+              required:
+              - gateway
+              - system
+              - secretRef
+              type: object
+            storageClassName:
+              description: storageClassName is the name of StorageClass to which this
+                persistent volume belongs. Empty value means that this volume does
+                not belong to any StorageClass.
+              type: string
+            storageos:
+              description: 'storageOS represents a StorageOS volume that is attached
+                to the kubelet''s host machine and mounted into the pod More info:
+                https://examples.k8s.io/volumes/storageos/README.md'
+              properties:
+                fsType:
+                  description: fsType is the filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                readOnly:
+                  description: readOnly defaults to false (read/write). ReadOnly here
+                    will force the ReadOnly setting in VolumeMounts.
+                  type: boolean
+                secretRef:
+                  description: secretRef specifies the secret to use for obtaining
+                    the StorageOS API credentials.  If not specified, default values
+                    will be attempted.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                volumeName:
+                  description: volumeName is the human-readable name of the StorageOS
+                    volume.  Volume names are only unique within a namespace.
+                  type: string
+                volumeNamespace:
+                  description: volumeNamespace specifies the scope of the volume within
+                    StorageOS.  If no namespace is specified then the Pod's namespace
+                    will be used.  This allows the Kubernetes name scoping to be mirrored
+                    within StorageOS for tighter integration. Set VolumeName to any
+                    name to override the default behaviour. Set to "default" if you
+                    are not using namespaces within StorageOS. Namespaces that do
+                    not pre-exist within StorageOS will be created.
+                  type: string
+              type: object
+            volumeMode:
+              description: volumeMode defines if a volume is intended to be used with
+                a formatted filesystem or to remain in raw block state. Value of Filesystem
+                is implied when not included in spec.
+              type: string
+            vsphereVolume:
+              description: vsphereVolume represents a vSphere volume attached and
+                mounted on kubelets host machine
+              properties:
+                fsType:
+                  description: fsType is filesystem type to mount. Must be a filesystem
+                    type supported by the host operating system. Ex. "ext4", "xfs",
+                    "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                  type: string
+                storagePolicyID:
+                  description: storagePolicyID is the storage Policy Based Management
+                    (SPBM) profile ID associated with the StoragePolicyName.
+                  type: string
+                storagePolicyName:
+                  description: storagePolicyName is the storage Policy Based Management
+                    (SPBM) profile name.
+                  type: string
+                volumePath:
+                  description: volumePath is the path that identifies vSphere volume
+                    vmdk
+                  type: string
+              required:
+              - volumePath
+              type: object
+          type: object
+        status:
+          description: 'status represents the current information/status for the persistent
+            volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes'
+          properties:
+            message:
+              description: message is a human-readable message indicating details
+                about why the volume is in this state.
+              type: string
+            phase:
+              description: |-
+                phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+
+                Possible enum values:
+                 - `"Available"` used for PersistentVolumes that are not yet bound Available volumes are held by the binder and matched to PersistentVolumeClaims
+                 - `"Bound"` used for PersistentVolumes that are bound
+                 - `"Failed"` used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+                 - `"Pending"` used for PersistentVolumes that are not available
+                 - `"Released"` used for PersistentVolumes where the bound PersistentVolumeClaim was deleted released volumes must be recycled before becoming available again this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
+              type: string
+            reason:
+              description: reason is a brief CamelCase string that describes any failure
+                and is meant for machine parsing and tidy display in the CLI.
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-priorityclasses.scheduling.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-priorityclasses.scheduling.k8s.io.yaml
@@ -1,0 +1,61 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.priorityclasses.scheduling.k8s.io
+spec:
+  group: scheduling.k8s.io
+  names:
+    kind: PriorityClass
+    listKind: PriorityClassList
+    plural: priorityclasses
+    shortNames:
+    - pc
+    singular: priorityclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: PriorityClass defines mapping from a priority class name to the
+        priority integer value. The value can be any valid integer.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        description:
+          description: description is an arbitrary string that usually provides guidelines
+            on when this priority class should be used.
+          type: string
+        globalDefault:
+          description: globalDefault specifies whether this PriorityClass should be
+            considered as the default priority for pods that do not have any priority
+            class. Only one PriorityClass can be marked as `globalDefault`. However,
+            if more than one PriorityClasses exists with their `globalDefault` field
+            set to true, the smallest value of such global default PriorityClasses
+            will be used as the default priority.
+          type: boolean
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        preemptionPolicy:
+          description: PreemptionPolicy is the Policy for preempting pods with lower
+            priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority
+            if unset.
+          type: string
+        value:
+          description: The value of this priority class. This is the actual priority
+            that pods receive when they have the name of this class in their pod spec.
+          format: int32
+          type: integer
+      required:
+      - value
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-prioritylevelconfigurations.flowcontrol.apiserver.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-prioritylevelconfigurations.flowcontrol.apiserver.k8s.io.yaml
@@ -1,0 +1,157 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.prioritylevelconfigurations.flowcontrol.apiserver.k8s.io
+spec:
+  group: flowcontrol.apiserver.k8s.io
+  names:
+    kind: PriorityLevelConfiguration
+    listKind: PriorityLevelConfigurationList
+    plural: prioritylevelconfigurations
+    singular: prioritylevelconfiguration
+  scope: Cluster
+  versions:
+  - name: v1beta2
+    schema:
+      description: PriorityLevelConfiguration represents the configuration of a priority
+        level.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: '`spec` is the specification of the desired behavior of a "request-priority".
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            limited:
+              description: '`limited` specifies how requests are handled for a Limited
+                priority level. This field must be non-empty if and only if `type`
+                is `"Limited"`.'
+              properties:
+                assuredConcurrencyShares:
+                  description: |-
+                    `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                                ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+                    bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+                  format: int32
+                  type: integer
+                limitResponse:
+                  description: '`limitResponse` indicates what to do with requests
+                    that can not be executed right now'
+                  properties:
+                    queuing:
+                      description: '`queuing` holds the configuration parameters for
+                        queuing. This field may be non-empty only if `type` is `"Queue"`.'
+                      properties:
+                        handSize:
+                          description: '`handSize` is a small positive number that
+                            configures the shuffle sharding of requests into queues.  When
+                            enqueuing a request at this priority level the request''s
+                            flow identifier (a string pair) is hashed and the hash
+                            value is used to shuffle the list of queues and deal a
+                            hand of the size specified here.  The request is put into
+                            one of the shortest queues in that hand. `handSize` must
+                            be no larger than `queues`, and should be significantly
+                            smaller (so that a few heavy flows do not saturate most
+                            of the queues).  See the user-facing documentation for
+                            more extensive guidance on setting this field.  This field
+                            has a default value of 8.'
+                          format: int32
+                          type: integer
+                        queueLengthLimit:
+                          description: '`queueLengthLimit` is the maximum number of
+                            requests allowed to be waiting in a given queue of this
+                            priority level at a time; excess requests are rejected.  This
+                            value must be positive.  If not specified, it will be
+                            defaulted to 50.'
+                          format: int32
+                          type: integer
+                        queues:
+                          description: '`queues` is the number of queues for this
+                            priority level. The queues exist independently at each
+                            apiserver. The value must be positive.  Setting it to
+                            1 effectively precludes shufflesharding and thus makes
+                            the distinguisher method of associated flow schemas irrelevant.  This
+                            field has a default value of 64.'
+                          format: int32
+                          type: integer
+                      type: object
+                    type:
+                      description: '`type` is "Queue" or "Reject". "Queue" means that
+                        requests that can not be executed upon arrival are held in
+                        a queue until they can be executed or a queuing limit is reached.
+                        "Reject" means that requests that can not be executed upon
+                        arrival are rejected. Required.'
+                      type: string
+                  required:
+                  - type
+                  type: object
+              type: object
+            type:
+              description: '`type` indicates whether this priority level is subject
+                to limitation on request execution.  A value of `"Exempt"` means that
+                requests of this priority level are not subject to a limit (and thus
+                are never queued) and do not detract from the capacity made available
+                to other priority levels.  A value of `"Limited"` means that (a) requests
+                of this priority level _are_ subject to limits and (b) some of the
+                server''s limited capacity is made available exclusively to this priority
+                level. Required.'
+              type: string
+          required:
+          - type
+          type: object
+        status:
+          description: '`status` is the current status of a "request-priority". More
+            info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            conditions:
+              description: '`conditions` is the current state of "request-priority".'
+              items:
+                description: PriorityLevelConfigurationCondition defines the condition
+                  of priority level.
+                properties:
+                  lastTransitionTime:
+                    description: '`lastTransitionTime` is the last time the condition
+                      transitioned from one status to another.'
+                    format: date-time
+                    type: string
+                  message:
+                    description: '`message` is a human-readable message indicating
+                      details about last transition.'
+                    type: string
+                  reason:
+                    description: '`reason` is a unique, one-word, CamelCase reason
+                      for the condition''s last transition.'
+                    type: string
+                  status:
+                    description: '`status` is the status of the condition. Can be
+                      True, False, Unknown. Required.'
+                    type: string
+                  type:
+                    description: '`type` is the type of the condition. Required.'
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-runtimeclasses.node.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-runtimeclasses.node.k8s.io.yaml
@@ -1,0 +1,132 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.runtimeclasses.node.k8s.io
+spec:
+  group: node.k8s.io
+  names:
+    kind: RuntimeClass
+    listKind: RuntimeClassList
+    plural: runtimeclasses
+    singular: runtimeclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: RuntimeClass defines a class of container runtime supported in
+        the cluster. The RuntimeClass is used to determine which container runtime
+        is used to run all containers in a pod. RuntimeClasses are manually defined
+        by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet
+        is responsible for resolving the RuntimeClassName reference before running
+        the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        handler:
+          description: Handler specifies the underlying runtime and configuration
+            that the CRI implementation will use to handle pods of this class. The
+            possible values are specific to the node & CRI configuration.  It is assumed
+            that all handlers are available on every node, and handlers of the same
+            name are equivalent on every node. For example, a handler called "runc"
+            might specify that the runc OCI runtime (using native Linux containers)
+            will be used to run the containers in a pod. The Handler must be lowercase,
+            conform to the DNS Label (RFC 1123) requirements, and is immutable.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        overhead:
+          description: |-
+            Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+             https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
+          properties:
+            podFixed:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: PodFixed represents the fixed resource overhead associated
+                with running a pod.
+              type: object
+          type: object
+        scheduling:
+          description: Scheduling holds the scheduling constraints to ensure that
+            pods running with this RuntimeClass are scheduled to nodes that support
+            it. If scheduling is nil, this RuntimeClass is assumed to be supported
+            by all nodes.
+          properties:
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: nodeSelector lists labels that must be present on nodes
+                that support this RuntimeClass. Pods using this RuntimeClass can only
+                be scheduled to a node matched by this selector. The RuntimeClass
+                nodeSelector is merged with a pod's existing nodeSelector. Any conflicts
+                will cause the pod to be rejected in admission.
+              type: object
+            tolerations:
+              description: tolerations are appended (excluding duplicates) to pods
+                running with this RuntimeClass during admission, effectively unioning
+                the set of nodes tolerated by the pod and the RuntimeClass.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: |-
+                      Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                      Possible enum values:
+                       - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                       - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                       - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: |-
+                      Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                      Possible enum values:
+                       - `"Equal"`
+                       - `"Exists"`
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+          type: object
+      required:
+      - handler
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-storageclasses.storage.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-storageclasses.storage.k8s.io.yaml
@@ -1,0 +1,107 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.storageclasses.storage.k8s.io
+spec:
+  group: storage.k8s.io
+  names:
+    kind: StorageClass
+    listKind: StorageClassList
+    plural: storageclasses
+    shortNames:
+    - sc
+    singular: storageclass
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: |-
+        StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
+
+        StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
+      properties:
+        allowVolumeExpansion:
+          description: AllowVolumeExpansion shows whether the storage class allow
+            volume expand
+          type: boolean
+        allowedTopologies:
+          description: Restrict the node topologies where volumes can be dynamically
+            provisioned. Each volume plugin defines its own supported topology specifications.
+            An empty TopologySelectorTerm list means there is no topology restriction.
+            This field is only honored by servers that enable the VolumeScheduling
+            feature.
+          items:
+            description: A topology selector term represents the result of label queries.
+              A null or empty topology selector term matches no objects. The requirements
+              of them are ANDed. It provides a subset of functionality as NodeSelectorTerm.
+              This is an alpha feature and may change in the future.
+            properties:
+              matchLabelExpressions:
+                description: A list of topology selector requirements by labels.
+                items:
+                  description: A topology selector requirement is a selector that
+                    matches given label. This is an alpha feature and may change in
+                    the future.
+                  properties:
+                    key:
+                      description: The label key that the selector applies to.
+                      type: string
+                    values:
+                      description: An array of string values. One value must match
+                        the label to be selected. Each entry in Values is ORed.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - key
+                  - values
+                  type: object
+                type: array
+            type: object
+          type: array
+          x-kubernetes-list-type: atomic
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        mountOptions:
+          description: Dynamically provisioned PersistentVolumes of this storage class
+            are created with these mountOptions, e.g. ["ro", "soft"]. Not validated
+            - mount of the PVs will simply fail if one is invalid.
+          items:
+            type: string
+          type: array
+        parameters:
+          additionalProperties:
+            type: string
+          description: Parameters holds the parameters for the provisioner that should
+            create volumes of this storage class.
+          type: object
+        provisioner:
+          description: Provisioner indicates the type of the provisioner.
+          type: string
+        reclaimPolicy:
+          description: Dynamically provisioned PersistentVolumes of this storage class
+            are created with this reclaimPolicy. Defaults to Delete.
+          type: string
+        volumeBindingMode:
+          description: VolumeBindingMode indicates how PersistentVolumeClaims should
+            be provisioned and bound.  When unset, VolumeBindingImmediate is used.
+            This field is only honored by servers that enable the VolumeScheduling
+            feature.
+          type: string
+      required:
+      - provisioner
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/cluster-scoped/apiresourceschema-volumeattachments.storage.k8s.io.yaml
+++ b/config/kube/exports/cluster-scoped/apiresourceschema-volumeattachments.storage.k8s.io.yaml
@@ -1,0 +1,1169 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.volumeattachments.storage.k8s.io
+spec:
+  group: storage.k8s.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    singular: volumeattachment
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      description: |-
+        VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+        VolumeAttachment objects are non-namespaced.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired attach/detach volume behavior.
+            Populated by the Kubernetes system.
+          properties:
+            attacher:
+              description: Attacher indicates the name of the volume driver that MUST
+                handle this request. This is the name returned by GetPluginName().
+              type: string
+            nodeName:
+              description: The node that the volume should be attached to.
+              type: string
+            source:
+              description: Source represents the volume that should be attached.
+              properties:
+                inlineVolumeSpec:
+                  description: inlineVolumeSpec contains all the information necessary
+                    to attach a persistent volume defined by a pod's inline VolumeSource.
+                    This field is populated only for the CSIMigration feature. It
+                    contains translated fields from a pod's inline VolumeSource to
+                    a PersistentVolumeSpec. This field is beta-level and is only honored
+                    by servers that enabled the CSIMigration feature.
+                  properties:
+                    accessModes:
+                      description: 'accessModes contains all ways the volume can be
+                        mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes'
+                      items:
+                        type: string
+                      type: array
+                    awsElasticBlockStore:
+                      description: 'awsElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly value true will force the readOnly
+                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'volumeID is unique ID of the persistent disk
+                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: azureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          description: fsType is Filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: azureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        secretNamespace:
+                          description: secretNamespace is the namespace of the secret
+                            that contains Azure Storage Account Name and Key default
+                            is the same as the Pod
+                          type: string
+                        shareName:
+                          description: shareName is the azure Share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    capacity:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'capacity is the description of the persistent
+                        volume''s resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity'
+                      type: object
+                    cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        user:
+                          description: 'user is Optional: User is the rados user name,
+                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType Filesystem type to mount. Must be a
+                            filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is Optional: points to a secret
+                            object containing parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        volumeID:
+                          description: 'volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    claimRef:
+                      description: 'claimRef is part of a bi-directional binding between
+                        PersistentVolume and PersistentVolumeClaim. Expected to be
+                        non-nil when bound. claim.VolumeName is the authoritative
+                        bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding'
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    csi:
+                      description: csi represents storage that is handled by an external
+                        CSI driver (Beta feature).
+                      properties:
+                        controllerExpandSecretRef:
+                          description: controllerExpandSecretRef is a reference to
+                            the secret object containing sensitive information to
+                            pass to the CSI driver to complete the CSI ControllerExpandVolume
+                            call. This is an beta field and requires enabling ExpandCSIVolumes
+                            feature gate. This field is optional, and may be empty
+                            if no secret is required. If the secret object contains
+                            more than one secret, all secrets are passed.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        controllerPublishSecretRef:
+                          description: controllerPublishSecretRef is a reference to
+                            the secret object containing sensitive information to
+                            pass to the CSI driver to complete the CSI ControllerPublishVolume
+                            and ControllerUnpublishVolume calls. This field is optional,
+                            and may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secrets are
+                            passed.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume. Required.
+                          type: string
+                        fsType:
+                          description: fsType to mount. Must be a filesystem type
+                            supported by the host operating system. Ex. "ext4", "xfs",
+                            "ntfs".
+                          type: string
+                        nodeExpandSecretRef:
+                          description: nodeExpandSecretRef is a reference to the secret
+                            object containing sensitive information to pass to the
+                            CSI driver to complete the CSI NodeExpandVolume call.
+                            This is an alpha field and requires enabling CSINodeExpandSecret
+                            feature gate. This field is optional, may be omitted if
+                            no secret is required. If the secret object contains more
+                            than one secret, all secrets are passed.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        nodePublishSecretRef:
+                          description: nodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secrets are
+                            passed.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        nodeStageSecretRef:
+                          description: nodeStageSecretRef is a reference to the secret
+                            object containing sensitive information to pass to the
+                            CSI driver to complete the CSI NodeStageVolume and NodeStageVolume
+                            and NodeUnstageVolume calls. This field is optional, and
+                            may be empty if no secret is required. If the secret object
+                            contains more than one secret, all secrets are passed.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        readOnly:
+                          description: readOnly value to pass to ControllerPublishVolumeRequest.
+                            Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: volumeAttributes of the volume to publish.
+                          type: object
+                        volumeHandle:
+                          description: volumeHandle is the unique volume name returned
+                            by the CSI volume plugin’s CreateVolume to refer to the
+                            volume on all subsequent calls. Required.
+                          type: string
+                      required:
+                      - driver
+                      - volumeHandle
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'wwids Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: flexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: fsType is the Filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                            on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'readOnly is Optional: defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the secret object containing sensitive information
+                            to pass to the plugin scripts. This may be empty if no
+                            secret object is specified. If the secret object contains
+                            more than one secret, all secrets are passed to the plugin
+                            scripts.'
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine and exposed to the pod for its usage.
+                        This depends on the Flocker control service being running
+                      properties:
+                        datasetName:
+                          description: datasetName is Name of the dataset stored as
+                            metadata -> name on the dataset for Flocker should be
+                            considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'gcePersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'fsType is filesystem type of the volume that
+                            you want to mount. Tip: Ensure that the filesystem type
+                            is supported by the host operating system. Examples: "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'pdName is unique name of the PD resource in
+                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    glusterfs:
+                      description: 'glusterfs represents a Glusterfs volume that is
+                        attached to a host and exposed to the pod. Provisioned by
+                        an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'endpoints is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        endpointsNamespace:
+                          description: 'endpointsNamespace is the namespace that contains
+                            Glusterfs endpoint. If this field is empty, the EndpointNamespace
+                            defaults to the same namespace as the bound PVC. More
+                            info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'hostPath represents a directory on the host. Provisioned
+                        by a developer or tester. This is useful for single-node development
+                        and testing only! On-host storage is not supported in any
+                        way and WILL NOT WORK in a multi-node cluster. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      properties:
+                        path:
+                          description: 'path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: iscsi represents an ISCSI Disk resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod. Provisioned by an admin.
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                          type: string
+                        initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name. If initiatorName is specified with iscsiInterface
+                            simultaneously, new iSCSI interface <target portal>:<volume
+                            name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is Target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iscsiInterface is the interface Name that uses
+                            an iSCSI transport. Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun is iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: portals is the iSCSI Target Portal List. The
+                            Portal is either an IP or ip_addr:port if the port is
+                            other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        targetPortal:
+                          description: targetPortal is iSCSI Target Portal. The Portal
+                            is either an IP or ip_addr:port if the port is other than
+                            default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - targetPortal
+                      - iqn
+                      - lun
+                      type: object
+                    local:
+                      description: local represents directly-attached storage with
+                        node affinity
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. It
+                            applies only when the Path is a block device. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default value is to auto-select
+                            a filesystem if unspecified.
+                          type: string
+                        path:
+                          description: path of the full path to the volume on the
+                            node. It can be either a directory or block device (disk,
+                            partition, ...).
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    mountOptions:
+                      description: 'mountOptions is the list of mount options, e.g.
+                        ["ro", "soft"]. Not validated - mount will simply fail if
+                        one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+                      items:
+                        type: string
+                      type: array
+                    nfs:
+                      description: 'nfs represents an NFS mount on the host. Provisioned
+                        by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - server
+                      - path
+                      type: object
+                    nodeAffinity:
+                      description: nodeAffinity defines constraints that limit what
+                        nodes this volume can be accessed from. This field influences
+                        the scheduling of pods that use this volume.
+                      properties:
+                        required:
+                          description: required specifies hard node constraints that
+                            must be met.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    persistentVolumeReclaimPolicy:
+                      description: |-
+                        persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+                        Possible enum values:
+                         - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+                         - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+                         - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+                      type: string
+                    photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
+                      properties:
+                        group:
+                          description: group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: readOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: user to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: 'rbd represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                          type: string
+                        image:
+                          description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        pool:
+                          description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        user:
+                          description: 'user is the rados user name. Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      - image
+                      type: object
+                    scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                        sslEnabled:
+                          description: sslEnabled is the flag to enable/disable SSL
+                            communication with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: volumeName is the name of a volume already
+                            created in the ScaleIO system that is associated with
+                            this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - system
+                      - secretRef
+                      type: object
+                    storageClassName:
+                      description: storageClassName is the name of StorageClass to
+                        which this persistent volume belongs. Empty value means that
+                        this volume does not belong to any StorageClass.
+                      type: string
+                    storageos:
+                      description: 'storageOS represents a StorageOS volume that is
+                        attached to the kubelet''s host machine and mounted into the
+                        pod More info: https://examples.k8s.io/volumes/storageos/README.md'
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object.'
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                        volumeName:
+                          description: volumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    volumeMode:
+                      description: volumeMode defines if a volume is intended to be
+                        used with a formatted filesystem or to remain in raw block
+                        state. Value of Filesystem is implied when not included in
+                        spec.
+                      type: string
+                    vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  type: object
+                persistentVolumeName:
+                  description: Name of the persistent volume to attach.
+                  type: string
+              type: object
+          required:
+          - attacher
+          - source
+          - nodeName
+          type: object
+        status:
+          description: Status of the VolumeAttachment request. Populated by the entity
+            completing the attach or detach operation, i.e. the external-attacher.
+          properties:
+            attachError:
+              description: The last error encountered during attach operation, if
+                any. This field must only be set by the entity completing the attach
+                operation, i.e. the external-attacher.
+              properties:
+                message:
+                  description: String detailing the error encountered during Attach
+                    or Detach operation. This string may be logged, so it should not
+                    contain sensitive information.
+                  type: string
+                time:
+                  description: Time the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            attached:
+              description: Indicates the volume is successfully attached. This field
+                must only be set by the entity completing the attach operation, i.e.
+                the external-attacher.
+              type: boolean
+            attachmentMetadata:
+              additionalProperties:
+                type: string
+              description: Upon successful attach, this field is populated with any
+                information returned by the attach operation that must be passed into
+                subsequent WaitForAttach or Mount calls. This field must only be set
+                by the entity completing the attach operation, i.e. the external-attacher.
+              type: object
+            detachError:
+              description: The last error encountered during detach operation, if
+                any. This field must only be set by the entity completing the detach
+                operation, i.e. the external-attacher.
+              properties:
+                message:
+                  description: String detailing the error encountered during Attach
+                    or Detach operation. This string may be logged, so it should not
+                    contain sensitive information.
+                  type: string
+                time:
+                  description: Time the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+          required:
+          - attached
+          type: object
+      required:
+      - spec
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiexport-apps.yaml
+++ b/config/kube/exports/namespaced/apiexport-apps.yaml
@@ -1,0 +1,11 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: apps
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.daemonsets.apps
+  - v230615-d48020c8.replicasets.apps
+  - v230615-d48020c8.statefulsets.apps
+status: {}

--- a/config/kube/exports/namespaced/apiexport-autoscaling.yaml
+++ b/config/kube/exports/namespaced/apiexport-autoscaling.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: autoscaling
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.horizontalpodautoscalers.autoscaling
+status: {}

--- a/config/kube/exports/namespaced/apiexport-batch.yaml
+++ b/config/kube/exports/namespaced/apiexport-batch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: batch
+spec:
+  latestResourceSchemas:
+  - v230615-6e3cae39.jobs.batch
+  - v230615-d48020c8.cronjobs.batch
+status: {}

--- a/config/kube/exports/namespaced/apiexport-core.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiexport-core.k8s.io.yaml
@@ -1,0 +1,12 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: core.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.endpoints.core
+  - v230615-d48020c8.persistentvolumeclaims.core
+  - v230615-d48020c8.podtemplates.core
+  - v230615-d48020c8.replicationcontrollers.core
+status: {}

--- a/config/kube/exports/namespaced/apiexport-discovery.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiexport-discovery.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: discovery.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.endpointslices.discovery.k8s.io
+status: {}

--- a/config/kube/exports/namespaced/apiexport-networking.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiexport-networking.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: networking.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.networkpolicies.networking.k8s.io
+status: {}

--- a/config/kube/exports/namespaced/apiexport-policy.yaml
+++ b/config/kube/exports/namespaced/apiexport-policy.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: policy
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.poddisruptionbudgets.policy
+status: {}

--- a/config/kube/exports/namespaced/apiexport-storage.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiexport-storage.k8s.io.yaml
@@ -1,0 +1,9 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  creationTimestamp: null
+  name: storage.k8s.io
+spec:
+  latestResourceSchemas:
+  - v230615-d48020c8.csistoragecapacities.storage.k8s.io
+status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-cronjobs.batch.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-cronjobs.batch.yaml
@@ -1,0 +1,8030 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.cronjobs.batch
+spec:
+  group: batch
+  names:
+    categories:
+    - all
+    kind: CronJob
+    listKind: CronJobList
+    plural: cronjobs
+    shortNames:
+    - cj
+    singular: cronjob
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: CronJob represents the configuration of a single cron job.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'Specification of the desired behavior of a cron job, including
+            the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            concurrencyPolicy:
+              description: |-
+                Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+
+                Possible enum values:
+                 - `"Allow"` allows CronJobs to run concurrently.
+                 - `"Forbid"` forbids concurrent runs, skipping next run if previous hasn't finished yet.
+                 - `"Replace"` cancels currently running job and replaces it with a new one.
+              type: string
+            failedJobsHistoryLimit:
+              description: The number of failed finished jobs to retain. Value must
+                be non-negative integer. Defaults to 1.
+              format: int32
+              type: integer
+            jobTemplate:
+              description: Specifies the job that will be created when executing a
+                CronJob.
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata of the jobs created from
+                    this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the job.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Specifies the duration in seconds relative to the
+                        startTime that the job may be continuously active before the
+                        system tries to terminate it; value must be positive integer.
+                        If a Job is suspended (at creation or through an update),
+                        this timer will effectively be stopped and reset when the
+                        Job is resumed again.
+                      format: int64
+                      type: integer
+                    backoffLimit:
+                      description: Specifies the number of retries before marking
+                        this job failed. Defaults to 6
+                      format: int32
+                      type: integer
+                    completionMode:
+                      description: |-
+                        CompletionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+                        `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+                        `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                        More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+                      type: string
+                    completions:
+                      description: 'Specifies the desired number of successfully finished
+                        pods the job should be run with.  Setting to nil means that
+                        the success of any pod signals the success of all pods, and
+                        allows parallelism to have any positive value.  Setting to
+                        1 means that parallelism is limited to 1 and the success of
+                        that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                      format: int32
+                      type: integer
+                    manualSelector:
+                      description: 'manualSelector controls generation of pod labels
+                        and pod selectors. Leave `manualSelector` unset unless you
+                        are certain what you are doing. When false or unset, the system
+                        pick labels unique to this job and appends those labels to
+                        the pod template.  When true, the user is responsible for
+                        picking unique labels and specifying the selector.  Failure
+                        to pick a unique label may cause this and other jobs to not
+                        function correctly.  However, You may see `manualSelector=true`
+                        in jobs that were created with the old `extensions/v1beta1`
+                        API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+                      type: boolean
+                    parallelism:
+                      description: 'Specifies the maximum desired number of pods the
+                        job should run at any given time. The actual number of pods
+                        running in steady state will be less than this number when
+                        ((.spec.completions - .status.successful) < .spec.parallelism),
+                        i.e. when the work left to do is less than max parallelism.
+                        More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                      format: int32
+                      type: integer
+                    podFailurePolicy:
+                      description: |-
+                        Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+                        This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+                      properties:
+                        rules:
+                          description: A list of pod failure policy rules. The rules
+                            are evaluated in order. Once a rule matches a Pod failure,
+                            the remaining of the rules are ignored. When no rule matches
+                            the Pod failure, the default handling applies - the counter
+                            of pod failures is incremented and it is checked against
+                            the backoffLimit. At most 20 elements are allowed.
+                          items:
+                            description: PodFailurePolicyRule describes how a pod
+                              failure is handled when the requirements are met. One
+                              of OnExitCodes and onPodConditions, but not both, can
+                              be used in each rule.
+                            properties:
+                              action:
+                                description: |-
+                                  Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: - FailJob: indicates that the pod's job is marked as Failed and all
+                                    running pods are terminated.
+                                  - Ignore: indicates that the counter towards the .backoffLimit is not
+                                    incremented and a replacement pod is created.
+                                  - Count: indicates that the pod is handled in the default way - the
+                                    counter towards the .backoffLimit is incremented.
+                                  Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+
+                                  Possible enum values:
+                                   - `"Count"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.
+                                   - `"FailJob"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.
+                                   - `"Ignore"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.
+                                type: string
+                              onExitCodes:
+                                description: Represents the requirement on the container
+                                  exit codes.
+                                properties:
+                                  containerName:
+                                    description: Restricts the check for exit codes
+                                      to the container with the specified name. When
+                                      null, the rule applies to all containers. When
+                                      specified, it should match one the container
+                                      or initContainer names in the pod template.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: - In: the requirement is satisfied if at least one container exit code
+                                        (might be multiple if there are multiple containers not restricted
+                                        by the 'containerName' field) is in the set of specified values.
+                                      - NotIn: the requirement is satisfied if at least one container exit code
+                                        (might be multiple if there are multiple containers not restricted
+                                        by the 'containerName' field) is not in the set of specified values.
+                                      Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+
+                                      Possible enum values:
+                                       - `"In"`
+                                       - `"NotIn"`
+                                    type: string
+                                  values:
+                                    description: Specifies the set of values. Each
+                                      returned container exit code (might be multiple
+                                      in case of multiple containers) is checked against
+                                      this set of values with respect to the operator.
+                                      The list of values must be ordered and must
+                                      not contain duplicates. Value '0' cannot be
+                                      used for the In operator. At least one element
+                                      is required. At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                required:
+                                - operator
+                                - values
+                                type: object
+                              onPodConditions:
+                                description: Represents the requirement on the pod
+                                  conditions. The requirement is represented as a
+                                  list of pod condition patterns. The requirement
+                                  is satisfied if at least one pattern matches an
+                                  actual pod condition. At most 20 elements are allowed.
+                                items:
+                                  description: PodFailurePolicyOnPodConditionsPattern
+                                    describes a pattern for matching an actual pod
+                                    condition type.
+                                  properties:
+                                    status:
+                                      description: Specifies the required Pod condition
+                                        status. To match a pod condition it is required
+                                        that the specified status equals the pod condition
+                                        status. Defaults to True.
+                                      type: string
+                                    type:
+                                      description: Specifies the required Pod condition
+                                        type. To match a pod condition it is required
+                                        that specified type equals the pod condition
+                                        type.
+                                      type: string
+                                  required:
+                                  - type
+                                  - status
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - action
+                            - onPodConditions
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - rules
+                      type: object
+                    selector:
+                      description: 'A label query over pods that should match the
+                        pod count. Normally, the system sets this field for you. More
+                        info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    suspend:
+                      description: Suspend specifies whether the Job controller should
+                        create Pods or not. If a Job is created with suspend set to
+                        true, no Pods are created by the Job controller. If a Job
+                        is suspended after creation (i.e. the flag goes from false
+                        to true), the Job controller will delete all active Pods associated
+                        with this Job. Users must design their workload to gracefully
+                        handle this. Suspending a Job will reset the StartTime field
+                        of the Job, effectively resetting the ActiveDeadlineSeconds
+                        timer too. Defaults to false.
+                      type: boolean
+                    template:
+                      description: 'Describes the pod that will be created when executing
+                        a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                      properties:
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        spec:
+                          description: 'Specification of the desired behavior of the
+                            pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                          properties:
+                            activeDeadlineSeconds:
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the system will actively try to mark it failed and
+                                kill associated containers. Value must be a positive
+                                integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node matches the corresponding matchExpressions;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op). A null preferred
+                                          scheduling term matches no objects (i.e.
+                                          is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                        Possible enum values:
+                                                         - `"DoesNotExist"`
+                                                         - `"Exists"`
+                                                         - `"Gt"`
+                                                         - `"In"`
+                                                         - `"Lt"`
+                                                         - `"NotIn"`
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                        Possible enum values:
+                                                         - `"DoesNotExist"`
+                                                         - `"Exists"`
+                                                         - `"Gt"`
+                                                         - `"In"`
+                                                         - `"Lt"`
+                                                         - `"NotIn"`
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - weight
+                                        - preference
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed. The TopologySelectorTerm
+                                              type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                        Possible enum values:
+                                                         - `"DoesNotExist"`
+                                                         - `"Exists"`
+                                                         - `"Gt"`
+                                                         - `"In"`
+                                                         - `"Lt"`
+                                                         - `"NotIn"`
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                        Possible enum values:
+                                                         - `"DoesNotExist"`
+                                                         - `"Exists"`
+                                                         - `"Gt"`
+                                                         - `"In"`
+                                                         - `"Lt"`
+                                                         - `"NotIn"`
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node has pods which matches the corresponding
+                                        podAffinityTerm; the node(s) with the highest
+                                        sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - weight
+                                        - podAffinityTerm
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node. When there are
+                                        multiple elements, the lists of nodes corresponding
+                                        to each podAffinityTerm are intersected, i.e.
+                                        all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions specified by this field, but it
+                                        may choose a node that violates one or more
+                                        of the expressions. The node that is most
+                                        preferred is the one with the greatest sum
+                                        of weights, i.e. for each node that meets
+                                        all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity
+                                        expressions, etc.), compute a sum by iterating
+                                        through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which
+                                        matches the corresponding podAffinityTerm;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - weight
+                                        - podAffinityTerm
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod will not be scheduled onto the
+                                        node. If the anti-affinity requirements specified
+                                        by this field cease to be met at some point
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node. When
+                                        there are multiple elements, the lists of
+                                        nodes corresponding to each podAffinityTerm
+                                        are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
+                              type: boolean
+                            containers:
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed. There
+                                must be at least one container in a Pod. Cannot be
+                                updated.
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                      Possible enum values:
+                                       - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                       - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                       - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                            Possible enum values:
+                                             - `"SCTP"` is the SCTP protocol.
+                                             - `"TCP"` is the TCP protocol.
+                                             - `"UDP"` is the UDP protocol.
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                              Possible enum values:
+                                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                      Possible enum values:
+                                       - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                       - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            dnsConfig:
+                              description: Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated
+                                DNS configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers
+                                    generated from DNSPolicy. Duplicated nameservers
+                                    will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy. Duplicated entries will be removed.
+                                    Resolution options given in Options will override
+                                    those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  description: A list of DNS search domains for host-name
+                                    lookup. This will be appended to the base search
+                                    paths generated from DNSPolicy. Duplicated search
+                                    paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              description: |-
+                                Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                                Possible enum values:
+                                 - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                                 - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                                 - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                                 - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                              type: string
+                            enableServiceLinks:
+                              description: 'EnableServiceLinks indicates whether information
+                                about services should be injected into pod''s environment
+                                variables, matching the syntax of Docker links. Optional:
+                                Defaults to true.'
+                              type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this
+                                pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging.
+                                This list cannot be specified when creating a pod,
+                                and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
+                              items:
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                                  To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                      Possible enum values:
+                                       - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                       - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                       - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL. This name must be unique among
+                                      all containers, init containers and ephemeral
+                                      containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                            Possible enum values:
+                                             - `"SCTP"` is the SCTP protocol.
+                                             - `"TCP"` is the TCP protocol.
+                                             - `"UDP"` is the UDP protocol.
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: Resources are not allowed for ephemeral
+                                      containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                              Possible enum values:
+                                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                      The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                      Possible enum values:
+                                       - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                       - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
+                              items:
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                required:
+                                - ip
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - ip
+                              x-kubernetes-list-type: map
+                            hostIPC:
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostNetwork:
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace. If this option is
+                                set, the ports that will be used must be specified.
+                                Default to false.
+                              type: boolean
+                            hostPID:
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostUsers:
+                              description: 'Use the host''s user namespace. Optional:
+                                Default to true. If set to true or not present, the
+                                pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to
+                                the host user namespace, such as loading a kernel
+                                module with CAP_SYS_MODULE. When set to false, a new
+                                userns is created for the pod. Setting false is useful
+                                for mitigating container breakout vulnerabilities
+                                even allowing users to run their containers as root
+                                without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers
+                                that enable the UserNamespacesSupport feature.'
+                              type: boolean
+                            hostname:
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defined
+                                value.
+                              type: string
+                            imagePullSecrets:
+                              description: 'ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              items:
+                                description: LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            initContainers:
+                              description: 'List of initialization containers belonging
+                                to the pod. Init containers are executed in order
+                                prior to containers being started. If any init container
+                                fails, the pod is considered to have failed and is
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers. Init containers may not have
+                                Lifecycle actions, Readiness probes, Liveness probes,
+                                or Startup probes. The resourceRequirements of an
+                                init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource
+                                type, and then using the max of of that value or the
+                                sum of the normal containers. Limits are applied to
+                                init containers in a similar fashion. Init containers
+                                cannot currently be added or removed. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previously defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                                      Possible enum values:
+                                       - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                                       - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                                       - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                                  Possible enum values:
+                                                   - `"HTTP"` means that the scheme used will be http://
+                                                   - `"HTTPS"` means that the scheme used will be https://
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Not specifying a port here DOES NOT
+                                      prevent that port from being exposed. Any port
+                                      which is listening on the default "0.0.0.0"
+                                      address inside a container will be accessible
+                                      from the network. Modifying this array with
+                                      strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                            Possible enum values:
+                                             - `"SCTP"` is the SCTP protocol.
+                                             - `"TCP"` is the TCP protocol.
+                                             - `"UDP"` is the UDP protocol.
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by
+                                          this container. If seccomp options are provided
+                                          at both the pod & container level, the container
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates
+                                              a profile defined in a file on the node
+                                              should be used. The profile must be
+                                              preconfigured on the node to work. Must
+                                              be a descending path, relative to the
+                                              kubelet's configured seccomp profile
+                                              location. Must only be set if type is
+                                              "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                              Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                              Possible enum values:
+                                               - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                               - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                               - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                              Possible enum values:
+                                               - `"HTTP"` means that the scheme used will be http://
+                                               - `"HTTPS"` means that the scheme used will be https://
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                                      Possible enum values:
+                                       - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                                       - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            nodeName:
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node. If it is non-empty, the
+                                scheduler simply schedules this pod onto that node,
+                                assuming that it fits resource requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must
+                                be true for the pod to fit on a node. Selector which
+                                must match a node''s labels for the pod to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: object
+                            os:
+                              description: |-
+                                Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                                If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                                If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time
+                                by the RuntimeClass admission controller. If the RuntimeClass
+                                admission controller is enabled, overhead must not
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set. If RuntimeClass is configured
+                                and selected in the PodSpec, Overhead will be set
+                                to the value defined in the corresponding RuntimeClass,
+                                otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority. One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset.
+                              type: string
+                            priority:
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod. When
+                                Priority Admission Controller is enabled, it prevents
+                                users from setting this field. The admission controller
+                                populates this field from PriorityClassName. The higher
+                                the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
+                            readinessGates:
+                              description: 'If specified, all readiness gates will
+                                be evaluated for pod readiness. A pod is ready when
+                                all its containers are ready AND all conditions specified
+                                in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                              items:
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              description: |-
+                                Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                                Possible enum values:
+                                 - `"Always"`
+                                 - `"Never"`
+                                 - `"OnFailure"`
+                              type: string
+                            runtimeClassName:
+                              description: 'RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                              type: string
+                            schedulerName:
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler. If not specified, the pod
+                                will be dispatched by default scheduler.
+                              type: string
+                            securityContext:
+                              description: 'SecurityContext holds pod-level security
+                                attributes and common container settings. Optional:
+                                Defaults to empty.  See type description for default
+                                values of each field.'
+                              properties:
+                                fsGroup:
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                                    1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                                    If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  description: 'fsGroupChangePolicy defines behavior
+                                    of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will
+                                    only apply to volume types which support fsGroup
+                                    based ownership(and permissions). It will have
+                                    no effect on ephemeral volume types such as: secret,
+                                    configmaps and emptydir. Valid values are "OnRootMismatch"
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
+                                  type: string
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the
+                                    value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    all containers. If unspecified, the container
+                                    runtime will allocate a random SELinux context
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by the containers
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile
+                                        defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node
+                                        to work. Must be a descending path, relative
+                                        to the kubelet's configured seccomp profile
+                                        location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                        Possible enum values:
+                                         - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                         - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                         - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  description: A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container's primary GID.  If unspecified,
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod. Pods with unsupported sysctls
+                                    (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: 'DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                instead.'
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run this pod. More info:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              type: string
+                            setHostnameAsFQDN:
+                              description: If true the pod's hostname will be configured
+                                as the pod's FQDN, rather than the leaf name (the
+                                default). In Linux containers, this means setting
+                                the FQDN in the hostname field of the kernel (the
+                                nodename field of struct utsname). In Windows containers,
+                                this means setting the registry value of hostname
+                                for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                                to FQDN. If a pod does not have FQDN, this has no
+                                effect. Default to false.
+                              type: boolean
+                            shareProcessNamespace:
+                              description: 'Share a single process namespace between
+                                all of the containers in a pod. When this is set containers
+                                will be able to view and signal processes from other
+                                containers in the same pod, and the first process
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
+                              type: boolean
+                            subdomain:
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                domain>". If not specified, the pod will not have
+                                a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully. May be decreased in delete
+                                request. Value must be non-negative integer. The value
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
+                                signal and the time when the processes are forcibly
+                                halted with a kill signal. Set this value longer than
+                                the expected cleanup time for your process. Defaults
+                                to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect>
+                                  using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                                      Possible enum values:
+                                       - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                                       - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                                       - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists;
+                                      this combination means to match all values and
+                                      all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                                      Possible enum values:
+                                       - `"Equal"`
+                                       - `"Exists"`
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is
+                                      ignored) tolerates the taint. By default, it
+                                      is not set, which means tolerate the taint forever
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration
+                                      matches to. If the operator is Exists, the value
+                                      should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
+                                Scheduler will schedule pods in a way which abides
+                                by the constraints. All topologySpreadConstraints
+                                are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select the pods over which spreading
+                                      will be calculated. The keys are used to lookup
+                                      values from the incoming pod labels, those key-value
+                                      labels are ANDed with labelSelector to select
+                                      the group of existing pods over which spreading
+                                      will be calculated for the incoming pod. Keys
+                                      that don't exist in the incoming pod labels
+                                      will be ignored. A null or empty list means
+                                      only match against labelSelector.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. When
+                                      `whenUnsatisfiable=DoNotSchedule`, it is the
+                                      maximum permitted difference between the number
+                                      of matching pods in the target topology and
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
+                                      cluster, MaxSkew is set to 1, and pods with
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      it is used to give higher precedence to topologies
+                                      that satisfy it. It''s a required field. Default
+                                      value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                      For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                                      This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes meet the requirements
+                                      of nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
+                                      A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                                      Possible enum values:
+                                       - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                                       - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: 'List of volumes that can be mounted by
+                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              items:
+                                description: Volume represents a named volume in a
+                                  pod that may be accessed by any container in the
+                                  pod.
+                                properties:
+                                  awsElasticBlockStore:
+                                    description: 'awsElasticBlockStore represents
+                                      an AWS Disk resource that is attached to a kubelet''s
+                                      host machine and then exposed to the pod. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: string
+                                      partition:
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: boolean
+                                      volumeID:
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    description: azureDisk represents an Azure Data
+                                      Disk mount on the host and bind mount to the
+                                      pod.
+                                    properties:
+                                      cachingMode:
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
+                                        type: string
+                                      diskName:
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
+                                        type: string
+                                      diskURI:
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
+                                        type: string
+                                      fsType:
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      kind:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
+                                          single blob disk per storage account  Managed:
+                                          azure managed data disk (only in managed
+                                          availability set). defaults to shared'
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    description: azureFile represents an Azure File
+                                      Service mount on the host and bind mount to
+                                      the pod.
+                                    properties:
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretName:
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
+                                        type: string
+                                      shareName:
+                                        description: shareName is the azure share
+                                          Name
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    description: cephFS represents a Ceph FS mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      monitors:
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretFile:
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                      secretRef:
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    description: 'cinder represents a cinder volume
+                                      attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      volumeID:
+                                        description: 'volumeID used to identify the
+                                          volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  configMap:
+                                    description: configMap represents a configMap
+                                      that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items if unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the ConfigMap, the volume setup will
+                                          error unless it is marked optional. Paths
+                                          must be relative and may not contain the
+                                          '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  csi:
+                                    description: csi (Container Storage Interface)
+                                      represents ephemeral storage that is handled
+                                      by certain external CSI drivers (Beta feature).
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the CSI
+                                          driver that handles this volume. Consult
+                                          with your admin for the correct name as
+                                          registered in the cluster.
+                                        type: string
+                                      fsType:
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
+                                        type: string
+                                      nodePublishSecretRef:
+                                        description: nodePublishSecretRef is a reference
+                                          to the secret object containing sensitive
+                                          information to pass to the CSI driver to
+                                          complete the CSI NodePublishVolume and NodeUnpublishVolume
+                                          calls. This field is optional, and  may
+                                          be empty if no secret is required. If the
+                                          secret object contains more than one secret,
+                                          all secret references are passed.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      readOnly:
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: volumeAttributes stores driver-specific
+                                          properties that are passed to the CSI driver.
+                                          Consult your driver's documentation for
+                                          supported values.
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI represents downward API
+                                      about the pod that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on
+                                          created files by default. Must be a Optional:
+                                          mode bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: Items is a list of downward API
+                                          volume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used
+                                                to set permissions on this file, must
+                                                be an octal value between 0000 and
+                                                0777 or a decimal value between 0
+                                                and 511. YAML accepts both octal and
+                                                decimal values, JSON requires decimal
+                                                values for mode bits. If not specified,
+                                                the volume defaultMode will be used.
+                                                This might be in conflict with other
+                                                options that affect the file mode,
+                                                like fsGroup, and the result can be
+                                                other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                requests.cpu and requests.memory)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  emptyDir:
+                                    description: 'emptyDir represents a temporary
+                                      directory that shares a pod''s lifetime. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    properties:
+                                      medium:
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                                      Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                         tracking are needed,
+                                      c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                         a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                         information on the connection between this volume type
+                                         and PersistentVolumeClaim).
+
+                                      Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                                      Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                                      A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                                    properties:
+                                      volumeClaimTemplate:
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                          An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                          This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                          Required, must not be nil.
+                                        properties:
+                                          metadata:
+                                            description: May contain labels and annotations
+                                              that will be copied into the PVC when
+                                              creating it. No other fields are allowed
+                                              and will be rejected during validation.
+                                            type: object
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          spec:
+                                            description: The specification for the
+                                              PersistentVolumeClaim. The entire content
+                                              is copied unchanged into the PVC that
+                                              gets created from this template. The
+                                              same fields as in a PersistentVolumeClaim
+                                              are also valid here.
+                                            properties:
+                                              accessModes:
+                                                description: 'accessModes contains
+                                                  the desired access modes the volume
+                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                  * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                                    preserves all values, and generates an error if a disallowed value is
+                                                    specified.
+                                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              resources:
+                                                description: 'resources represents
+                                                  the minimum resources the volume
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Limits describes
+                                                      the maximum amount of compute
+                                                      resources allowed. More info:
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Requests describes
+                                                      the minimum amount of compute
+                                                      resources required. If Requests
+                                                      is omitted for a container,
+                                                      it defaults to Limits if that
+                                                      is explicitly specified, otherwise
+                                                      to an implementation-defined
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              storageClassName:
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                type: string
+                                              volumeMode:
+                                                description: volumeMode defines what
+                                                  type of volume is required by the
+                                                  claim. Value of Filesystem is implied
+                                                  when not included in claim spec.
+                                                type: string
+                                              volumeName:
+                                                description: volumeName is the binding
+                                                  reference to the PersistentVolume
+                                                  backing this claim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - spec
+                                        type: object
+                                    type: object
+                                  fc:
+                                    description: fc represents a Fibre Channel resource
+                                      that is attached to a kubelet's host machine
+                                      and then exposed to the pod.
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      lun:
+                                        description: 'lun is Optional: FC target lun
+                                          number'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      targetWWNs:
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    description: flexVolume represents a generic volume
+                                      resource that is provisioned/attached using
+                                      an exec based plugin.
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the driver
+                                          to use for this volume.
+                                        type: string
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
+                                        type: object
+                                      readOnly:
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    description: flocker represents a Flocker volume
+                                      attached to a kubelet's host machine. This depends
+                                      on the Flocker control service being running
+                                    properties:
+                                      datasetName:
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
+                                        type: string
+                                      datasetUUID:
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    description: 'gcePersistentDisk represents a GCE
+                                      Disk resource that is attached to a kubelet''s
+                                      host machine and then exposed to the pod. More
+                                      info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: string
+                                      partition:
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    description: 'gitRepo represents a git repository
+                                      at a particular revision. DEPRECATED: GitRepo
+                                      is deprecated. To provision a container with
+                                      a git repo, mount an EmptyDir into an InitContainer
+                                      that clones the repo using git, then mount the
+                                      EmptyDir into the Pod''s container.'
+                                    properties:
+                                      directory:
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
+                                        type: string
+                                      repository:
+                                        description: repository is the URL
+                                        type: string
+                                      revision:
+                                        description: revision is the commit hash for
+                                          the specified revision.
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    description: 'glusterfs represents a Glusterfs
+                                      mount on the host that shares a pod''s lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    properties:
+                                      endpoints:
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      path:
+                                        description: 'path is the Glusterfs volume
+                                          path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          Glusterfs volume to be mounted with read-only
+                                          permissions. Defaults to false. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    description: 'hostPath represents a pre-existing
+                                      file or directory on the host machine that is
+                                      directly exposed to the container. This is generally
+                                      used for system agents or other privileged things
+                                      that are allowed to see the host machine. Most
+                                      containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    properties:
+                                      path:
+                                        description: 'path of the directory on the
+                                          host. If the path is a symlink, it will
+                                          follow the link to the real path. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                      type:
+                                        description: 'type for HostPath Volume Defaults
+                                          to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    description: 'iscsi represents an ISCSI Disk resource
+                                      that is attached to a kubelet''s host machine
+                                      and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    properties:
+                                      chapAuthDiscovery:
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
+                                        type: boolean
+                                      chapAuthSession:
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
+                                        type: boolean
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                        type: string
+                                      initiatorName:
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
+                                        type: string
+                                      iqn:
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
+                                        type: string
+                                      iscsiInterface:
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
+                                        type: string
+                                      lun:
+                                        description: lun represents iSCSI Target Lun
+                                          number.
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        description: readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      targetPortal:
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
+                                        type: string
+                                    required:
+                                    - targetPortal
+                                    - iqn
+                                    - lun
+                                    type: object
+                                  name:
+                                    description: 'name of the volume. Must be a DNS_LABEL
+                                      and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  nfs:
+                                    description: 'nfs represents an NFS mount on the
+                                      host that shares a pod''s lifetime More info:
+                                      https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    properties:
+                                      path:
+                                        description: 'path that is exported by the
+                                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          NFS export to be mounted with read-only
+                                          permissions. Defaults to false. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: boolean
+                                      server:
+                                        description: 'server is the hostname or IP
+                                          address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                    required:
+                                    - server
+                                    - path
+                                    type: object
+                                  persistentVolumeClaim:
+                                    description: 'persistentVolumeClaimVolumeSource
+                                      represents a reference to a PersistentVolumeClaim
+                                      in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    properties:
+                                      claimName:
+                                        description: 'claimName is the name of a PersistentVolumeClaim
+                                          in the same namespace as the pod using this
+                                          volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    description: photonPersistentDisk represents a
+                                      PhotonController persistent disk attached and
+                                      mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      pdID:
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    description: portworxVolume represents a portworx
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: fSType represents the filesystem
+                                          type to mount Must be a filesystem type
+                                          supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to
+                                          be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      volumeID:
+                                        description: volumeID uniquely identifies
+                                          a Portworx volume
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
+                                    properties:
+                                      defaultMode:
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        description: sources is the list of volume
+                                          projections
+                                        items:
+                                          description: Projection that may be projected
+                                            along with other supported volume types
+                                          properties:
+                                            configMap:
+                                              description: configMap information about
+                                                the configMap data to project
+                                              properties:
+                                                items:
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
+                                                    the listed keys will be projected
+                                                    into the specified paths, and
+                                                    unlisted keys will not be present.
+                                                    If a key is specified which is
+                                                    not present in the ConfigMap,
+                                                    the volume setup will error unless
+                                                    it is marked optional. Paths must
+                                                    be relative and may not contain
+                                                    the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
+                                                          on this file. Must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: path is the relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path. May not contain
+                                                          the path element '..'. May
+                                                          not start with the string
+                                                          '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
+                                                  type: boolean
+                                              type: object
+                                            downwardAPI:
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
+                                              properties:
+                                                items:
+                                                  description: Items is a list of
+                                                    DownwardAPIVolume file
+                                                  items:
+                                                    description: DownwardAPIVolumeFile
+                                                      represents information to create
+                                                      the file containing the pod
+                                                      field
+                                                    properties:
+                                                      fieldRef:
+                                                        description: 'Required: Selects
+                                                          a field of the pod: only
+                                                          annotations, labels, name
+                                                          and namespace are supported.'
+                                                        properties:
+                                                          apiVersion:
+                                                            description: Version of
+                                                              the schema the FieldPath
+                                                              is written in terms
+                                                              of, defaults to "v1".
+                                                            type: string
+                                                          fieldPath:
+                                                            description: Path of the
+                                                              field to select in the
+                                                              specified API version.
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      mode:
+                                                        description: 'Optional: mode
+                                                          bits used to set permissions
+                                                          on this file, must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: 'Required: Path
+                                                          is  the relative path name
+                                                          of the file to be created.
+                                                          Must not be absolute or
+                                                          contain the ''..'' path.
+                                                          Must be utf-8 encoded. The
+                                                          first item of the relative
+                                                          path must not start with
+                                                          ''..'''
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        description: 'Selects a resource
+                                                          of the container: only resources
+                                                          limits and requests (limits.cpu,
+                                                          limits.memory, requests.cpu
+                                                          and requests.memory) are
+                                                          currently supported.'
+                                                        properties:
+                                                          containerName:
+                                                            description: 'Container
+                                                              name: required for volumes,
+                                                              optional for env vars'
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            description: Specifies
+                                                              the output format of
+                                                              the exposed resources,
+                                                              defaults to "1"
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            description: 'Required:
+                                                              resource to select'
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            secret:
+                                              description: secret information about
+                                                the secret data to project
+                                              properties:
+                                                items:
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
+                                                    the listed keys will be projected
+                                                    into the specified paths, and
+                                                    unlisted keys will not be present.
+                                                    If a key is specified which is
+                                                    not present in the Secret, the
+                                                    volume setup will error unless
+                                                    it is marked optional. Paths must
+                                                    be relative and may not contain
+                                                    the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
+                                                          on this file. Must be an
+                                                          octal value between 0000
+                                                          and 0777 or a decimal value
+                                                          between 0 and 511. YAML
+                                                          accepts both octal and decimal
+                                                          values, JSON requires decimal
+                                                          values for mode bits. If
+                                                          not specified, the volume
+                                                          defaultMode will be used.
+                                                          This might be in conflict
+                                                          with other options that
+                                                          affect the file mode, like
+                                                          fsGroup, and the result
+                                                          can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: path is the relative
+                                                          path of the file to map
+                                                          the key to. May not be an
+                                                          absolute path. May not contain
+                                                          the path element '..'. May
+                                                          not start with the string
+                                                          '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                                  type: string
+                                                optional:
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
+                                                  type: boolean
+                                              type: object
+                                            serviceAccountToken:
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
+                                                data to project
+                                              properties:
+                                                audience:
+                                                  description: audience is the intended
+                                                    audience of the token. A recipient
+                                                    of a token must identify itself
+                                                    with an identifier specified in
+                                                    the audience of the token, and
+                                                    otherwise should reject the token.
+                                                    The audience defaults to the identifier
+                                                    of the apiserver.
+                                                  type: string
+                                                expirationSeconds:
+                                                  description: expirationSeconds is
+                                                    the requested duration of validity
+                                                    of the service account token.
+                                                    As the token approaches expiration,
+                                                    the kubelet volume plugin will
+                                                    proactively rotate the service
+                                                    account token. The kubelet will
+                                                    start trying to rotate the token
+                                                    if the token is older than 80
+                                                    percent of its time to live or
+                                                    if the token is older than 24
+                                                    hours.Defaults to 1 hour and must
+                                                    be at least 10 minutes.
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  description: path is the path relative
+                                                    to the mount point of the file
+                                                    to project the token into.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                    type: object
+                                  quobyte:
+                                    description: quobyte represents a Quobyte mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      group:
+                                        description: group to map volume access to
+                                          Default is no group
+                                        type: string
+                                      readOnly:
+                                        description: readOnly here will force the
+                                          Quobyte volume to be mounted with read-only
+                                          permissions. Defaults to false.
+                                        type: boolean
+                                      registry:
+                                        description: registry represents a single
+                                          or multiple Quobyte Registry services specified
+                                          as a string as host:port pair (multiple
+                                          entries are separated with commas) which
+                                          acts as the central registry for volumes
+                                        type: string
+                                      tenant:
+                                        description: tenant owning the given Quobyte
+                                          volume in the Backend Used with dynamically
+                                          provisioned Quobyte volumes, value is set
+                                          by the plugin
+                                        type: string
+                                      user:
+                                        description: user to map volume access to
+                                          Defaults to serivceaccount user
+                                        type: string
+                                      volume:
+                                        description: volume is a string that references
+                                          an already created Quobyte volume by name.
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    description: 'rbd represents a Rados Block Device
+                                      mount on the host that shares a pod''s lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                        type: string
+                                      image:
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      keyring:
+                                        description: 'keyring is the path to key ring
+                                          for RBDUser. Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      monitors:
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      readOnly:
+                                        description: 'readOnly here will force the
+                                          ReadOnly setting in VolumeMounts. Defaults
+                                          to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'secretRef is name of the authentication
+                                          secret for RBDUser. If provided overrides
+                                          keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - monitors
+                                    - image
+                                    type: object
+                                  scaleIO:
+                                    description: scaleIO represents a ScaleIO persistent
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
+                                        type: string
+                                      gateway:
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
+                                        type: string
+                                      protectionDomain:
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly Defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef references to the secret
+                                          for ScaleIO user and other sensitive information.
+                                          If this is not provided, Login operation
+                                          will fail.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      sslEnabled:
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
+                                        type: boolean
+                                      storageMode:
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
+                                          or ThinProvisioned. Default is ThinProvisioned.
+                                        type: string
+                                      storagePool:
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
+                                        type: string
+                                      system:
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - system
+                                    - secretRef
+                                    type: object
+                                  secret:
+                                    description: 'secret represents a secret that
+                                      should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    properties:
+                                      defaultMode:
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: items If unspecified, each key-value
+                                          pair in the Data field of the referenced
+                                          Secret will be projected into the volume
+                                          as a file whose name is the key and content
+                                          is the value. If specified, the listed keys
+                                          will be projected into the specified paths,
+                                          and unlisted keys will not be present. If
+                                          a key is specified which is not present
+                                          in the Secret, the volume setup will error
+                                          unless it is marked optional. Paths must
+                                          be relative and may not contain the '..'
+                                          path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
+                                                the path element '..'. May not start
+                                                with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    description: storageOS represents a StorageOS
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef specifies the secret
+                                          to use for obtaining the StorageOS API credentials.  If
+                                          not specified, default values will be attempted.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                            type: string
+                                        type: object
+                                      volumeName:
+                                        description: volumeName is the human-readable
+                                          name of the StorageOS volume.  Volume names
+                                          are only unique within a namespace.
+                                        type: string
+                                      volumeNamespace:
+                                        description: volumeNamespace specifies the
+                                          scope of the volume within StorageOS.  If
+                                          no namespace is specified then the Pod's
+                                          namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within
+                                          StorageOS for tighter integration. Set VolumeName
+                                          to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces
+                                          within StorageOS. Namespaces that do not
+                                          pre-exist within StorageOS will be created.
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    description: vsphereVolume represents a vSphere
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
+                                        type: string
+                                      storagePolicyID:
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
+                                        type: string
+                                      storagePolicyName:
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
+                                        type: string
+                                      volumePath:
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                    ttlSecondsAfterFinished:
+                      description: ttlSecondsAfterFinished limits the lifetime of
+                        a Job that has finished execution (either Complete or Failed).
+                        If this field is set, ttlSecondsAfterFinished after the Job
+                        finishes, it is eligible to be automatically deleted. When
+                        the Job is being deleted, its lifecycle guarantees (e.g. finalizers)
+                        will be honored. If this field is unset, the Job won't be
+                        automatically deleted. If this field is set to zero, the Job
+                        becomes eligible to be deleted immediately after it finishes.
+                      format: int32
+                      type: integer
+                  required:
+                  - template
+                  type: object
+              type: object
+            schedule:
+              description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+              type: string
+            startingDeadlineSeconds:
+              description: Optional deadline in seconds for starting the job if it
+                misses scheduled time for any reason.  Missed jobs executions will
+                be counted as failed ones.
+              format: int64
+              type: integer
+            successfulJobsHistoryLimit:
+              description: The number of successful finished jobs to retain. Value
+                must be non-negative integer. Defaults to 3.
+              format: int32
+              type: integer
+            suspend:
+              description: This flag tells the controller to suspend subsequent executions,
+                it does not apply to already started executions.  Defaults to false.
+              type: boolean
+            timeZone:
+              description: The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+                If not specified, this will default to the time zone of the kube-controller-manager
+                process. The set of valid time zone names and the time zone offset
+                is loaded from the system-wide time zone database by the API server
+                during CronJob validation and the controller manager during execution.
+                If no system-wide time zone database can be found a bundled version
+                of the database is used instead. If the time zone name becomes invalid
+                during the lifetime of a CronJob or due to a change in host configuration,
+                the controller will stop creating new new Jobs and will create a system
+                event with the reason UnknownTimeZone. More information can be found
+                in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+                This is beta field and must be enabled via the `CronJobTimeZone` feature
+                gate.
+              type: string
+          required:
+          - schedule
+          - jobTemplate
+          type: object
+        status:
+          description: 'Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            active:
+              description: A list of pointers to currently running jobs.
+              items:
+                description: ObjectReference contains enough information to let you
+                  inspect or modify the referred object.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            lastScheduleTime:
+              description: Information when was the last time the job was successfully
+                scheduled.
+              format: date-time
+              type: string
+            lastSuccessfulTime:
+              description: Information when was the last time the job successfully
+                completed.
+              format: date-time
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-csistoragecapacities.storage.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-csistoragecapacities.storage.k8s.io.yaml
@@ -1,0 +1,116 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.csistoragecapacities.storage.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1111
+spec:
+  group: storage.k8s.io
+  names:
+    kind: CSIStorageCapacity
+    listKind: CSIStorageCapacityList
+    plural: csistoragecapacities
+    singular: csistoragecapacity
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: |-
+        CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
+
+        For example this can express things like: - StorageClass "standard" has "1234 GiB" available in "topology.kubernetes.io/zone=us-east1" - StorageClass "localssd" has "10 GiB" available in "kubernetes.io/hostname=knode-abc123"
+
+        The following three cases all imply that no capacity is available for a certain combination: - no object exists with suitable topology and storage class name - such an object exists, but the capacity is unset - such an object exists, but the capacity is zero
+
+        The producer of these objects can decide which approach is more suitable.
+
+        They are consumed by the kube-scheduler when a CSI driver opts into capacity-aware scheduling with CSIDriverSpec.StorageCapacity. The scheduler compares the MaximumVolumeSize against the requested size of pending volumes to filter out unsuitable nodes. If MaximumVolumeSize is unset, it falls back to a comparison against the less precise Capacity. If that is also unset, the scheduler assumes that capacity is insufficient and tries some other node.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        capacity:
+          anyOf:
+          - type: integer
+          - type: string
+          description: |-
+            Capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+            The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
+          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+          x-kubernetes-int-or-string: true
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        maximumVolumeSize:
+          anyOf:
+          - type: integer
+          - type: string
+          description: |-
+            MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+            This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
+          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+          x-kubernetes-int-or-string: true
+        metadata:
+          type: object
+        nodeTopology:
+          description: NodeTopology defines which nodes have access to the storage
+            for which capacity was reported. If not set, the storage is not accessible
+            from any node in the cluster. If empty, the storage is accessible from
+            all nodes. This field is immutable.
+          properties:
+            matchExpressions:
+              description: matchExpressions is a list of label selector requirements.
+                The requirements are ANDed.
+              items:
+                description: A label selector requirement is a selector that contains
+                  values, a key, and an operator that relates the key and values.
+                properties:
+                  key:
+                    description: key is the label key that the selector applies to.
+                    type: string
+                  operator:
+                    description: operator represents a key's relationship to a set
+                      of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                    type: string
+                  values:
+                    description: values is an array of string values. If the operator
+                      is In or NotIn, the values array must be non-empty. If the operator
+                      is Exists or DoesNotExist, the values array must be empty. This
+                      array is replaced during a strategic merge patch.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - key
+                - operator
+                type: object
+              type: array
+            matchLabels:
+              additionalProperties:
+                type: string
+              description: matchLabels is a map of {key,value} pairs. A single {key,value}
+                in the matchLabels map is equivalent to an element of matchExpressions,
+                whose key field is "key", the operator is "In", and the values array
+                contains only "value". The requirements are ANDed.
+              type: object
+          type: object
+        storageClassName:
+          description: The name of the StorageClass that the reported capacity applies
+            to. It must meet the same requirements as the name of a StorageClass object
+            (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity
+            object is obsolete and should be removed by its creator. This field is
+            immutable.
+          type: string
+      required:
+      - storageClassName
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/namespaced/apiresourceschema-daemonsets.apps.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-daemonsets.apps.yaml
@@ -1,0 +1,7258 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.daemonsets.apps
+spec:
+  group: apps
+  names:
+    categories:
+    - all
+    kind: DaemonSet
+    listKind: DaemonSetList
+    plural: daemonsets
+    shortNames:
+    - ds
+    singular: daemonset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: DaemonSet represents the configuration of a daemon set.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            minReadySeconds:
+              description: The minimum number of seconds for which a newly created
+                DaemonSet pod should be ready without any of its container crashing,
+                for it to be considered available. Defaults to 0 (pod will be considered
+                available as soon as it is ready).
+              format: int32
+              type: integer
+            revisionHistoryLimit:
+              description: The number of old history to retain to allow rollback.
+                This is a pointer to distinguish between explicit zero and not specified.
+                Defaults to 10.
+              format: int32
+              type: integer
+            selector:
+              description: 'A label query over pods that are managed by the daemon
+                set. Must match in order to be controlled. It must match the pod template''s
+                labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            template:
+              description: 'An object that describes the pod that will be created.
+                The DaemonSet will create exactly one copy of this pod on every node
+                that matches the template''s node selector (or on every node if no
+                node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the pod.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
+                    affinity:
+                      description: If specified, the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - preference
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      description: AutomountServiceAccountToken indicates whether
+                        a service account token should be automatically mounted.
+                      type: boolean
+                    containers:
+                      description: List of containers belonging to the pod. Containers
+                        cannot currently be added or removed. There must be at least
+                        one container in a Pod. Cannot be updated.
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    dnsConfig:
+                      description: Specifies the DNS parameters of a pod. Parameters
+                        specified here will be merged to the generated DNS configuration
+                        based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: A list of DNS name server IP addresses. This
+                            will be appended to the base nameservers generated from
+                            DNSPolicy. Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          description: A list of DNS resolver options. This will be
+                            merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options
+                            given in Options will override those that appear in the
+                            base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: Required.
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          description: A list of DNS search domains for host-name
+                            lookup. This will be appended to the base search paths
+                            generated from DNSPolicy. Duplicated search paths will
+                            be removed.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                        Possible enum values:
+                         - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                         - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                      type: string
+                    enableServiceLinks:
+                      description: 'EnableServiceLinks indicates whether information
+                        about services should be injected into pod''s environment
+                        variables, matching the syntax of Docker links. Optional:
+                        Defaults to true.'
+                      type: boolean
+                    ephemeralContainers:
+                      description: List of ephemeral containers run in this pod. Ephemeral
+                        containers may be run in an existing pod to perform user-initiated
+                        actions such as debugging. This list cannot be specified when
+                        creating a pod, and it cannot be modified by updating the
+                        pod spec. In order to add an ephemeral container to an existing
+                        pod, use the pod's ephemeralcontainers subresource.
+                      items:
+                        description: |-
+                          An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The image''s
+                              CMD is used if this is not provided. Variable references
+                              $(VAR_NAME) are expanded using the container''s environment.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The image''s ENTRYPOINT is used if this is not
+                              provided. Variable references $(VAR_NAME) are expanded
+                              using the container''s environment. If a variable cannot
+                              be resolved, the reference in the input string will
+                              be unchanged. Double $$ are reduced to a single $, which
+                              allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                              will produce the string literal "$(VAR_NAME)". Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Cannot be updated. More
+                              info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Lifecycle is not allowed for ephemeral containers.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the ephemeral container specified
+                              as a DNS_LABEL. This name must be unique among all containers,
+                              init containers and ephemeral containers.
+                            type: string
+                          ports:
+                            description: Ports are not allowed for ephemeral containers.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: Resources are not allowed for ephemeral containers.
+                              Ephemeral containers use spare resources already allocated
+                              to the pod.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Optional: SecurityContext defines the security
+                              options the ephemeral container should be run with.
+                              If set, the fields of SecurityContext override the equivalent
+                              fields of PodSecurityContext.'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          targetContainerName:
+                            description: |-
+                              If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                              The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                            type: string
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Subpath mounts are not allowed for ephemeral
+                              containers. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    hostAliases:
+                      description: HostAliases is an optional list of hosts and IPs
+                        that will be injected into the pod's hosts file if specified.
+                        This is only valid for non-hostNetwork pods.
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        required:
+                        - ip
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - ip
+                      x-kubernetes-list-type: map
+                    hostIPC:
+                      description: 'Use the host''s ipc namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace. If this option is set, the ports
+                        that will be used must be specified. Default to false.
+                      type: boolean
+                    hostPID:
+                      description: 'Use the host''s pid namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostUsers:
+                      description: 'Use the host''s user namespace. Optional: Default
+                        to true. If set to true or not present, the pod will be run
+                        in the host user namespace, useful for when the pod needs
+                        a feature only available to the host user namespace, such
+                        as loading a kernel module with CAP_SYS_MODULE. When set to
+                        false, a new userns is created for the pod. Setting false
+                        is useful for mitigating container breakout vulnerabilities
+                        even allowing users to run their containers as root without
+                        actually having root privileges on the host. This field is
+                        alpha-level and is only honored by servers that enable the
+                        UserNamespacesSupport feature.'
+                      type: boolean
+                    hostname:
+                      description: Specifies the hostname of the Pod If not specified,
+                        the pod's hostname will be set to a system-defined value.
+                      type: string
+                    imagePullSecrets:
+                      description: 'ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of
+                        the images used by this PodSpec. If specified, these secrets
+                        will be passed to individual puller implementations for them
+                        to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    initContainers:
+                      description: 'List of initialization containers belonging to
+                        the pod. Init containers are executed in order prior to containers
+                        being started. If any init container fails, the pod is considered
+                        to have failed and is handled according to its restartPolicy.
+                        The name for an init container or normal container must be
+                        unique among all containers. Init containers may not have
+                        Lifecycle actions, Readiness probes, Liveness probes, or Startup
+                        probes. The resourceRequirements of an init container are
+                        taken into account during scheduling by finding the highest
+                        request/limit for each resource type, and then using the max
+                        of of that value or the sum of the normal containers. Limits
+                        are applied to init containers in a similar fashion. Init
+                        containers cannot currently be added or removed. Cannot be
+                        updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    nodeName:
+                      description: NodeName is a request to schedule this pod onto
+                        a specific node. If it is non-empty, the scheduler simply
+                        schedules this pod onto that node, assuming that it fits resource
+                        requirements.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    os:
+                      description: |-
+                        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                      properties:
+                        name:
+                          description: 'Name is the name of the operating system.
+                            The currently supported values are linux and windows.
+                            Additional value may be defined in future and can be one
+                            of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                            Clients should expect to handle additional values and
+                            treat unrecognized values in this field as os: null'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Overhead represents the resource overhead associated
+                        with running a pod for a given RuntimeClass. This field will
+                        be autopopulated at admission time by the RuntimeClass admission
+                        controller. If the RuntimeClass admission controller is enabled,
+                        overhead must not be set in Pod create requests. The RuntimeClass
+                        admission controller will reject Pod create requests which
+                        have the overhead already set. If RuntimeClass is configured
+                        and selected in the PodSpec, Overhead will be set to the value
+                        defined in the corresponding RuntimeClass, otherwise it will
+                        remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                      type: object
+                    preemptionPolicy:
+                      description: PreemptionPolicy is the Policy for preempting pods
+                        with lower priority. One of Never, PreemptLowerPriority. Defaults
+                        to PreemptLowerPriority if unset.
+                      type: string
+                    priority:
+                      description: The priority value. Various system components use
+                        this field to find the priority of the pod. When Priority
+                        Admission Controller is enabled, it prevents users from setting
+                        this field. The admission controller populates this field
+                        from PriorityClassName. The higher the value, the higher the
+                        priority.
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which
+                        indicate the highest priorities with the former being the
+                        highest priority. Any other name must be defined by creating
+                        a PriorityClass object with that name. If not specified, the
+                        pod priority will be default or zero if there is no default.
+                      type: string
+                    readinessGates:
+                      description: 'If specified, all readiness gates will be evaluated
+                        for pod readiness. A pod is ready when all its containers
+                        are ready AND all conditions specified in the readiness gates
+                        have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                      items:
+                        description: PodReadinessGate contains the reference to a
+                          pod condition
+                        properties:
+                          conditionType:
+                            description: ConditionType refers to a condition in the
+                              pod's condition list with matching type.
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      description: |-
+                        Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                        Possible enum values:
+                         - `"Always"`
+                         - `"Never"`
+                         - `"OnFailure"`
+                      type: string
+                    runtimeClassName:
+                      description: 'RuntimeClassName refers to a RuntimeClass object
+                        in the node.k8s.io group, which should be used to run this
+                        pod.  If no RuntimeClass resource matches the named class,
+                        the pod will not be run. If unset or empty, the "legacy" RuntimeClass
+                        will be used, which is an implicit class with an empty definition
+                        that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                      type: string
+                    schedulerName:
+                      description: If specified, the pod will be dispatched by specified
+                        scheduler. If not specified, the pod will be dispatched by
+                        default scheduler.
+                      type: string
+                    securityContext:
+                      description: 'SecurityContext holds pod-level security attributes
+                        and common container settings. Optional: Defaults to empty.  See
+                        type description for default values of each field.'
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                Possible enum values:
+                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: 'DeprecatedServiceAccount is a depreciated alias
+                        for ServiceAccountName. Deprecated: Use serviceAccountName
+                        instead.'
+                      type: string
+                    serviceAccountName:
+                      description: 'ServiceAccountName is the name of the ServiceAccount
+                        to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                      type: string
+                    setHostnameAsFQDN:
+                      description: If true the pod's hostname will be configured as
+                        the pod's FQDN, rather than the leaf name (the default). In
+                        Linux containers, this means setting the FQDN in the hostname
+                        field of the kernel (the nodename field of struct utsname).
+                        In Windows containers, this means setting the registry value
+                        of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                        to FQDN. If a pod does not have FQDN, this has no effect.
+                        Default to false.
+                      type: boolean
+                    shareProcessNamespace:
+                      description: 'Share a single process namespace between all of
+                        the containers in a pod. When this is set containers will
+                        be able to view and signal processes from other containers
+                        in the same pod, and the first process in each container will
+                        not be assigned PID 1. HostPID and ShareProcessNamespace cannot
+                        both be set. Optional: Default to false.'
+                      type: boolean
+                    subdomain:
+                      description: If specified, the fully qualified Pod hostname
+                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                        domain>". If not specified, the pod will not have a domainname
+                        at all.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully. May be decreased in delete request. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). If this
+                        value is nil, the default grace period will be used instead.
+                        The grace period is the duration in seconds after the processes
+                        running in the pod are sent a termination signal and the time
+                        when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your
+                        process. Defaults to 30 seconds.
+                      format: int64
+                      type: integer
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                              Possible enum values:
+                               - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                               - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                               - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                              Possible enum values:
+                               - `"Equal"`
+                               - `"Exists"`
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints describes how a group
+                        of pods ought to spread across topology domains. Scheduler
+                        will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select the pods over which spreading will be calculated.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading
+                              will be calculated for the incoming pod. Keys that don't
+                              exist in the incoming pod labels will be ignored. A
+                              null or empty list means only match against labelSelector.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. The global minimum is the minimum number of
+                              matching pods in an eligible domain or zero if the number
+                              of eligible domains is less than MinDomains. For example,
+                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
+                              the same labelSelector spread as 2/2/1: In this case,
+                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
+                              can only be scheduled to zone3 to become 2/2/2; scheduling
+                              it onto zone1(zone2) would make the ActualSkew(3-1)
+                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
+                              2, incoming pod can be scheduled onto any zone. When
+                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
+                              higher precedence to topologies that satisfy it. It''s
+                              a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. We define a domain
+                              as a particular instance of a topology. Also, we define
+                              an eligible domain as a domain whose nodes meet the
+                              requirements of nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each
+                              Node is a domain of that topology. And, if TopologyKey
+                              is "topology.kubernetes.io/zone", each zone is a domain
+                              of that topology. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                              Possible enum values:
+                               - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                               - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    volumes:
+                      description: 'List of volumes that can be mounted by containers
+                        belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                  disk resource in AWS (Amazon EBS volume). More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a
+                                  collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                  the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is
+                                  reference to the authentication secret for User,
+                                  default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados
+                                  user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Examples: "ext4", "xfs", "ntfs".
+                                  Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to
+                                  OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                  medium should back this directory. The default is
+                                  "" which means to use the node''s default medium.
+                                  Must be an empty string (default) or Memory. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'sizeLimit is the total amount of local
+                                  storage required for this EmptyDir volume. The size
+                                  limit is also applicable for memory medium. The
+                                  maximum usage on memory medium EmptyDir would be
+                                  the minimum value between the SizeLimit specified
+                                  here and the sum of memory limits of all containers
+                                  in a pod. The default is nil which means that the
+                                  limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used
+                                          to specify either: * An existing VolumeSnapshot
+                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name
+                                          of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide
+                                  identifiers (wwids) Either wwids or combination
+                                  of targetWWNs and lun must be set, but not both
+                                  simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". The
+                                  default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is
+                                  reference to the secret object containing sensitive
+                                  information to pass to the plugin scripts. This
+                                  may be empty if no secret object is specified. If
+                                  the secret object contains more than one secret,
+                                  all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                  in GCE. Used to identify the disk in GCE. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is
+                                  supplied, the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name
+                                  that uses an iSCSI transport. Defaults to 'default'
+                                  (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal.
+                                  The Portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                type: string
+                            required:
+                            - targetPortal
+                            - iqn
+                            - lun
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL
+                              and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - server
+                            - path
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to
+                                  set permissions on created files by default. Must
+                                  be an octal value between 0000 and 0777 or a decimal
+                                  value between 0 and 511. YAML accepts both octal
+                                  and decimal values, JSON requires decimal values
+                                  for mode bits. Directories within the path are not
+                                  affected by this setting. This might be in conflict
+                                  with other options that affect the file mode, like
+                                  fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default
+                                  is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default
+                                  is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            - image
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                  is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated
+                                  with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - system
+                            - secretRef
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret
+                                  in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - containers
+                  type: object
+              type: object
+            updateStrategy:
+              description: An update strategy to replace existing DaemonSet pods with
+                new pods.
+              properties:
+                rollingUpdate:
+                  description: Rolling update config params. Present only if type
+                    = "RollingUpdate".
+                  properties:
+                    maxSurge:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of nodes with an existing available
+                        DaemonSet pod that can have an updated DaemonSet pod during
+                        during an update. Value can be an absolute number (ex: 5)
+                        or a percentage of desired pods (ex: 10%). This can not be
+                        0 if MaxUnavailable is 0. Absolute number is calculated from
+                        percentage by rounding up to a minimum of 1. Default value
+                        is 0. Example: when this is set to 30%, at most 30% of the
+                        total number of nodes that should be running the daemon pod
+                        (i.e. status.desiredNumberScheduled) can have their a new
+                        pod created before the old pod is marked as deleted. The update
+                        starts by launching new pods on 30% of nodes. Once an updated
+                        pod is available (Ready for at least minReadySeconds) the
+                        old DaemonSet pod on that node is marked deleted. If the old
+                        pod becomes unavailable for any reason (Ready transitions
+                        to false, is evicted, or is drained) an updated pod is immediatedly
+                        created on that node without considering surge limits. Allowing
+                        surge implies the possibility that the resources consumed
+                        by the daemonset on any given node can double if the readiness
+                        check fails, and so resource intensive daemonsets should take
+                        into account that they may cause evictions during disruption.'
+                      x-kubernetes-int-or-string: true
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of DaemonSet pods that can
+                        be unavailable during the update. Value can be an absolute
+                        number (ex: 5) or a percentage of total number of DaemonSet
+                        pods at the start of the update (ex: 10%). Absolute number
+                        is calculated from percentage by rounding up. This cannot
+                        be 0 if MaxSurge is 0 Default value is 1. Example: when this
+                        is set to 30%, at most 30% of the total number of nodes that
+                        should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                        can have their pods stopped for an update at any given time.
+                        The update starts by stopping at most 30% of those DaemonSet
+                        pods and then brings up new DaemonSet pods in their place.
+                        Once the new pods are available, it then proceeds onto other
+                        DaemonSet pods, thus ensuring that at least 70% of original
+                        number of DaemonSet pods are available at all times during
+                        the update.'
+                      x-kubernetes-int-or-string: true
+                  type: object
+                type:
+                  description: |-
+                    Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+
+                    Possible enum values:
+                     - `"OnDelete"` Replace the old daemons only when it's killed
+                     - `"RollingUpdate"` Replace the old daemons by new ones using rolling update i.e replace them on each node one after the other.
+                  type: string
+              type: object
+          required:
+          - selector
+          - template
+          type: object
+        status:
+          description: 'The current status of this daemon set. This data may be out
+            of date by some window of time. Populated by the system. Read-only. More
+            info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            collisionCount:
+              description: Count of hash collisions for the DaemonSet. The DaemonSet
+                controller uses this field as a collision avoidance mechanism when
+                it needs to create the name for the newest ControllerRevision.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a DaemonSet's
+                current state.
+              items:
+                description: DaemonSetCondition describes the state of a DaemonSet
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of DaemonSet condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            currentNumberScheduled:
+              description: 'The number of nodes that are running at least 1 daemon
+                pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+              format: int32
+              type: integer
+            desiredNumberScheduled:
+              description: 'The total number of nodes that should be running the daemon
+                pod (including nodes correctly running the daemon pod). More info:
+                https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+              format: int32
+              type: integer
+            numberAvailable:
+              description: The number of nodes that should be running the daemon pod
+                and have one or more of the daemon pod running and available (ready
+                for at least spec.minReadySeconds)
+              format: int32
+              type: integer
+            numberMisscheduled:
+              description: 'The number of nodes that are running the daemon pod, but
+                are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+              format: int32
+              type: integer
+            numberReady:
+              description: numberReady is the number of nodes that should be running
+                the daemon pod and have one or more of the daemon pod running with
+                a Ready Condition.
+              format: int32
+              type: integer
+            numberUnavailable:
+              description: The number of nodes that should be running the daemon pod
+                and have none of the daemon pod running and available (ready for at
+                least spec.minReadySeconds)
+              format: int32
+              type: integer
+            observedGeneration:
+              description: The most recent generation observed by the daemon set controller.
+              format: int64
+              type: integer
+            updatedNumberScheduled:
+              description: The total number of nodes that are running updated daemon
+                pod
+              format: int32
+              type: integer
+          required:
+          - currentNumberScheduled
+          - numberMisscheduled
+          - desiredNumberScheduled
+          - numberReady
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-endpoints.core.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-endpoints.core.k8s.io.yaml
@@ -1,0 +1,217 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.endpoints.core
+spec:
+  group: ""
+  names:
+    kind: Endpoints
+    listKind: EndpointsList
+    plural: endpoints
+    shortNames:
+    - ep
+    singular: endpoints
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: "Endpoints is a collection of endpoints that implement the actual
+        service. Example:\n\n\t Name: \"mysvc\",\n\t Subsets: [\n\t   {\n\t     Addresses:
+        [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n\t     Ports: [{\"name\":
+        \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n\t   },\n\t   {\n\t
+        \    Addresses: [{\"ip\": \"10.10.3.3\"}],\n\t     Ports: [{\"name\": \"a\",
+        \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n\t   },\n\t]"
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        subsets:
+          description: The set of all endpoints is the union of all subsets. Addresses
+            are placed into subsets according to the IPs they share. A single address
+            with multiple ports, some of which are ready and some of which are not
+            (because they come from different containers) will result in the address
+            being displayed in different subsets for the different ports. No address
+            will appear in both Addresses and NotReadyAddresses in the same subset.
+            Sets of addresses and ports that comprise a service.
+          items:
+            description: "EndpointSubset is a group of addresses with a common set
+              of ports. The expanded set of endpoints is the Cartesian product of
+              Addresses x Ports. For example, given:\n\n\t{\n\t  Addresses: [{\"ip\":
+              \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n\t  Ports:     [{\"name\":
+              \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n\t}\n\nThe
+              resulting set of endpoints can be viewed as:\n\n\ta: [ 10.10.1.1:8675,
+              10.10.2.2:8675 ],\n\tb: [ 10.10.1.1:309, 10.10.2.2:309 ]"
+            properties:
+              addresses:
+                description: IP addresses which offer the related ports that are marked
+                  as ready. These endpoints should be considered safe for load balancers
+                  and clients to utilize.
+                items:
+                  description: EndpointAddress is a tuple that describes single IP
+                    address.
+                  properties:
+                    hostname:
+                      description: The Hostname of this endpoint
+                      type: string
+                    ip:
+                      description: The IP of this endpoint. May not be loopback (127.0.0.0/8),
+                        link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24).
+                        IPv6 is also accepted but not fully supported on all platforms.
+                        Also, certain kubernetes components, like kube-proxy, are
+                        not IPv6 ready.
+                      type: string
+                    nodeName:
+                      description: 'Optional: Node hosting this endpoint. This can
+                        be used to determine endpoints local to a node.'
+                      type: string
+                    targetRef:
+                      description: Reference to object providing the endpoint.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                  required:
+                  - ip
+                  type: object
+                type: array
+              notReadyAddresses:
+                description: IP addresses which offer the related ports but are not
+                  currently marked as ready because they have not yet finished starting,
+                  have recently failed a readiness check, or have recently failed
+                  a liveness check.
+                items:
+                  description: EndpointAddress is a tuple that describes single IP
+                    address.
+                  properties:
+                    hostname:
+                      description: The Hostname of this endpoint
+                      type: string
+                    ip:
+                      description: The IP of this endpoint. May not be loopback (127.0.0.0/8),
+                        link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24).
+                        IPv6 is also accepted but not fully supported on all platforms.
+                        Also, certain kubernetes components, like kube-proxy, are
+                        not IPv6 ready.
+                      type: string
+                    nodeName:
+                      description: 'Optional: Node hosting this endpoint. This can
+                        be used to determine endpoints local to a node.'
+                      type: string
+                    targetRef:
+                      description: Reference to object providing the endpoint.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                  required:
+                  - ip
+                  type: object
+                type: array
+              ports:
+                description: Port numbers available on the related IP addresses.
+                items:
+                  description: EndpointPort is a tuple that describes a single port.
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and https://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      type: string
+                    name:
+                      description: The name of this port.  This must match the 'name'
+                        field in the corresponding ServicePort. Must be a DNS_LABEL.
+                        Optional only if one port is defined.
+                      type: string
+                    port:
+                      description: The port number of the endpoint.
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: |-
+                        The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+
+                        Possible enum values:
+                         - `"SCTP"` is the SCTP protocol.
+                         - `"TCP"` is the TCP protocol.
+                         - `"UDP"` is the UDP protocol.
+                      type: string
+                  required:
+                  - port
+                  type: object
+                type: array
+            type: object
+          type: array
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/namespaced/apiresourceschema-endpointslices.discovery.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-endpointslices.discovery.k8s.io.yaml
@@ -1,0 +1,219 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.endpointslices.discovery.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1111
+spec:
+  group: discovery.k8s.io
+  names:
+    kind: EndpointSlice
+    listKind: EndpointSliceList
+    plural: endpointslices
+    singular: endpointslice
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: EndpointSlice represents a subset of the endpoints that implement
+        a service. For a given service there may be multiple EndpointSlice objects,
+        selected by labels, which must be joined to produce the full set of endpoints.
+      properties:
+        addressType:
+          description: |-
+            addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+
+            Possible enum values:
+             - `"FQDN"` represents a FQDN.
+             - `"IPv4"` represents an IPv4 Address.
+             - `"IPv6"` represents an IPv6 Address.
+          type: string
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        endpoints:
+          description: endpoints is a list of unique endpoints in this slice. Each
+            slice may include a maximum of 1000 endpoints.
+          items:
+            description: Endpoint represents a single logical "backend" implementing
+              a service.
+            properties:
+              addresses:
+                description: 'addresses of this endpoint. The contents of this field
+                  are interpreted according to the corresponding EndpointSlice addressType
+                  field. Consumers must handle different types of addresses in the
+                  context of their own capabilities. This must contain at least one
+                  address but no more than 100. These are all assumed to be fungible
+                  and clients may choose to only use the first element. Refer to:
+                  https://issue.k8s.io/106267'
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              conditions:
+                description: conditions contains information about the current status
+                  of the endpoint.
+                properties:
+                  ready:
+                    description: ready indicates that this endpoint is prepared to
+                      receive traffic, according to whatever system is managing the
+                      endpoint. A nil value indicates an unknown state. In most cases
+                      consumers should interpret this unknown state as ready. For
+                      compatibility reasons, ready should never be "true" for terminating
+                      endpoints.
+                    type: boolean
+                  serving:
+                    description: serving is identical to ready except that it is set
+                      regardless of the terminating state of endpoints. This condition
+                      should be set to true for a ready endpoint that is terminating.
+                      If nil, consumers should defer to the ready condition. This
+                      field can be enabled with the EndpointSliceTerminatingCondition
+                      feature gate.
+                    type: boolean
+                  terminating:
+                    description: terminating indicates that this endpoint is terminating.
+                      A nil value indicates an unknown state. Consumers should interpret
+                      this unknown state to mean that the endpoint is not terminating.
+                      This field can be enabled with the EndpointSliceTerminatingCondition
+                      feature gate.
+                    type: boolean
+                type: object
+              deprecatedTopology:
+                additionalProperties:
+                  type: string
+                description: deprecatedTopology contains topology information part
+                  of the v1beta1 API. This field is deprecated, and will be removed
+                  when the v1beta1 API is removed (no sooner than kubernetes v1.24).  While
+                  this field can hold values, it is not writable through the v1 API,
+                  and any attempts to write to it will be silently ignored. Topology
+                  information can be found in the zone and nodeName fields instead.
+                type: object
+              hints:
+                description: hints contains information associated with how an endpoint
+                  should be consumed.
+                properties:
+                  forZones:
+                    description: forZones indicates the zone(s) this endpoint should
+                      be consumed by to enable topology aware routing.
+                    items:
+                      description: ForZone provides information about which zones
+                        should consume this endpoint.
+                      properties:
+                        name:
+                          description: name represents the name of the zone.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              hostname:
+                description: hostname of this endpoint. This field may be used by
+                  consumers of endpoints to distinguish endpoints from each other
+                  (e.g. in DNS names). Multiple endpoints which use the same hostname
+                  should be considered fungible (e.g. multiple A values in DNS). Must
+                  be lowercase and pass DNS Label (RFC 1123) validation.
+                type: string
+              nodeName:
+                description: nodeName represents the name of the Node hosting this
+                  endpoint. This can be used to determine endpoints local to a Node.
+                type: string
+              targetRef:
+                description: targetRef is a reference to a Kubernetes object that
+                  represents this endpoint.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              zone:
+                description: zone is the name of the Zone this endpoint exists in.
+                type: string
+            required:
+            - addresses
+            type: object
+          type: array
+          x-kubernetes-list-type: atomic
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        ports:
+          description: ports specifies the list of network ports exposed by each endpoint
+            in this slice. Each port must have a unique name. When ports is empty,
+            it indicates that there are no defined ports. When a port is defined with
+            a nil port value, it indicates "all ports". Each slice may include a maximum
+            of 100 ports.
+          items:
+            description: EndpointPort represents a Port used by an EndpointSlice
+            properties:
+              appProtocol:
+                description: The application protocol for this port. This field follows
+                  standard Kubernetes label syntax. Un-prefixed names are reserved
+                  for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                  Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                type: string
+              name:
+                description: 'The name of this port. All ports in an EndpointSlice
+                  must have a unique name. If the EndpointSlice is dervied from a
+                  Kubernetes service, this corresponds to the Service.ports[].name.
+                  Name must either be an empty string or pass DNS_LABEL validation:
+                  * must be no more than 63 characters long. * must consist of lower
+                  case alphanumeric characters or ''-''. * must start and end with
+                  an alphanumeric character. Default is empty string.'
+                type: string
+              port:
+                description: The port number of the endpoint. If this is not specified,
+                  ports are not restricted and must be interpreted in the context
+                  of the specific consumer.
+                format: int32
+                type: integer
+              protocol:
+                description: The IP protocol for this port. Must be UDP, TCP, or SCTP.
+                  Default is TCP.
+                type: string
+            type: object
+          type: array
+          x-kubernetes-list-type: atomic
+      required:
+      - addressType
+      - endpoints
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/namespaced/apiresourceschema-horizontalpodautoscalers.autoscaling.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-horizontalpodautoscalers.autoscaling.yaml
@@ -1,0 +1,1147 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.horizontalpodautoscalers.autoscaling
+spec:
+  group: autoscaling
+  names:
+    categories:
+    - all
+    kind: HorizontalPodAutoscaler
+    listKind: HorizontalPodAutoscalerList
+    plural: horizontalpodautoscalers
+    shortNames:
+    - hpa
+    singular: horizontalpodautoscaler
+  scope: Namespaced
+  versions:
+  - name: v2
+    schema:
+      description: HorizontalPodAutoscaler is the configuration for a horizontal pod
+        autoscaler, which automatically manages the replica count of any resource
+        implementing the scale subresource based on the metrics specified.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'spec is the specification for the behaviour of the autoscaler.
+            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+          properties:
+            behavior:
+              description: behavior configures the scaling behavior of the target
+                in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                If not set, the default HPAScalingRules for scale up and scale down
+                are used.
+              properties:
+                scaleDown:
+                  description: scaleDown is scaling policy for scaling Down. If not
+                    set, the default value is to allow to scale down to minReplicas
+                    pods, with a 300 second stabilization window (i.e., the highest
+                    recommendation for the last 300sec is used).
+                  properties:
+                    policies:
+                      description: policies is a list of potential scaling polices
+                        which can be used during scaling. At least one policy must
+                        be specified, otherwise the HPAScalingRules will be discarded
+                        as invalid
+                      items:
+                        description: HPAScalingPolicy is a single policy which must
+                          hold true for a specified past interval.
+                        properties:
+                          periodSeconds:
+                            description: PeriodSeconds specifies the window of time
+                              for which the policy should hold true. PeriodSeconds
+                              must be greater than zero and less than or equal to
+                              1800 (30 min).
+                            format: int32
+                            type: integer
+                          type:
+                            description: Type is used to specify the scaling policy.
+                            type: string
+                          value:
+                            description: Value contains the amount of change which
+                              is permitted by the policy. It must be greater than
+                              zero
+                            format: int32
+                            type: integer
+                        required:
+                        - type
+                        - value
+                        - periodSeconds
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    selectPolicy:
+                      description: selectPolicy is used to specify which policy should
+                        be used. If not set, the default value Max is used.
+                      type: string
+                    stabilizationWindowSeconds:
+                      description: 'StabilizationWindowSeconds is the number of seconds
+                        for which past recommendations should be considered while
+                        scaling up or scaling down. StabilizationWindowSeconds must
+                        be greater than or equal to zero and less than or equal to
+                        3600 (one hour). If not set, use the default values: - For
+                        scale up: 0 (i.e. no stabilization is done). - For scale down:
+                        300 (i.e. the stabilization window is 300 seconds long).'
+                      format: int32
+                      type: integer
+                  type: object
+                scaleUp:
+                  description: |-
+                    scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+                      * increase no more than 4 pods per 60 seconds
+                      * double the number of pods per 60 seconds
+                    No stabilization is used.
+                  properties:
+                    policies:
+                      description: policies is a list of potential scaling polices
+                        which can be used during scaling. At least one policy must
+                        be specified, otherwise the HPAScalingRules will be discarded
+                        as invalid
+                      items:
+                        description: HPAScalingPolicy is a single policy which must
+                          hold true for a specified past interval.
+                        properties:
+                          periodSeconds:
+                            description: PeriodSeconds specifies the window of time
+                              for which the policy should hold true. PeriodSeconds
+                              must be greater than zero and less than or equal to
+                              1800 (30 min).
+                            format: int32
+                            type: integer
+                          type:
+                            description: Type is used to specify the scaling policy.
+                            type: string
+                          value:
+                            description: Value contains the amount of change which
+                              is permitted by the policy. It must be greater than
+                              zero
+                            format: int32
+                            type: integer
+                        required:
+                        - type
+                        - value
+                        - periodSeconds
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    selectPolicy:
+                      description: selectPolicy is used to specify which policy should
+                        be used. If not set, the default value Max is used.
+                      type: string
+                    stabilizationWindowSeconds:
+                      description: 'StabilizationWindowSeconds is the number of seconds
+                        for which past recommendations should be considered while
+                        scaling up or scaling down. StabilizationWindowSeconds must
+                        be greater than or equal to zero and less than or equal to
+                        3600 (one hour). If not set, use the default values: - For
+                        scale up: 0 (i.e. no stabilization is done). - For scale down:
+                        300 (i.e. the stabilization window is 300 seconds long).'
+                      format: int32
+                      type: integer
+                  type: object
+              type: object
+            maxReplicas:
+              description: maxReplicas is the upper limit for the number of replicas
+                to which the autoscaler can scale up. It cannot be less that minReplicas.
+              format: int32
+              type: integer
+            metrics:
+              description: metrics contains the specifications for which to use to
+                calculate the desired replica count (the maximum replica count across
+                all metrics will be used).  The desired replica count is calculated
+                multiplying the ratio between the target value and the current value
+                by the current number of pods.  Ergo, metrics used must decrease as
+                the pod count is increased, and vice-versa.  See the individual metric
+                source types for more information about how each type of metric must
+                respond. If not set, the default metric will be set to 80% average
+                CPU utilization.
+              items:
+                description: MetricSpec specifies how to scale based on a single metric
+                  (only `type` and one other matching field should be set at once).
+                properties:
+                  containerResource:
+                    description: containerResource refers to a resource metric (such
+                      as those specified in requests and limits) known to Kubernetes
+                      describing a single container in each pod of the current scale
+                      target (e.g. CPU or memory). Such metrics are built in to Kubernetes,
+                      and have special scaling options on top of those available to
+                      normal per-pod metrics using the "pods" source. This is an alpha
+                      feature and can be enabled by the HPAContainerMetrics feature
+                      flag.
+                    properties:
+                      container:
+                        description: container is the name of the container in the
+                          pods of the scaling target
+                        type: string
+                      name:
+                        description: name is the name of the resource in question.
+                        type: string
+                      target:
+                        description: target specifies the target value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: averageUtilization is the target value of
+                              the average of the resource metric across all relevant
+                              pods, represented as a percentage of the requested value
+                              of the resource for the pods. Currently only valid for
+                              Resource metric source type
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the target value of the average
+                              of the metric across all relevant pods (as a quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type:
+                            description: type represents whether the metric type is
+                              Utilization, Value, or AverageValue
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the target value of the metric (as
+                              a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - name
+                    - target
+                    - container
+                    type: object
+                  external:
+                    description: external refers to a global metric that is not associated
+                      with any Kubernetes object. It allows autoscaling based on information
+                      coming from components running outside of cluster (for example
+                      length of queue in cloud messaging service, or QPS from loadbalancer
+                      running outside of cluster).
+                    properties:
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      target:
+                        description: target specifies the target value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: averageUtilization is the target value of
+                              the average of the resource metric across all relevant
+                              pods, represented as a percentage of the requested value
+                              of the resource for the pods. Currently only valid for
+                              Resource metric source type
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the target value of the average
+                              of the metric across all relevant pods (as a quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type:
+                            description: type represents whether the metric type is
+                              Utilization, Value, or AverageValue
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the target value of the metric (as
+                              a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - metric
+                    - target
+                    type: object
+                  object:
+                    description: object refers to a metric describing a single kubernetes
+                      object (for example, hits-per-second on an Ingress object).
+                    properties:
+                      describedObject:
+                        description: describedObject specifies the descriptions of
+                          a object,such as kind,name apiVersion
+                        properties:
+                          apiVersion:
+                            description: API version of the referent
+                            type: string
+                          kind:
+                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                            type: string
+                          name:
+                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      target:
+                        description: target specifies the target value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: averageUtilization is the target value of
+                              the average of the resource metric across all relevant
+                              pods, represented as a percentage of the requested value
+                              of the resource for the pods. Currently only valid for
+                              Resource metric source type
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the target value of the average
+                              of the metric across all relevant pods (as a quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type:
+                            description: type represents whether the metric type is
+                              Utilization, Value, or AverageValue
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the target value of the metric (as
+                              a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - describedObject
+                    - target
+                    - metric
+                    type: object
+                  pods:
+                    description: pods refers to a metric describing each pod in the
+                      current scale target (for example, transactions-processed-per-second).  The
+                      values will be averaged together before being compared to the
+                      target value.
+                    properties:
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      target:
+                        description: target specifies the target value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: averageUtilization is the target value of
+                              the average of the resource metric across all relevant
+                              pods, represented as a percentage of the requested value
+                              of the resource for the pods. Currently only valid for
+                              Resource metric source type
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the target value of the average
+                              of the metric across all relevant pods (as a quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type:
+                            description: type represents whether the metric type is
+                              Utilization, Value, or AverageValue
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the target value of the metric (as
+                              a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - metric
+                    - target
+                    type: object
+                  resource:
+                    description: resource refers to a resource metric (such as those
+                      specified in requests and limits) known to Kubernetes describing
+                      each pod in the current scale target (e.g. CPU or memory). Such
+                      metrics are built in to Kubernetes, and have special scaling
+                      options on top of those available to normal per-pod metrics
+                      using the "pods" source.
+                    properties:
+                      name:
+                        description: name is the name of the resource in question.
+                        type: string
+                      target:
+                        description: target specifies the target value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: averageUtilization is the target value of
+                              the average of the resource metric across all relevant
+                              pods, represented as a percentage of the requested value
+                              of the resource for the pods. Currently only valid for
+                              Resource metric source type
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the target value of the average
+                              of the metric across all relevant pods (as a quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type:
+                            description: type represents whether the metric type is
+                              Utilization, Value, or AverageValue
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the target value of the metric (as
+                              a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - name
+                    - target
+                    type: object
+                  type:
+                    description: 'type is the type of metric source.  It should be
+                      one of "ContainerResource", "External", "Object", "Pods" or
+                      "Resource", each mapping to a matching field in the object.
+                      Note: "ContainerResource" type is available on when the feature-gate
+                      HPAContainerMetrics is enabled'
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            minReplicas:
+              description: minReplicas is the lower limit for the number of replicas
+                to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas
+                is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled
+                and at least one Object or External metric is configured.  Scaling
+                is active as long as at least one metric value is available.
+              format: int32
+              type: integer
+            scaleTargetRef:
+              description: scaleTargetRef points to the target resource to scale,
+                and is used to the pods for which metrics should be collected, as
+                well as to actually change the replica count.
+              properties:
+                apiVersion:
+                  description: API version of the referent
+                  type: string
+                kind:
+                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                  type: string
+                name:
+                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+          required:
+          - scaleTargetRef
+          - maxReplicas
+          type: object
+        status:
+          description: status is the current information about the autoscaler.
+          properties:
+            conditions:
+              description: conditions is the set of conditions required for this autoscaler
+                to scale its target, and indicates whether or not those conditions
+                are met.
+              items:
+                description: HorizontalPodAutoscalerCondition describes the state
+                  of a HorizontalPodAutoscaler at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human-readable explanation containing
+                      details about the transition
+                    type: string
+                  reason:
+                    description: reason is the reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: status is the status of the condition (True, False,
+                      Unknown)
+                    type: string
+                  type:
+                    description: type describes the current condition
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            currentMetrics:
+              description: currentMetrics is the last read state of the metrics used
+                by this autoscaler.
+              items:
+                description: MetricStatus describes the last-read state of a single
+                  metric.
+                properties:
+                  containerResource:
+                    description: container resource refers to a resource metric (such
+                      as those specified in requests and limits) known to Kubernetes
+                      describing a single container in each pod in the current scale
+                      target (e.g. CPU or memory). Such metrics are built in to Kubernetes,
+                      and have special scaling options on top of those available to
+                      normal per-pod metrics using the "pods" source.
+                    properties:
+                      container:
+                        description: Container is the name of the container in the
+                          pods of the scaling target
+                        type: string
+                      current:
+                        description: current contains the current value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: currentAverageUtilization is the current
+                              value of the average of the resource metric across all
+                              relevant pods, represented as a percentage of the requested
+                              value of the resource for the pods.
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the current value of the
+                              average of the metric across all relevant pods (as a
+                              quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the current value of the metric
+                              (as a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      name:
+                        description: Name is the name of the resource in question.
+                        type: string
+                    required:
+                    - name
+                    - current
+                    - container
+                    type: object
+                  external:
+                    description: external refers to a global metric that is not associated
+                      with any Kubernetes object. It allows autoscaling based on information
+                      coming from components running outside of cluster (for example
+                      length of queue in cloud messaging service, or QPS from loadbalancer
+                      running outside of cluster).
+                    properties:
+                      current:
+                        description: current contains the current value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: currentAverageUtilization is the current
+                              value of the average of the resource metric across all
+                              relevant pods, represented as a percentage of the requested
+                              value of the resource for the pods.
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the current value of the
+                              average of the metric across all relevant pods (as a
+                              quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the current value of the metric
+                              (as a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - metric
+                    - current
+                    type: object
+                  object:
+                    description: object refers to a metric describing a single kubernetes
+                      object (for example, hits-per-second on an Ingress object).
+                    properties:
+                      current:
+                        description: current contains the current value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: currentAverageUtilization is the current
+                              value of the average of the resource metric across all
+                              relevant pods, represented as a percentage of the requested
+                              value of the resource for the pods.
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the current value of the
+                              average of the metric across all relevant pods (as a
+                              quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the current value of the metric
+                              (as a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      describedObject:
+                        description: DescribedObject specifies the descriptions of
+                          a object,such as kind,name apiVersion
+                        properties:
+                          apiVersion:
+                            description: API version of the referent
+                            type: string
+                          kind:
+                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                            type: string
+                          name:
+                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - metric
+                    - current
+                    - describedObject
+                    type: object
+                  pods:
+                    description: pods refers to a metric describing each pod in the
+                      current scale target (for example, transactions-processed-per-second).  The
+                      values will be averaged together before being compared to the
+                      target value.
+                    properties:
+                      current:
+                        description: current contains the current value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: currentAverageUtilization is the current
+                              value of the average of the resource metric across all
+                              relevant pods, represented as a percentage of the requested
+                              value of the resource for the pods.
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the current value of the
+                              average of the metric across all relevant pods (as a
+                              quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the current value of the metric
+                              (as a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      metric:
+                        description: metric identifies the target metric by name and
+                          selector
+                        properties:
+                          name:
+                            description: name is the name of the given metric
+                            type: string
+                          selector:
+                            description: selector is the string-encoded form of a
+                              standard kubernetes label selector for the given metric
+                              When set, it is passed as an additional parameter to
+                              the metrics server for more specific metrics scoping.
+                              When unset, just the metricName will be used to gather
+                              metrics.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - metric
+                    - current
+                    type: object
+                  resource:
+                    description: resource refers to a resource metric (such as those
+                      specified in requests and limits) known to Kubernetes describing
+                      each pod in the current scale target (e.g. CPU or memory). Such
+                      metrics are built in to Kubernetes, and have special scaling
+                      options on top of those available to normal per-pod metrics
+                      using the "pods" source.
+                    properties:
+                      current:
+                        description: current contains the current value for the given
+                          metric
+                        properties:
+                          averageUtilization:
+                            description: currentAverageUtilization is the current
+                              value of the average of the resource metric across all
+                              relevant pods, represented as a percentage of the requested
+                              value of the resource for the pods.
+                            format: int32
+                            type: integer
+                          averageValue:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: averageValue is the current value of the
+                              average of the metric across all relevant pods (as a
+                              quantity)
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: value is the current value of the metric
+                              (as a quantity).
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      name:
+                        description: Name is the name of the resource in question.
+                        type: string
+                    required:
+                    - name
+                    - current
+                    type: object
+                  type:
+                    description: 'type is the type of metric source.  It will be one
+                      of "ContainerResource", "External", "Object", "Pods" or "Resource",
+                      each corresponds to a matching field in the object. Note: "ContainerResource"
+                      type is available on when the feature-gate HPAContainerMetrics
+                      is enabled'
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            currentReplicas:
+              description: currentReplicas is current number of replicas of pods managed
+                by this autoscaler, as last seen by the autoscaler.
+              format: int32
+              type: integer
+            desiredReplicas:
+              description: desiredReplicas is the desired number of replicas of pods
+                managed by this autoscaler, as last calculated by the autoscaler.
+              format: int32
+              type: integer
+            lastScaleTime:
+              description: lastScaleTime is the last time the HorizontalPodAutoscaler
+                scaled the number of pods, used by the autoscaler to control how often
+                the number of pods is changed.
+              format: date-time
+              type: string
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                by this autoscaler.
+              format: int64
+              type: integer
+          required:
+          - desiredReplicas
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-jobs.batch.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-jobs.batch.yaml
@@ -1,0 +1,7376 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-6e3cae39.jobs.batch
+spec:
+  group: batch
+  names:
+    categories:
+    - all
+    kind: Job
+    listKind: JobList
+    plural: jobs
+    singular: job
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: Job represents the configuration of a single job.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'Specification of the desired behavior of a job. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            activeDeadlineSeconds:
+              description: Specifies the duration in seconds relative to the startTime
+                that the job may be continuously active before the system tries to
+                terminate it; value must be positive integer. If a Job is suspended
+                (at creation or through an update), this timer will effectively be
+                stopped and reset when the Job is resumed again.
+              format: int64
+              type: integer
+            backoffLimit:
+              description: Specifies the number of retries before marking this job
+                failed. Defaults to 6
+              format: int32
+              type: integer
+            completionMode:
+              description: |-
+                CompletionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+                `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+                `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+              type: string
+            completions:
+              description: 'Specifies the desired number of successfully finished
+                pods the job should be run with.  Setting to nil means that the success
+                of any pod signals the success of all pods, and allows parallelism
+                to have any positive value.  Setting to 1 means that parallelism is
+                limited to 1 and the success of that pod signals the success of the
+                job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+              format: int32
+              type: integer
+            manualSelector:
+              description: 'manualSelector controls generation of pod labels and pod
+                selectors. Leave `manualSelector` unset unless you are certain what
+                you are doing. When false or unset, the system pick labels unique
+                to this job and appends those labels to the pod template.  When true,
+                the user is responsible for picking unique labels and specifying the
+                selector.  Failure to pick a unique label may cause this and other
+                jobs to not function correctly.  However, You may see `manualSelector=true`
+                in jobs that were created with the old `extensions/v1beta1` API. More
+                info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+              type: boolean
+            parallelism:
+              description: 'Specifies the maximum desired number of pods the job should
+                run at any given time. The actual number of pods running in steady
+                state will be less than this number when ((.spec.completions - .status.successful)
+                < .spec.parallelism), i.e. when the work left to do is less than max
+                parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+              format: int32
+              type: integer
+            podFailurePolicy:
+              description: |-
+                Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+                This field is alpha-level. To use this field, you must enable the `JobPodFailurePolicy` feature gate (disabled by default).
+              properties:
+                rules:
+                  description: A list of pod failure policy rules. The rules are evaluated
+                    in order. Once a rule matches a Pod failure, the remaining of
+                    the rules are ignored. When no rule matches the Pod failure, the
+                    default handling applies - the counter of pod failures is incremented
+                    and it is checked against the backoffLimit. At most 20 elements
+                    are allowed.
+                  items:
+                    description: PodFailurePolicyRule describes how a pod failure
+                      is handled when the requirements are met. One of OnExitCodes
+                      and onPodConditions, but not both, can be used in each rule.
+                    properties:
+                      action:
+                        description: |-
+                          Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: - FailJob: indicates that the pod's job is marked as Failed and all
+                            running pods are terminated.
+                          - Ignore: indicates that the counter towards the .backoffLimit is not
+                            incremented and a replacement pod is created.
+                          - Count: indicates that the pod is handled in the default way - the
+                            counter towards the .backoffLimit is incremented.
+                          Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+
+                          Possible enum values:
+                           - `"Count"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.
+                           - `"FailJob"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.
+                           - `"Ignore"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.
+                        type: string
+                      onExitCodes:
+                        description: Represents the requirement on the container exit
+                          codes.
+                        properties:
+                          containerName:
+                            description: Restricts the check for exit codes to the
+                              container with the specified name. When null, the rule
+                              applies to all containers. When specified, it should
+                              match one the container or initContainer names in the
+                              pod template.
+                            type: string
+                          operator:
+                            description: |-
+                              Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: - In: the requirement is satisfied if at least one container exit code
+                                (might be multiple if there are multiple containers not restricted
+                                by the 'containerName' field) is in the set of specified values.
+                              - NotIn: the requirement is satisfied if at least one container exit code
+                                (might be multiple if there are multiple containers not restricted
+                                by the 'containerName' field) is not in the set of specified values.
+                              Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+
+                              Possible enum values:
+                               - `"In"`
+                               - `"NotIn"`
+                            type: string
+                          values:
+                            description: Specifies the set of values. Each returned
+                              container exit code (might be multiple in case of multiple
+                              containers) is checked against this set of values with
+                              respect to the operator. The list of values must be
+                              ordered and must not contain duplicates. Value '0' cannot
+                              be used for the In operator. At least one element is
+                              required. At most 255 elements are allowed.
+                            items:
+                              format: int32
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - operator
+                        - values
+                        type: object
+                      onPodConditions:
+                        description: Represents the requirement on the pod conditions.
+                          The requirement is represented as a list of pod condition
+                          patterns. The requirement is satisfied if at least one pattern
+                          matches an actual pod condition. At most 20 elements are
+                          allowed.
+                        items:
+                          description: PodFailurePolicyOnPodConditionsPattern describes
+                            a pattern for matching an actual pod condition type.
+                          properties:
+                            status:
+                              description: Specifies the required Pod condition status.
+                                To match a pod condition it is required that the specified
+                                status equals the pod condition status. Defaults to
+                                True.
+                              type: string
+                            type:
+                              description: Specifies the required Pod condition type.
+                                To match a pod condition it is required that specified
+                                type equals the pod condition type.
+                              type: string
+                          required:
+                          - type
+                          - status
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    required:
+                    - action
+                    - onPodConditions
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+              - rules
+              type: object
+            selector:
+              description: 'A label query over pods that should match the pod count.
+                Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            suspend:
+              description: Suspend specifies whether the Job controller should create
+                Pods or not. If a Job is created with suspend set to true, no Pods
+                are created by the Job controller. If a Job is suspended after creation
+                (i.e. the flag goes from false to true), the Job controller will delete
+                all active Pods associated with this Job. Users must design their
+                workload to gracefully handle this. Suspending a Job will reset the
+                StartTime field of the Job, effectively resetting the ActiveDeadlineSeconds
+                timer too. Defaults to false.
+              type: boolean
+            template:
+              description: 'Describes the pod that will be created when executing
+                a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the pod.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
+                    affinity:
+                      description: If specified, the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - preference
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      description: AutomountServiceAccountToken indicates whether
+                        a service account token should be automatically mounted.
+                      type: boolean
+                    containers:
+                      description: List of containers belonging to the pod. Containers
+                        cannot currently be added or removed. There must be at least
+                        one container in a Pod. Cannot be updated.
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    dnsConfig:
+                      description: Specifies the DNS parameters of a pod. Parameters
+                        specified here will be merged to the generated DNS configuration
+                        based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: A list of DNS name server IP addresses. This
+                            will be appended to the base nameservers generated from
+                            DNSPolicy. Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          description: A list of DNS resolver options. This will be
+                            merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options
+                            given in Options will override those that appear in the
+                            base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: Required.
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          description: A list of DNS search domains for host-name
+                            lookup. This will be appended to the base search paths
+                            generated from DNSPolicy. Duplicated search paths will
+                            be removed.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                        Possible enum values:
+                         - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                         - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                      type: string
+                    enableServiceLinks:
+                      description: 'EnableServiceLinks indicates whether information
+                        about services should be injected into pod''s environment
+                        variables, matching the syntax of Docker links. Optional:
+                        Defaults to true.'
+                      type: boolean
+                    ephemeralContainers:
+                      description: List of ephemeral containers run in this pod. Ephemeral
+                        containers may be run in an existing pod to perform user-initiated
+                        actions such as debugging. This list cannot be specified when
+                        creating a pod, and it cannot be modified by updating the
+                        pod spec. In order to add an ephemeral container to an existing
+                        pod, use the pod's ephemeralcontainers subresource.
+                      items:
+                        description: |-
+                          An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The image''s
+                              CMD is used if this is not provided. Variable references
+                              $(VAR_NAME) are expanded using the container''s environment.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The image''s ENTRYPOINT is used if this is not
+                              provided. Variable references $(VAR_NAME) are expanded
+                              using the container''s environment. If a variable cannot
+                              be resolved, the reference in the input string will
+                              be unchanged. Double $$ are reduced to a single $, which
+                              allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                              will produce the string literal "$(VAR_NAME)". Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Cannot be updated. More
+                              info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Lifecycle is not allowed for ephemeral containers.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the ephemeral container specified
+                              as a DNS_LABEL. This name must be unique among all containers,
+                              init containers and ephemeral containers.
+                            type: string
+                          ports:
+                            description: Ports are not allowed for ephemeral containers.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: Resources are not allowed for ephemeral containers.
+                              Ephemeral containers use spare resources already allocated
+                              to the pod.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Optional: SecurityContext defines the security
+                              options the ephemeral container should be run with.
+                              If set, the fields of SecurityContext override the equivalent
+                              fields of PodSecurityContext.'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          targetContainerName:
+                            description: |-
+                              If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                              The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                            type: string
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Subpath mounts are not allowed for ephemeral
+                              containers. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    hostAliases:
+                      description: HostAliases is an optional list of hosts and IPs
+                        that will be injected into the pod's hosts file if specified.
+                        This is only valid for non-hostNetwork pods.
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        required:
+                        - ip
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - ip
+                      x-kubernetes-list-type: map
+                    hostIPC:
+                      description: 'Use the host''s ipc namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace. If this option is set, the ports
+                        that will be used must be specified. Default to false.
+                      type: boolean
+                    hostPID:
+                      description: 'Use the host''s pid namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostUsers:
+                      description: 'Use the host''s user namespace. Optional: Default
+                        to true. If set to true or not present, the pod will be run
+                        in the host user namespace, useful for when the pod needs
+                        a feature only available to the host user namespace, such
+                        as loading a kernel module with CAP_SYS_MODULE. When set to
+                        false, a new userns is created for the pod. Setting false
+                        is useful for mitigating container breakout vulnerabilities
+                        even allowing users to run their containers as root without
+                        actually having root privileges on the host. This field is
+                        alpha-level and is only honored by servers that enable the
+                        UserNamespacesSupport feature.'
+                      type: boolean
+                    hostname:
+                      description: Specifies the hostname of the Pod If not specified,
+                        the pod's hostname will be set to a system-defined value.
+                      type: string
+                    imagePullSecrets:
+                      description: 'ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of
+                        the images used by this PodSpec. If specified, these secrets
+                        will be passed to individual puller implementations for them
+                        to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    initContainers:
+                      description: 'List of initialization containers belonging to
+                        the pod. Init containers are executed in order prior to containers
+                        being started. If any init container fails, the pod is considered
+                        to have failed and is handled according to its restartPolicy.
+                        The name for an init container or normal container must be
+                        unique among all containers. Init containers may not have
+                        Lifecycle actions, Readiness probes, Liveness probes, or Startup
+                        probes. The resourceRequirements of an init container are
+                        taken into account during scheduling by finding the highest
+                        request/limit for each resource type, and then using the max
+                        of of that value or the sum of the normal containers. Limits
+                        are applied to init containers in a similar fashion. Init
+                        containers cannot currently be added or removed. Cannot be
+                        updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    nodeName:
+                      description: NodeName is a request to schedule this pod onto
+                        a specific node. If it is non-empty, the scheduler simply
+                        schedules this pod onto that node, assuming that it fits resource
+                        requirements.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    os:
+                      description: |-
+                        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                      properties:
+                        name:
+                          description: 'Name is the name of the operating system.
+                            The currently supported values are linux and windows.
+                            Additional value may be defined in future and can be one
+                            of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                            Clients should expect to handle additional values and
+                            treat unrecognized values in this field as os: null'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Overhead represents the resource overhead associated
+                        with running a pod for a given RuntimeClass. This field will
+                        be autopopulated at admission time by the RuntimeClass admission
+                        controller. If the RuntimeClass admission controller is enabled,
+                        overhead must not be set in Pod create requests. The RuntimeClass
+                        admission controller will reject Pod create requests which
+                        have the overhead already set. If RuntimeClass is configured
+                        and selected in the PodSpec, Overhead will be set to the value
+                        defined in the corresponding RuntimeClass, otherwise it will
+                        remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                      type: object
+                    preemptionPolicy:
+                      description: PreemptionPolicy is the Policy for preempting pods
+                        with lower priority. One of Never, PreemptLowerPriority. Defaults
+                        to PreemptLowerPriority if unset.
+                      type: string
+                    priority:
+                      description: The priority value. Various system components use
+                        this field to find the priority of the pod. When Priority
+                        Admission Controller is enabled, it prevents users from setting
+                        this field. The admission controller populates this field
+                        from PriorityClassName. The higher the value, the higher the
+                        priority.
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which
+                        indicate the highest priorities with the former being the
+                        highest priority. Any other name must be defined by creating
+                        a PriorityClass object with that name. If not specified, the
+                        pod priority will be default or zero if there is no default.
+                      type: string
+                    readinessGates:
+                      description: 'If specified, all readiness gates will be evaluated
+                        for pod readiness. A pod is ready when all its containers
+                        are ready AND all conditions specified in the readiness gates
+                        have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                      items:
+                        description: PodReadinessGate contains the reference to a
+                          pod condition
+                        properties:
+                          conditionType:
+                            description: ConditionType refers to a condition in the
+                              pod's condition list with matching type.
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      description: |-
+                        Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                        Possible enum values:
+                         - `"Always"`
+                         - `"Never"`
+                         - `"OnFailure"`
+                      type: string
+                    runtimeClassName:
+                      description: 'RuntimeClassName refers to a RuntimeClass object
+                        in the node.k8s.io group, which should be used to run this
+                        pod.  If no RuntimeClass resource matches the named class,
+                        the pod will not be run. If unset or empty, the "legacy" RuntimeClass
+                        will be used, which is an implicit class with an empty definition
+                        that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                      type: string
+                    schedulerName:
+                      description: If specified, the pod will be dispatched by specified
+                        scheduler. If not specified, the pod will be dispatched by
+                        default scheduler.
+                      type: string
+                    securityContext:
+                      description: 'SecurityContext holds pod-level security attributes
+                        and common container settings. Optional: Defaults to empty.  See
+                        type description for default values of each field.'
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                Possible enum values:
+                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: 'DeprecatedServiceAccount is a depreciated alias
+                        for ServiceAccountName. Deprecated: Use serviceAccountName
+                        instead.'
+                      type: string
+                    serviceAccountName:
+                      description: 'ServiceAccountName is the name of the ServiceAccount
+                        to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                      type: string
+                    setHostnameAsFQDN:
+                      description: If true the pod's hostname will be configured as
+                        the pod's FQDN, rather than the leaf name (the default). In
+                        Linux containers, this means setting the FQDN in the hostname
+                        field of the kernel (the nodename field of struct utsname).
+                        In Windows containers, this means setting the registry value
+                        of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                        to FQDN. If a pod does not have FQDN, this has no effect.
+                        Default to false.
+                      type: boolean
+                    shareProcessNamespace:
+                      description: 'Share a single process namespace between all of
+                        the containers in a pod. When this is set containers will
+                        be able to view and signal processes from other containers
+                        in the same pod, and the first process in each container will
+                        not be assigned PID 1. HostPID and ShareProcessNamespace cannot
+                        both be set. Optional: Default to false.'
+                      type: boolean
+                    subdomain:
+                      description: If specified, the fully qualified Pod hostname
+                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                        domain>". If not specified, the pod will not have a domainname
+                        at all.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully. May be decreased in delete request. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). If this
+                        value is nil, the default grace period will be used instead.
+                        The grace period is the duration in seconds after the processes
+                        running in the pod are sent a termination signal and the time
+                        when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your
+                        process. Defaults to 30 seconds.
+                      format: int64
+                      type: integer
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                              Possible enum values:
+                               - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                               - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                               - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                              Possible enum values:
+                               - `"Equal"`
+                               - `"Exists"`
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints describes how a group
+                        of pods ought to spread across topology domains. Scheduler
+                        will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select the pods over which spreading will be calculated.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading
+                              will be calculated for the incoming pod. Keys that don't
+                              exist in the incoming pod labels will be ignored. A
+                              null or empty list means only match against labelSelector.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. The global minimum is the minimum number of
+                              matching pods in an eligible domain or zero if the number
+                              of eligible domains is less than MinDomains. For example,
+                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
+                              the same labelSelector spread as 2/2/1: In this case,
+                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
+                              can only be scheduled to zone3 to become 2/2/2; scheduling
+                              it onto zone1(zone2) would make the ActualSkew(3-1)
+                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
+                              2, incoming pod can be scheduled onto any zone. When
+                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
+                              higher precedence to topologies that satisfy it. It''s
+                              a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. We define a domain
+                              as a particular instance of a topology. Also, we define
+                              an eligible domain as a domain whose nodes meet the
+                              requirements of nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each
+                              Node is a domain of that topology. And, if TopologyKey
+                              is "topology.kubernetes.io/zone", each zone is a domain
+                              of that topology. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                              Possible enum values:
+                               - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                               - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    volumes:
+                      description: 'List of volumes that can be mounted by containers
+                        belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                  disk resource in AWS (Amazon EBS volume). More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a
+                                  collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                  the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is
+                                  reference to the authentication secret for User,
+                                  default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados
+                                  user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Examples: "ext4", "xfs", "ntfs".
+                                  Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to
+                                  OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                  medium should back this directory. The default is
+                                  "" which means to use the node''s default medium.
+                                  Must be an empty string (default) or Memory. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'sizeLimit is the total amount of local
+                                  storage required for this EmptyDir volume. The size
+                                  limit is also applicable for memory medium. The
+                                  maximum usage on memory medium EmptyDir would be
+                                  the minimum value between the SizeLimit specified
+                                  here and the sum of memory limits of all containers
+                                  in a pod. The default is nil which means that the
+                                  limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used
+                                          to specify either: * An existing VolumeSnapshot
+                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name
+                                          of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide
+                                  identifiers (wwids) Either wwids or combination
+                                  of targetWWNs and lun must be set, but not both
+                                  simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". The
+                                  default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is
+                                  reference to the secret object containing sensitive
+                                  information to pass to the plugin scripts. This
+                                  may be empty if no secret object is specified. If
+                                  the secret object contains more than one secret,
+                                  all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                  in GCE. Used to identify the disk in GCE. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is
+                                  supplied, the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name
+                                  that uses an iSCSI transport. Defaults to 'default'
+                                  (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal.
+                                  The Portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                type: string
+                            required:
+                            - targetPortal
+                            - iqn
+                            - lun
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL
+                              and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - server
+                            - path
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to
+                                  set permissions on created files by default. Must
+                                  be an octal value between 0000 and 0777 or a decimal
+                                  value between 0 and 511. YAML accepts both octal
+                                  and decimal values, JSON requires decimal values
+                                  for mode bits. Directories within the path are not
+                                  affected by this setting. This might be in conflict
+                                  with other options that affect the file mode, like
+                                  fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default
+                                  is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default
+                                  is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            - image
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                  is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated
+                                  with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - system
+                            - secretRef
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret
+                                  in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - containers
+                  type: object
+              type: object
+            ttlSecondsAfterFinished:
+              description: ttlSecondsAfterFinished limits the lifetime of a Job that
+                has finished execution (either Complete or Failed). If this field
+                is set, ttlSecondsAfterFinished after the Job finishes, it is eligible
+                to be automatically deleted. When the Job is being deleted, its lifecycle
+                guarantees (e.g. finalizers) will be honored. If this field is unset,
+                the Job won't be automatically deleted. If this field is set to zero,
+                the Job becomes eligible to be deleted immediately after it finishes.
+              format: int32
+              type: integer
+          required:
+          - template
+          type: object
+        status:
+          description: 'Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            active:
+              description: The number of pending and running pods.
+              format: int32
+              type: integer
+            completedIndexes:
+              description: CompletedIndexes holds the completed indexes when .spec.completionMode
+                = "Indexed" in a text format. The indexes are represented as decimal
+                integers separated by commas. The numbers are listed in increasing
+                order. Three or more consecutive numbers are compressed and represented
+                by the first and last element of the series, separated by a hyphen.
+                For example, if the completed indexes are 1, 3, 4, 5 and 7, they are
+                represented as "1,3-5,7".
+              type: string
+            completionTime:
+              description: Represents time when the job was completed. It is not guaranteed
+                to be set in happens-before order across separate operations. It is
+                represented in RFC3339 form and is in UTC. The completion time is
+                only set when the job finishes successfully.
+              format: date-time
+              type: string
+            conditions:
+              description: 'The latest available observations of an object''s current
+                state. When a Job fails, one of the conditions will have type "Failed"
+                and status true. When a Job is suspended, one of the conditions will
+                have type "Suspended" and status true; when the Job is resumed, the
+                status of this condition will become false. When a Job is completed,
+                one of the conditions will have type "Complete" and status true. More
+                info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+              items:
+                description: JobCondition describes current state of a job.
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of job condition, Complete or Failed.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            failed:
+              description: The number of pods which reached phase Failed.
+              format: int32
+              type: integer
+            ready:
+              description: |-
+                The number of pods which have a Ready condition.
+
+                This field is beta-level. The job controller populates the field when the feature gate JobReadyPods is enabled (enabled by default).
+              format: int32
+              type: integer
+            startTime:
+              description: Represents time when the job controller started processing
+                a job. When a Job is created in the suspended state, this field is
+                not set until the first time it is resumed. This field is reset every
+                time a Job is resumed from suspension. It is represented in RFC3339
+                form and is in UTC.
+              format: date-time
+              type: string
+            succeeded:
+              description: The number of pods which reached phase Succeeded.
+              format: int32
+              type: integer
+            uncountedTerminatedPods:
+              description: |-
+                UncountedTerminatedPods holds the UIDs of Pods that have terminated but the job controller hasn't yet accounted for in the status counters.
+
+                The job controller creates pods with a finalizer. When a pod terminates (succeeded or failed), the controller does three steps to account for it in the job status: (1) Add the pod UID to the arrays in this field. (2) Remove the pod finalizer. (3) Remove the pod UID from the arrays while increasing the corresponding
+                    counter.
+
+                This field is beta-level. The job controller only makes use of this field when the feature gate JobTrackingWithFinalizers is enabled (enabled by default). Old jobs might not be tracked using this field, in which case the field remains null.
+              properties:
+                failed:
+                  description: Failed holds UIDs of failed Pods.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+                succeeded:
+                  description: Succeeded holds UIDs of succeeded Pods.
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: set
+              type: object
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-networkpolicies.networking.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-networkpolicies.networking.k8s.io.yaml
@@ -1,0 +1,530 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.networkpolicies.networking.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1111
+spec:
+  group: networking.k8s.io
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: NetworkPolicy describes what network traffic is allowed for a set
+        of Pods
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired behavior for this NetworkPolicy.
+          properties:
+            egress:
+              description: List of egress rules to be applied to the selected pods.
+                Outgoing traffic is allowed if there are no NetworkPolicies selecting
+                the pod (and cluster policy otherwise allows the traffic), OR if the
+                traffic matches at least one egress rule across all of the NetworkPolicy
+                objects whose podSelector matches the pod. If this field is empty
+                then this NetworkPolicy limits all outgoing traffic (and serves solely
+                to ensure that the pods it selects are isolated by default). This
+                field is beta-level in 1.8
+              items:
+                description: NetworkPolicyEgressRule describes a particular set of
+                  traffic that is allowed out of pods matched by a NetworkPolicySpec's
+                  podSelector. The traffic must match both ports and to. This type
+                  is beta-level in 1.8
+                properties:
+                  ports:
+                    description: List of destination ports for outgoing traffic. Each
+                      item in this list is combined using a logical OR. If this field
+                      is empty or missing, this rule matches all ports (traffic not
+                      restricted by port). If this field is present and contains at
+                      least one item, then this rule allows traffic only if the traffic
+                      matches at least one port in the list.
+                    items:
+                      description: NetworkPolicyPort describes a port to allow traffic
+                        on
+                      properties:
+                        endPort:
+                          description: If set, indicates that the range of ports from
+                            port to endPort, inclusive, should be allowed by the policy.
+                            This field cannot be defined if the port field is not
+                            defined or if the port field is defined as a named (string)
+                            port. The endPort must be equal or greater than port.
+                          format: int32
+                          type: integer
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: The port on the given protocol. This can either
+                            be a numerical or named port on a pod. If this field is
+                            not provided, this matches all port names and numbers.
+                            If present, only traffic on the specified protocol AND
+                            port will be matched.
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          description: The protocol (TCP, UDP, or SCTP) which traffic
+                            must match. If not specified, this field defaults to TCP.
+                          type: string
+                      type: object
+                    type: array
+                  to:
+                    description: List of destinations for outgoing traffic of pods
+                      selected for this rule. Items in this list are combined using
+                      a logical OR operation. If this field is empty or missing, this
+                      rule matches all destinations (traffic not restricted by destination).
+                      If this field is present and contains at least one item, this
+                      rule allows traffic only if the traffic matches at least one
+                      item in the to list.
+                    items:
+                      description: NetworkPolicyPeer describes a peer to allow traffic
+                        to/from. Only certain combinations of fields are allowed
+                      properties:
+                        ipBlock:
+                          description: IPBlock defines policy on a particular IPBlock.
+                            If this field is set then neither of the other fields
+                            can be.
+                          properties:
+                            cidr:
+                              description: CIDR is a string representing the IP Block
+                                Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                              type: string
+                            except:
+                              description: Except is a slice of CIDRs that should
+                                not be included within an IP Block Valid examples
+                                are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                will be rejected if they are outside the CIDR range
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - cidr
+                          type: object
+                        namespaceSelector:
+                          description: |-
+                            Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                            If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        podSelector:
+                          description: |-
+                            This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                            If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              type: array
+            ingress:
+              description: List of ingress rules to be applied to the selected pods.
+                Traffic is allowed to a pod if there are no NetworkPolicies selecting
+                the pod (and cluster policy otherwise allows the traffic), OR if the
+                traffic source is the pod's local node, OR if the traffic matches
+                at least one ingress rule across all of the NetworkPolicy objects
+                whose podSelector matches the pod. If this field is empty then this
+                NetworkPolicy does not allow any traffic (and serves solely to ensure
+                that the pods it selects are isolated by default)
+              items:
+                description: NetworkPolicyIngressRule describes a particular set of
+                  traffic that is allowed to the pods matched by a NetworkPolicySpec's
+                  podSelector. The traffic must match both ports and from.
+                properties:
+                  from:
+                    description: List of sources which should be able to access the
+                      pods selected for this rule. Items in this list are combined
+                      using a logical OR operation. If this field is empty or missing,
+                      this rule matches all sources (traffic not restricted by source).
+                      If this field is present and contains at least one item, this
+                      rule allows traffic only if the traffic matches at least one
+                      item in the from list.
+                    items:
+                      description: NetworkPolicyPeer describes a peer to allow traffic
+                        to/from. Only certain combinations of fields are allowed
+                      properties:
+                        ipBlock:
+                          description: IPBlock defines policy on a particular IPBlock.
+                            If this field is set then neither of the other fields
+                            can be.
+                          properties:
+                            cidr:
+                              description: CIDR is a string representing the IP Block
+                                Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                              type: string
+                            except:
+                              description: Except is a slice of CIDRs that should
+                                not be included within an IP Block Valid examples
+                                are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                will be rejected if they are outside the CIDR range
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - cidr
+                          type: object
+                        namespaceSelector:
+                          description: |-
+                            Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                            If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        podSelector:
+                          description: |-
+                            This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                            If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      type: object
+                    type: array
+                  ports:
+                    description: List of ports which should be made accessible on
+                      the pods selected for this rule. Each item in this list is combined
+                      using a logical OR. If this field is empty or missing, this
+                      rule matches all ports (traffic not restricted by port). If
+                      this field is present and contains at least one item, then this
+                      rule allows traffic only if the traffic matches at least one
+                      port in the list.
+                    items:
+                      description: NetworkPolicyPort describes a port to allow traffic
+                        on
+                      properties:
+                        endPort:
+                          description: If set, indicates that the range of ports from
+                            port to endPort, inclusive, should be allowed by the policy.
+                            This field cannot be defined if the port field is not
+                            defined or if the port field is defined as a named (string)
+                            port. The endPort must be equal or greater than port.
+                          format: int32
+                          type: integer
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: The port on the given protocol. This can either
+                            be a numerical or named port on a pod. If this field is
+                            not provided, this matches all port names and numbers.
+                            If present, only traffic on the specified protocol AND
+                            port will be matched.
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          description: The protocol (TCP, UDP, or SCTP) which traffic
+                            must match. If not specified, this field defaults to TCP.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              type: array
+            podSelector:
+              description: Selects the pods to which this NetworkPolicy object applies.
+                The array of ingress rules is applied to any pods selected by this
+                field. Multiple network policies can select the same set of pods.
+                In this case, the ingress rules for each are combined additively.
+                This field is NOT optional and follows standard label selector semantics.
+                An empty podSelector matches all pods in this namespace.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            policyTypes:
+              description: List of rule types that the NetworkPolicy relates to. Valid
+                options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If
+                this field is not specified, it will default based on the existence
+                of Ingress or Egress rules; policies that contain an Egress section
+                are assumed to affect Egress, and all policies (whether or not they
+                contain an Ingress section) are assumed to affect Ingress. If you
+                want to write an egress-only policy, you must explicitly specify policyTypes
+                [ "Egress" ]. Likewise, if you want to write a policy that specifies
+                that no egress is allowed, you must specify a policyTypes value that
+                include "Egress" (since such a policy would not include an Egress
+                section and would otherwise default to just [ "Ingress" ]). This field
+                is beta-level in 1.8
+              items:
+                type: string
+              type: array
+          required:
+          - podSelector
+          type: object
+        status:
+          description: 'Status is the current state of the NetworkPolicy. More info:
+            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            conditions:
+              description: Conditions holds an array of metav1.Condition that describe
+                the state of the NetworkPolicy. Current service state
+              items:
+                description: Condition contains details for one aspect of the current
+                  state of this API Resource.
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another. This should be when
+                      the underlying condition changed.  If that is not known, then
+                      using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details
+                      about the transition. This may be an empty string.
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.conditions[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating
+                      the reason for the condition's last transition. Producers of
+                      specific condition types may define expected values and meanings
+                      for this field, and whether the values are considered a guaranteed
+                      API. The value should be a CamelCase string. This field may
+                      not be empty.
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-persistentvolumeclaims.core.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-persistentvolumeclaims.core.k8s.io.yaml
@@ -1,0 +1,278 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.persistentvolumeclaims.core
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/1111
+spec:
+  group: ""
+  names:
+    kind: PersistentVolumeClaim
+    listKind: PersistentVolumeClaimList
+    plural: persistentvolumeclaims
+    shortNames:
+    - pvc
+    singular: persistentvolumeclaim
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: PersistentVolumeClaim is a user's request for and claim to a persistent
+        volume
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'spec defines the desired characteristics of a volume requested
+            by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+          properties:
+            accessModes:
+              description: 'accessModes contains the desired access modes the volume
+                should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+              items:
+                type: string
+              type: array
+            dataSource:
+              description: 'dataSource field can be used to specify either: * An existing
+                VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An
+                existing PVC (PersistentVolumeClaim) If the provisioner or an external
+                controller can support the specified data source, it will create a
+                new volume based on the contents of the specified data source. If
+                the AnyVolumeDataSource feature gate is enabled, this field will always
+                have the same contents as the DataSourceRef field.'
+              properties:
+                apiGroup:
+                  description: APIGroup is the group for the resource being referenced.
+                    If APIGroup is not specified, the specified Kind must be in the
+                    core API group. For any other third-party types, APIGroup is required.
+                  type: string
+                kind:
+                  description: Kind is the type of resource being referenced
+                  type: string
+                name:
+                  description: Name is the name of resource being referenced
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+            dataSourceRef:
+              description: |-
+                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                  preserves all values, and generates an error if a disallowed value is
+                  specified.
+                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+              properties:
+                apiGroup:
+                  description: APIGroup is the group for the resource being referenced.
+                    If APIGroup is not specified, the specified Kind must be in the
+                    core API group. For any other third-party types, APIGroup is required.
+                  type: string
+                kind:
+                  description: Kind is the type of resource being referenced
+                  type: string
+                name:
+                  description: Name is the name of resource being referenced
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+            resources:
+              description: 'resources represents the minimum resources the volume
+                should have. If RecoverVolumeExpansionFailure feature is enabled users
+                are allowed to specify resource requirements that are lower than previous
+                value but must still be higher than capacity recorded in the status
+                field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                  type: object
+              type: object
+            selector:
+              description: selector is a label query over volumes to consider for
+                binding.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            storageClassName:
+              description: 'storageClassName is the name of the StorageClass required
+                by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+              type: string
+            volumeMode:
+              description: volumeMode defines what type of volume is required by the
+                claim. Value of Filesystem is implied when not included in claim spec.
+              type: string
+            volumeName:
+              description: volumeName is the binding reference to the PersistentVolume
+                backing this claim.
+              type: string
+          type: object
+        status:
+          description: 'status represents the current information/status of a persistent
+            volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+          properties:
+            accessModes:
+              description: 'accessModes contains the actual access modes the volume
+                backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+              items:
+                type: string
+              type: array
+            allocatedResources:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: allocatedResources is the storage resource within AllocatedResources
+                tracks the capacity allocated to a PVC. It may be larger than the
+                actual capacity when a volume expansion operation is requested. For
+                storage quota, the larger value from allocatedResources and PVC.spec.resources
+                is used. If allocatedResources is not set, PVC.spec.resources alone
+                is used for quota calculation. If a volume expansion capacity request
+                is lowered, allocatedResources is only lowered if there are no expansion
+                operations in progress and if the actual volume capacity is equal
+                or lower than the requested capacity. This is an alpha field and requires
+                enabling RecoverVolumeExpansionFailure feature.
+              type: object
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: capacity represents the actual resources of the underlying
+                volume.
+              type: object
+            conditions:
+              description: conditions is the current Condition of persistent volume
+                claim. If underlying persistent volume is being resized then the Condition
+                will be set to 'ResizeStarted'.
+              items:
+                description: PersistentVolumeClaimCondition contails details about
+                  state of pvc
+                properties:
+                  lastProbeTime:
+                    description: lastProbeTime is the time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: lastTransitionTime is the time the condition transitioned
+                      from one status to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is the human-readable message indicating
+                      details about last transition.
+                    type: string
+                  reason:
+                    description: reason is a unique, this should be a short, machine
+                      understandable string that gives the reason for condition's
+                      last transition. If it reports "ResizeStarted" that means the
+                      underlying persistent volume is being resized.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            phase:
+              description: |-
+                phase represents the current phase of PersistentVolumeClaim.
+
+                Possible enum values:
+                 - `"Bound"` used for PersistentVolumeClaims that are bound
+                 - `"Lost"` used for PersistentVolumeClaims that lost their underlying PersistentVolume. The claim was bound to a PersistentVolume and this volume does not exist any longer and all data on it was lost.
+                 - `"Pending"` used for PersistentVolumeClaims that are not yet bound
+              type: string
+            resizeStatus:
+              description: resizeStatus stores status of resize operation. ResizeStatus
+                is not set by default but when expansion is complete resizeStatus
+                is set to empty string by resize controller or kubelet. This is an
+                alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-poddisruptionbudgets.policy.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-poddisruptionbudgets.policy.yaml
@@ -1,0 +1,213 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.poddisruptionbudgets.policy
+spec:
+  group: policy
+  names:
+    kind: PodDisruptionBudget
+    listKind: PodDisruptionBudgetList
+    plural: poddisruptionbudgets
+    shortNames:
+    - pdb
+    singular: poddisruptionbudget
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: PodDisruptionBudget is an object to define the max disruption that
+        can be caused to a collection of pods
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of the desired behavior of the PodDisruptionBudget.
+          properties:
+            maxUnavailable:
+              anyOf:
+              - type: integer
+              - type: string
+              description: An eviction is allowed if at most "maxUnavailable" pods
+                selected by "selector" are unavailable after the eviction, i.e. even
+                in absence of the evicted pod. For example, one can prevent all voluntary
+                evictions by specifying 0. This is a mutually exclusive setting with
+                "minAvailable".
+              x-kubernetes-int-or-string: true
+            minAvailable:
+              anyOf:
+              - type: integer
+              - type: string
+              description: An eviction is allowed if at least "minAvailable" pods
+                selected by "selector" will still be available after the eviction,
+                i.e. even in the absence of the evicted pod.  So for example you can
+                prevent all voluntary evictions by specifying "100%".
+              x-kubernetes-int-or-string: true
+            selector:
+              description: Label query over pods whose evictions are managed by the
+                disruption budget. A null selector will match no pods, while an empty
+                ({}) selector will select all pods within the namespace.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          type: object
+        status:
+          description: Most recently observed status of the PodDisruptionBudget.
+          properties:
+            conditions:
+              description: |-
+                Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute
+                              the number of allowed disruptions. Therefore no disruptions are
+                              allowed and the status of the condition will be False.
+                - InsufficientPods: The number of pods are either at or below the number
+                                    required by the PodDisruptionBudget. No disruptions are
+                                    allowed and the status of the condition will be False.
+                - SufficientPods: There are more pods than required by the PodDisruptionBudget.
+                                  The condition will be True, and the number of allowed
+                                  disruptions are provided by the disruptionsAllowed property.
+              items:
+                description: Condition contains details for one aspect of the current
+                  state of this API Resource.
+                properties:
+                  lastTransitionTime:
+                    description: lastTransitionTime is the last time the condition
+                      transitioned from one status to another. This should be when
+                      the underlying condition changed.  If that is not known, then
+                      using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: message is a human readable message indicating details
+                      about the transition. This may be an empty string.
+                    type: string
+                  observedGeneration:
+                    description: observedGeneration represents the .metadata.generation
+                      that the condition was set based upon. For instance, if .metadata.generation
+                      is currently 12, but the .status.conditions[x].observedGeneration
+                      is 9, the condition is out of date with respect to the current
+                      state of the instance.
+                    format: int64
+                    type: integer
+                  reason:
+                    description: reason contains a programmatic identifier indicating
+                      the reason for the condition's last transition. Producers of
+                      specific condition types may define expected values and meanings
+                      for this field, and whether the values are considered a guaranteed
+                      API. The value should be a CamelCase string. This field may
+                      not be empty.
+                    type: string
+                  status:
+                    description: status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                    type: string
+                required:
+                - lastTransitionTime
+                - message
+                - reason
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            currentHealthy:
+              description: current number of healthy pods
+              format: int32
+              type: integer
+            desiredHealthy:
+              description: minimum desired number of healthy pods
+              format: int32
+              type: integer
+            disruptedPods:
+              additionalProperties:
+                format: date-time
+                type: string
+              description: DisruptedPods contains information about pods whose eviction
+                was processed by the API server eviction subresource handler but has
+                not yet been observed by the PodDisruptionBudget controller. A pod
+                will be in this map from the time when the API server processed the
+                eviction request to the time when the pod is seen by PDB controller
+                as having been marked for deletion (or after a timeout). The key in
+                the map is the name of the pod and the value is the time when the
+                API server processed the eviction request. If the deletion didn't
+                occur and a pod is still there it will be removed from the list automatically
+                by PodDisruptionBudget controller after some time. If everything goes
+                smooth this map should be empty for the most of the time. Large number
+                of entries in the map may indicate problems with pod deletions.
+              type: object
+            disruptionsAllowed:
+              description: Number of pod disruptions that are currently allowed.
+              format: int32
+              type: integer
+            expectedPods:
+              description: total number of pods counted by this disruption budget
+              format: int32
+              type: integer
+            observedGeneration:
+              description: Most recent generation observed when updating this PDB
+                status. DisruptionsAllowed and other status information is valid only
+                if observedGeneration equals to PDB's object generation.
+              format: int64
+              type: integer
+          required:
+          - disruptionsAllowed
+          - currentHealthy
+          - desiredHealthy
+          - expectedPods
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-podtemplates.core.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-podtemplates.core.k8s.io.yaml
@@ -1,0 +1,6809 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.podtemplates.core
+spec:
+  group: ""
+  names:
+    kind: PodTemplate
+    listKind: PodTemplateList
+    plural: podtemplates
+    singular: podtemplate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: PodTemplate describes a template for creating copies of a predefined
+        pod.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        template:
+          description: Template defines the pods that will be created from this pod
+            template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+          properties:
+            metadata:
+              description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            spec:
+              description: 'Specification of the desired behavior of the pod. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              properties:
+                activeDeadlineSeconds:
+                  description: Optional duration in seconds the pod may be active
+                    on the node relative to StartTime before the system will actively
+                    try to mark it failed and kill associated containers. Value must
+                    be a positive integer.
+                  format: int64
+                  type: integer
+                affinity:
+                  description: If specified, the pod's scheduling constraints
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            matches the corresponding matchExpressions; the node(s)
+                            with the highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects
+                              (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with
+                                  the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            - preference
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its
+                            node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                            Possible enum values:
+                                             - `"DoesNotExist"`
+                                             - `"Exists"`
+                                             - `"Gt"`
+                                             - `"In"`
+                                             - `"Lt"`
+                                             - `"NotIn"`
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            - podAffinityTerm
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to
+                                  the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field. null
+                                  selector and null or empty namespaces list means
+                                  "this pod's namespace". An empty selector ({}) matches
+                                  all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of
+                                  namespace names that the term applies to. The term
+                                  is applied to the union of the namespaces listed
+                                  in this field and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector
+                                  means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling anti-affinity
+                            expressions, etc.), compute a sum by iterating through
+                            the elements of this field and adding "weight" to the
+                            sum if the node has pods which matches the corresponding
+                            podAffinityTerm; the node(s) with the highest sum are
+                            the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - weight
+                            - podAffinityTerm
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified
+                            by this field are not met at scheduling time, the pod
+                            will not be scheduled onto the node. If the anti-affinity
+                            requirements specified by this field cease to be met at
+                            some point during pod execution (e.g. due to a pod label
+                            update), the system may or may not try to eventually evict
+                            the pod from its node. When there are multiple elements,
+                            the lists of nodes corresponding to each podAffinityTerm
+                            are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to
+                                  the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field. null
+                                  selector and null or empty namespaces list means
+                                  "this pod's namespace". An empty selector ({}) matches
+                                  all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies a static list of
+                                  namespace names that the term applies to. The term
+                                  is applied to the union of the namespaces listed
+                                  in this field and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector
+                                  means "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                automountServiceAccountToken:
+                  description: AutomountServiceAccountToken indicates whether a service
+                    account token should be automatically mounted.
+                  type: boolean
+                containers:
+                  description: List of containers belonging to the pod. Containers
+                    cannot currently be added or removed. There must be at least one
+                    container in a Pod. Cannot be updated.
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The container image''s
+                          CMD is used if this is not provided. Variable references
+                          $(VAR_NAME) are expanded using the container''s environment.
+                          If a variable cannot be resolved, the reference in the input
+                          string will be unchanged. Double $$ are reduced to a single
+                          $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of
+                          whether the variable exists or not. Cannot be updated. More
+                          info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                          The container image''s ENTRYPOINT is used if this is not
+                          provided. Variable references $(VAR_NAME) are expanded using
+                          the container''s environment. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double
+                          $$ are reduced to a single $, which allows for escaping
+                          the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                          the string literal "$(VAR_NAME)". Escaped references will
+                          never be expanded, regardless of whether the variable exists
+                          or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must
+                          be a C_IDENTIFIER. All invalid keys will be reported as
+                          an event when the container is starting. When a key exists
+                          in multiple sources, the value associated with the last
+                          source will take precedence. Values defined by an Env with
+                          a duplicate key will take precedence. Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      image:
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management
+                          to default or override container images in workload controllers
+                          like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Possible enum values:
+                           - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                           - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                           - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a
+                              container is created. If the handler fails, the container
+                              is terminated and restarted according to its restart
+                              policy. Other management of the container blocks until
+                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                              is terminated due to an API request or management event
+                              such as liveness/startup probe failure, preemption,
+                              resource contention, etc. The handler is not called
+                              if the container crashes or exits. The Pod''s termination
+                              grace period countdown begins before the PreStop hook
+                              is executed. Regardless of the outcome of the handler,
+                              the container will eventually terminate within the Pod''s
+                              termination grace period (unless delayed by finalizers).
+                              Other management of the container blocks until the hook
+                              completes or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                          will be restarted if the probe fails. Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x <
+                                65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x
+                                < 65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                Possible enum values:
+                                 - `"SCTP"` is the SCTP protocol.
+                                 - `"TCP"` is the TCP protocol.
+                                 - `"UDP"` is the UDP protocol.
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the
+                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resources:
+                        description: 'Compute Resources required by this container.
+                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'SecurityContext defines the security options
+                          the container should be run with. If set, the fields of
+                          SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN Note that this field cannot be
+                              set when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options from the
+                              PodSecurityContext will be used. If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: 'StartupProbe indicates that the Pod has successfully
+                          initialized. If specified, no other probes are executed
+                          until this completes successfully. If this probe fails,
+                          the Pod will be restarted, just as if the livenessProbe
+                          failed. This can be used to provide different probe parameters
+                          at the beginning of a Pod''s lifecycle, when it might take
+                          a long time to load data or warm a cache, than during steady-state
+                          operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set,
+                          reads from stdin in the container will always result in
+                          EOF. Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If
+                          this flag is false, a container processes that reads from
+                          stdin will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                          container''s termination message will be written is mounted
+                          into the container''s filesystem. Message written is intended
+                          to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes.
+                          The total message length across all containers will be limited
+                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                          Possible enum values:
+                           - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                           - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY
+                          for itself, also requires 'stdin' to be true. Default is
+                          false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to
+                          be used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                          - devicePath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - devicePath
+                        x-kubernetes-list-type: map
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - mountPath
+                        x-kubernetes-list-type: map
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                dnsConfig:
+                  description: Specifies the DNS parameters of a pod. Parameters specified
+                    here will be merged to the generated DNS configuration based on
+                    DNSPolicy.
+                  properties:
+                    nameservers:
+                      description: A list of DNS name server IP addresses. This will
+                        be appended to the base nameservers generated from DNSPolicy.
+                        Duplicated nameservers will be removed.
+                      items:
+                        type: string
+                      type: array
+                    options:
+                      description: A list of DNS resolver options. This will be merged
+                        with the base options generated from DNSPolicy. Duplicated
+                        entries will be removed. Resolution options given in Options
+                        will override those that appear in the base DNSPolicy.
+                      items:
+                        description: PodDNSConfigOption defines DNS resolver options
+                          of a pod.
+                        properties:
+                          name:
+                            description: Required.
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    searches:
+                      description: A list of DNS search domains for host-name lookup.
+                        This will be appended to the base search paths generated from
+                        DNSPolicy. Duplicated search paths will be removed.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                dnsPolicy:
+                  description: |-
+                    Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                    Possible enum values:
+                     - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                     - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                     - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                     - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                  type: string
+                enableServiceLinks:
+                  description: 'EnableServiceLinks indicates whether information about
+                    services should be injected into pod''s environment variables,
+                    matching the syntax of Docker links. Optional: Defaults to true.'
+                  type: boolean
+                ephemeralContainers:
+                  description: List of ephemeral containers run in this pod. Ephemeral
+                    containers may be run in an existing pod to perform user-initiated
+                    actions such as debugging. This list cannot be specified when
+                    creating a pod, and it cannot be modified by updating the pod
+                    spec. In order to add an ephemeral container to an existing pod,
+                    use the pod's ephemeralcontainers subresource.
+                  items:
+                    description: |-
+                      An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                      To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The image''s CMD
+                          is used if this is not provided. Variable references $(VAR_NAME)
+                          are expanded using the container''s environment. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. Double $$ are reduced to a single $, which
+                          allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                          will produce the string literal "$(VAR_NAME)". Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                          The image''s ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container''s
+                          environment. If a variable cannot be resolved, the reference
+                          in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME)
+                          syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                          "$(VAR_NAME)". Escaped references will never be expanded,
+                          regardless of whether the variable exists or not. Cannot
+                          be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must
+                          be a C_IDENTIFIER. All invalid keys will be reported as
+                          an event when the container is starting. When a key exists
+                          in multiple sources, the value associated with the last
+                          source will take precedence. Values defined by an Env with
+                          a duplicate key will take precedence. Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      image:
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Possible enum values:
+                           - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                           - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                           - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                        type: string
+                      lifecycle:
+                        description: Lifecycle is not allowed for ephemeral containers.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a
+                              container is created. If the handler fails, the container
+                              is terminated and restarted according to its restart
+                              policy. Other management of the container blocks until
+                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                              is terminated due to an API request or management event
+                              such as liveness/startup probe failure, preemption,
+                              resource contention, etc. The handler is not called
+                              if the container crashes or exits. The Pod''s termination
+                              grace period countdown begins before the PreStop hook
+                              is executed. Regardless of the outcome of the handler,
+                              the container will eventually terminate within the Pod''s
+                              termination grace period (unless delayed by finalizers).
+                              Other management of the container blocks until the hook
+                              completes or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: Probes are not allowed for ephemeral containers.
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the ephemeral container specified as
+                          a DNS_LABEL. This name must be unique among all containers,
+                          init containers and ephemeral containers.
+                        type: string
+                      ports:
+                        description: Ports are not allowed for ephemeral containers.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x <
+                                65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x
+                                < 65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                Possible enum values:
+                                 - `"SCTP"` is the SCTP protocol.
+                                 - `"TCP"` is the TCP protocol.
+                                 - `"UDP"` is the UDP protocol.
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: Probes are not allowed for ephemeral containers.
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resources:
+                        description: Resources are not allowed for ephemeral containers.
+                          Ephemeral containers use spare resources already allocated
+                          to the pod.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'Optional: SecurityContext defines the security
+                          options the ephemeral container should be run with. If set,
+                          the fields of SecurityContext override the equivalent fields
+                          of PodSecurityContext.'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN Note that this field cannot be
+                              set when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options from the
+                              PodSecurityContext will be used. If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: Probes are not allowed for ephemeral containers.
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set,
+                          reads from stdin in the container will always result in
+                          EOF. Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If
+                          this flag is false, a container processes that reads from
+                          stdin will never receive an EOF. Default is false
+                        type: boolean
+                      targetContainerName:
+                        description: |-
+                          If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                          The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                        type: string
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                          container''s termination message will be written is mounted
+                          into the container''s filesystem. Message written is intended
+                          to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes.
+                          The total message length across all containers will be limited
+                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                          Possible enum values:
+                           - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                           - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY
+                          for itself, also requires 'stdin' to be true. Default is
+                          false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to
+                          be used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                          - devicePath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - devicePath
+                        x-kubernetes-list-type: map
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Subpath mounts are not allowed for ephemeral containers.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - mountPath
+                        x-kubernetes-list-type: map
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                hostAliases:
+                  description: HostAliases is an optional list of hosts and IPs that
+                    will be injected into the pod's hosts file if specified. This
+                    is only valid for non-hostNetwork pods.
+                  items:
+                    description: HostAlias holds the mapping between IP and hostnames
+                      that will be injected as an entry in the pod's hosts file.
+                    properties:
+                      hostnames:
+                        description: Hostnames for the above IP address.
+                        items:
+                          type: string
+                        type: array
+                      ip:
+                        description: IP address of the host file entry.
+                        type: string
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - ip
+                  x-kubernetes-list-type: map
+                hostIPC:
+                  description: 'Use the host''s ipc namespace. Optional: Default to
+                    false.'
+                  type: boolean
+                hostNetwork:
+                  description: Host networking requested for this pod. Use the host's
+                    network namespace. If this option is set, the ports that will
+                    be used must be specified. Default to false.
+                  type: boolean
+                hostPID:
+                  description: 'Use the host''s pid namespace. Optional: Default to
+                    false.'
+                  type: boolean
+                hostUsers:
+                  description: 'Use the host''s user namespace. Optional: Default
+                    to true. If set to true or not present, the pod will be run in
+                    the host user namespace, useful for when the pod needs a feature
+                    only available to the host user namespace, such as loading a kernel
+                    module with CAP_SYS_MODULE. When set to false, a new userns is
+                    created for the pod. Setting false is useful for mitigating container
+                    breakout vulnerabilities even allowing users to run their containers
+                    as root without actually having root privileges on the host. This
+                    field is alpha-level and is only honored by servers that enable
+                    the UserNamespacesSupport feature.'
+                  type: boolean
+                hostname:
+                  description: Specifies the hostname of the Pod If not specified,
+                    the pod's hostname will be set to a system-defined value.
+                  type: string
+                imagePullSecrets:
+                  description: 'ImagePullSecrets is an optional list of references
+                    to secrets in the same namespace to use for pulling any of the
+                    images used by this PodSpec. If specified, these secrets will
+                    be passed to individual puller implementations for them to use.
+                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                  items:
+                    description: LocalObjectReference contains enough information
+                      to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                initContainers:
+                  description: 'List of initialization containers belonging to the
+                    pod. Init containers are executed in order prior to containers
+                    being started. If any init container fails, the pod is considered
+                    to have failed and is handled according to its restartPolicy.
+                    The name for an init container or normal container must be unique
+                    among all containers. Init containers may not have Lifecycle actions,
+                    Readiness probes, Liveness probes, or Startup probes. The resourceRequirements
+                    of an init container are taken into account during scheduling
+                    by finding the highest request/limit for each resource type, and
+                    then using the max of of that value or the sum of the normal containers.
+                    Limits are applied to init containers in a similar fashion. Init
+                    containers cannot currently be added or removed. Cannot be updated.
+                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The container image''s
+                          CMD is used if this is not provided. Variable references
+                          $(VAR_NAME) are expanded using the container''s environment.
+                          If a variable cannot be resolved, the reference in the input
+                          string will be unchanged. Double $$ are reduced to a single
+                          $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of
+                          whether the variable exists or not. Cannot be updated. More
+                          info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                          The container image''s ENTRYPOINT is used if this is not
+                          provided. Variable references $(VAR_NAME) are expanded using
+                          the container''s environment. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double
+                          $$ are reduced to a single $, which allows for escaping
+                          the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                          the string literal "$(VAR_NAME)". Escaped references will
+                          never be expanded, regardless of whether the variable exists
+                          or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables
+                                in the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                                the string literal "$(VAR_NAME)". Escaped references
+                                will never be expanded, regardless of whether the
+                                variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must
+                          be a C_IDENTIFIER. All invalid keys will be reported as
+                          an event when the container is starting. When a key exists
+                          in multiple sources, the value associated with the last
+                          source will take precedence. Values defined by an Env with
+                          a duplicate key will take precedence. Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                              type: object
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                              type: object
+                          type: object
+                        type: array
+                      image:
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management
+                          to default or override container images in workload controllers
+                          like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                          Possible enum values:
+                           - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                           - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                           - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a
+                              container is created. If the handler fails, the container
+                              is terminated and restarted according to its restart
+                              policy. Other management of the container blocks until
+                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                              is terminated due to an API request or management event
+                              such as liveness/startup probe failure, preemption,
+                              resource contention, etc. The handler is not called
+                              if the container crashes or exits. The Pod''s termination
+                              grace period countdown begins before the PreStop hook
+                              is executed. Regardless of the outcome of the handler,
+                              the container will eventually terminate within the Pod''s
+                              termination grace period (unless delayed by finalizers).
+                              Other management of the container blocks until the hook
+                              completes or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward
+                                  compatibility. There are no validation of this field
+                                  and lifecycle hooks will fail in runtime when tcp
+                                  handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                          will be restarted if the probe fails. Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x <
+                                65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x
+                                < 65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                Possible enum values:
+                                 - `"SCTP"` is the SCTP protocol.
+                                 - `"TCP"` is the TCP protocol.
+                                 - `"UDP"` is the UDP protocol.
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the
+                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resources:
+                        description: 'Compute Resources required by this container.
+                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'SecurityContext defines the security options
+                          the container should be run with. If set, the fields of
+                          SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN Note that this field cannot be
+                              set when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false. Note that this
+                              field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name
+                              is windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile
+                                  defined in a file on the node should be used. The
+                                  profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's
+                                  configured seccomp profile location. Must only be
+                                  set if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                  Possible enum values:
+                                   - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                   - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                   - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to
+                              all containers. If unspecified, the options from the
+                              PodSecurityContext will be used. If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set
+                              when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA
+                                  admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec
+                                  named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: 'StartupProbe indicates that the Pod has successfully
+                          initialized. If specified, no other probes are executed
+                          until this completes successfully. If this probe fails,
+                          the Pod will be restarted, just as if the livenessProbe
+                          failed. This can be used to provide different probe parameters
+                          at the beginning of a Pod''s lifecycle, when it might take
+                          a long time to load data or warm a cache, than during steady-state
+                          operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC
+                              port. This is a beta field and requires enabling GRPCContainerProbe
+                              feature gate.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                  Possible enum values:
+                                   - `"HTTP"` means that the scheme used will be http://
+                                   - `"HTTPS"` means that the scheme used will be https://
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a
+                              TCP port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and
+                              the time when the processes are forcibly halted with
+                              a kill signal. Set this value longer than the expected
+                              cleanup time for your process. If this value is nil,
+                              the pod's terminationGracePeriodSeconds will be used.
+                              Otherwise, this value overrides the value provided by
+                              the pod spec. Value must be non-negative integer. The
+                              value zero indicates stop immediately via the kill signal
+                              (no opportunity to shut down). This is a beta field
+                              and requires enabling ProbeTerminationGracePeriod feature
+                              gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                              is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set,
+                          reads from stdin in the container will always result in
+                          EOF. Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If
+                          this flag is false, a container processes that reads from
+                          stdin will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                          container''s termination message will be written is mounted
+                          into the container''s filesystem. Message written is intended
+                          to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes.
+                          The total message length across all containers will be limited
+                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                          Possible enum values:
+                           - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                           - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY
+                          for itself, also requires 'stdin' to be true. Default is
+                          false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to
+                          be used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                          - devicePath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - devicePath
+                        x-kubernetes-list-type: map
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - mountPath
+                        x-kubernetes-list-type: map
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+                nodeName:
+                  description: NodeName is a request to schedule this pod onto a specific
+                    node. If it is non-empty, the scheduler simply schedules this
+                    pod onto that node, assuming that it fits resource requirements.
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: 'NodeSelector is a selector which must be true for
+                    the pod to fit on a node. Selector which must match a node''s
+                    labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: object
+                os:
+                  description: |-
+                    Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                    If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                    If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                  properties:
+                    name:
+                      description: 'Name is the name of the operating system. The
+                        currently supported values are linux and windows. Additional
+                        value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                        Clients should expect to handle additional values and treat
+                        unrecognized values in this field as os: null'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                overhead:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Overhead represents the resource overhead associated
+                    with running a pod for a given RuntimeClass. This field will be
+                    autopopulated at admission time by the RuntimeClass admission
+                    controller. If the RuntimeClass admission controller is enabled,
+                    overhead must not be set in Pod create requests. The RuntimeClass
+                    admission controller will reject Pod create requests which have
+                    the overhead already set. If RuntimeClass is configured and selected
+                    in the PodSpec, Overhead will be set to the value defined in the
+                    corresponding RuntimeClass, otherwise it will remain unset and
+                    treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                  type: object
+                preemptionPolicy:
+                  description: PreemptionPolicy is the Policy for preempting pods
+                    with lower priority. One of Never, PreemptLowerPriority. Defaults
+                    to PreemptLowerPriority if unset.
+                  type: string
+                priority:
+                  description: The priority value. Various system components use this
+                    field to find the priority of the pod. When Priority Admission
+                    Controller is enabled, it prevents users from setting this field.
+                    The admission controller populates this field from PriorityClassName.
+                    The higher the value, the higher the priority.
+                  format: int32
+                  type: integer
+                priorityClassName:
+                  description: If specified, indicates the pod's priority. "system-node-critical"
+                    and "system-cluster-critical" are two special keywords which indicate
+                    the highest priorities with the former being the highest priority.
+                    Any other name must be defined by creating a PriorityClass object
+                    with that name. If not specified, the pod priority will be default
+                    or zero if there is no default.
+                  type: string
+                readinessGates:
+                  description: 'If specified, all readiness gates will be evaluated
+                    for pod readiness. A pod is ready when all its containers are
+                    ready AND all conditions specified in the readiness gates have
+                    status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                  items:
+                    description: PodReadinessGate contains the reference to a pod
+                      condition
+                    properties:
+                      conditionType:
+                        description: ConditionType refers to a condition in the pod's
+                          condition list with matching type.
+                        type: string
+                    required:
+                    - conditionType
+                    type: object
+                  type: array
+                restartPolicy:
+                  description: |-
+                    Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                    Possible enum values:
+                     - `"Always"`
+                     - `"Never"`
+                     - `"OnFailure"`
+                  type: string
+                runtimeClassName:
+                  description: 'RuntimeClassName refers to a RuntimeClass object in
+                    the node.k8s.io group, which should be used to run this pod.  If
+                    no RuntimeClass resource matches the named class, the pod will
+                    not be run. If unset or empty, the "legacy" RuntimeClass will
+                    be used, which is an implicit class with an empty definition that
+                    uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                  type: string
+                schedulerName:
+                  description: If specified, the pod will be dispatched by specified
+                    scheduler. If not specified, the pod will be dispatched by default
+                    scheduler.
+                  type: string
+                securityContext:
+                  description: 'SecurityContext holds pod-level security attributes
+                    and common container settings. Optional: Defaults to empty.  See
+                    type description for default values of each field.'
+                  properties:
+                    fsGroup:
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                        1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: 'fsGroupChangePolicy defines behavior of changing
+                        ownership and permission of the volume before being exposed
+                        inside Pod. This field will only apply to volume types which
+                        support fsGroup based ownership(and permissions). It will
+                        have no effect on ephemeral volume types such as: secret,
+                        configmaps and emptydir. Valid values are "OnRootMismatch"
+                        and "Always". If not specified, "Always" is used. Note that
+                        this field cannot be set when spec.os.name is windows.'
+                      type: string
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence for
+                        that container. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container. Note that this field
+                        cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by the containers in
+                        this pod. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                            Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                            Possible enum values:
+                             - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                             - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                             - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary
+                        GID.  If unspecified, no groups will be added to any container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used
+                        for the pod. Pods with unsupported sysctls (by the container
+                        runtime) might fail to launch. Note that this field cannot
+                        be set when spec.os.name is windows.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext
+                        will be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. This field is alpha-level
+                            and will only be honored by components that enable the
+                            WindowsHostProcessContainers feature flag. Setting this
+                            field without the feature flag will result in errors when
+                            validating the Pod. All of a Pod's containers must have
+                            the same effective HostProcess value (it is not allowed
+                            to have a mix of HostProcess containers and non-HostProcess
+                            containers).  In addition, if HostProcess is true then
+                            HostNetwork must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  description: 'DeprecatedServiceAccount is a depreciated alias for
+                    ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                  type: string
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the ServiceAccount
+                    to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                  type: string
+                setHostnameAsFQDN:
+                  description: If true the pod's hostname will be configured as the
+                    pod's FQDN, rather than the leaf name (the default). In Linux
+                    containers, this means setting the FQDN in the hostname field
+                    of the kernel (the nodename field of struct utsname). In Windows
+                    containers, this means setting the registry value of hostname
+                    for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                    to FQDN. If a pod does not have FQDN, this has no effect. Default
+                    to false.
+                  type: boolean
+                shareProcessNamespace:
+                  description: 'Share a single process namespace between all of the
+                    containers in a pod. When this is set containers will be able
+                    to view and signal processes from other containers in the same
+                    pod, and the first process in each container will not be assigned
+                    PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional:
+                    Default to false.'
+                  type: boolean
+                subdomain:
+                  description: If specified, the fully qualified Pod hostname will
+                    be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                    If not specified, the pod will not have a domainname at all.
+                  type: string
+                terminationGracePeriodSeconds:
+                  description: Optional duration in seconds the pod needs to terminate
+                    gracefully. May be decreased in delete request. Value must be
+                    non-negative integer. The value zero indicates stop immediately
+                    via the kill signal (no opportunity to shut down). If this value
+                    is nil, the default grace period will be used instead. The grace
+                    period is the duration in seconds after the processes running
+                    in the pod are sent a termination signal and the time when the
+                    processes are forcibly halted with a kill signal. Set this value
+                    longer than the expected cleanup time for your process. Defaults
+                    to 30 seconds.
+                  format: int64
+                  type: integer
+                tolerations:
+                  description: If specified, the pod's tolerations.
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                          Possible enum values:
+                           - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                           - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                           - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: |-
+                          Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                          Possible enum values:
+                           - `"Equal"`
+                           - `"Exists"`
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+                topologySpreadConstraints:
+                  description: TopologySpreadConstraints describes how a group of
+                    pods ought to spread across topology domains. Scheduler will schedule
+                    pods in a way which abides by the constraints. All topologySpreadConstraints
+                    are ANDed.
+                  items:
+                    description: TopologySpreadConstraint specifies how to spread
+                      matching pods among the given topology.
+                    properties:
+                      labelSelector:
+                        description: LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine
+                          the number of pods in their corresponding topology domain.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      matchLabelKeys:
+                        description: MatchLabelKeys is a set of pod label keys to
+                          select the pods over which spreading will be calculated.
+                          The keys are used to lookup values from the incoming pod
+                          labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading
+                          will be calculated for the incoming pod. Keys that don't
+                          exist in the incoming pod labels will be ignored. A null
+                          or empty list means only match against labelSelector.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      maxSkew:
+                        description: 'MaxSkew describes the degree to which pods may
+                          be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                          it is the maximum permitted difference between the number
+                          of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods
+                          in an eligible domain or zero if the number of eligible
+                          domains is less than MinDomains. For example, in a 3-zone
+                          cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                          spread as 2/2/1: In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if
+                          MaxSkew is 1, incoming pod can only be scheduled to zone3
+                          to become 2/2/2; scheduling it onto zone1(zone2) would make
+                          the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any
+                          zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used
+                          to give higher precedence to topologies that satisfy it.
+                          It''s a required field. Default value is 1 and 0 is not
+                          allowed.'
+                        format: int32
+                        type: integer
+                      minDomains:
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                          This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                        format: int32
+                        type: integer
+                      nodeAffinityPolicy:
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                          If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                        type: string
+                      nodeTaintsPolicy:
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                          If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                        type: string
+                      topologyKey:
+                        description: TopologyKey is the key of node labels. Nodes
+                          that have a label with this key and identical values are
+                          considered to be in the same topology. We consider each
+                          <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket. We define a domain as a particular
+                          instance of a topology. Also, we define an eligible domain
+                          as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                          and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                          each Node is a domain of that topology. And, if TopologyKey
+                          is "topology.kubernetes.io/zone", each zone is a domain
+                          of that topology. It's a required field.
+                        type: string
+                      whenUnsatisfiable:
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                          Possible enum values:
+                           - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                           - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                        type: string
+                    required:
+                    - maxSkew
+                    - topologyKey
+                    - whenUnsatisfiable
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - topologyKey
+                  - whenUnsatisfiable
+                  x-kubernetes-list-type: map
+                volumes:
+                  description: 'List of volumes that can be mounted by containers
+                    belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                  items:
+                    description: Volume represents a named volume in a pod that may
+                      be accessed by any container in the pod.
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'awsElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume
+                              that you want to mount. If omitted, the default is to
+                              mount by volume name. Examples: For volume /dev/sda1,
+                              you specify the partition as "1". Similarly, the volume
+                              partition for /dev/sda is "0" (or you can leave the
+                              property empty).'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly value true will force the readOnly
+                              setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'volumeID is unique ID of the persistent
+                              disk resource in AWS (Amazon EBS volume). More info:
+                              https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        description: azureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          cachingMode:
+                            description: 'cachingMode is the Host Caching mode: None,
+                              Read Only, Read Write.'
+                            type: string
+                          diskName:
+                            description: diskName is the Name of the data disk in
+                              the blob storage
+                            type: string
+                          diskURI:
+                            description: diskURI is the URI of data disk in the blob
+                              storage
+                            type: string
+                          fsType:
+                            description: fsType is Filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'kind expected values are Shared: multiple
+                              blob disks per storage account  Dedicated: single blob
+                              disk per storage account  Managed: azure managed data
+                              disk (only in managed availability set). defaults to
+                              shared'
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        description: azureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: secretName is the  name of secret that contains
+                              Azure Storage Account Name and Key
+                            type: string
+                          shareName:
+                            description: shareName is the azure share Name
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        description: cephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          monitors:
+                            description: 'monitors is Required: Monitors is a collection
+                              of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: 'path is Optional: Used as the mounted root,
+                              rather than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'secretFile is Optional: SecretFile is the
+                              path to key ring for User, default is /etc/ceph/user.secret
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'secretRef is Optional: SecretRef is reference
+                              to the authentication secret for User, default is empty.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is optional: User is the rados user
+                              name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        description: 'cinder represents a cinder volume attached and
+                          mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating
+                              system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                              inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is optional: points to a secret
+                              object containing parameters used to connect to OpenStack.'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          volumeID:
+                            description: 'volumeID used to identify the volume in
+                              cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        description: configMap represents a configMap that should
+                          populate this volume
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is optional: mode bits used
+                              to set permissions on created files by default. Must
+                              be an octal value between 0000 and 0777 or a decimal
+                              value between 0 and 511. YAML accepts both octal and
+                              decimal values, JSON requires decimal values for mode
+                              bits. Defaults to 0644. Directories within the path
+                              are not affected by this setting. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: items if unspecified, each key-value pair
+                              in the Data field of the referenced ConfigMap will be
+                              projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed
+                              keys will be projected into the specified paths, and
+                              unlisted keys will not be present. If a key is specified
+                              which is not present in the ConfigMap, the volume setup
+                              will error unless it is marked optional. Paths must
+                              be relative and may not contain the '..' path or start
+                              with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to
+                                    set permissions on this file. Must be an octal
+                                    value between 0000 and 0777 or a decimal value
+                                    between 0 and 511. YAML accepts both octal and
+                                    decimal values, JSON requires decimal values for
+                                    mode bits. If not specified, the volume defaultMode
+                                    will be used. This might be in conflict with other
+                                    options that affect the file mode, like fsGroup,
+                                    and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file
+                                    to map the key to. May not be an absolute path.
+                                    May not contain the path element '..'. May not
+                                    start with the string '..'.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: optional specify whether the ConfigMap or
+                              its keys must be defined
+                            type: boolean
+                        type: object
+                      csi:
+                        description: csi (Container Storage Interface) represents
+                          ephemeral storage that is handled by certain external CSI
+                          drivers (Beta feature).
+                        properties:
+                          driver:
+                            description: driver is the name of the CSI driver that
+                              handles this volume. Consult with your admin for the
+                              correct name as registered in the cluster.
+                            type: string
+                          fsType:
+                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                              If not provided, the empty value is passed to the associated
+                              CSI driver which will determine the default filesystem
+                              to apply.
+                            type: string
+                          nodePublishSecretRef:
+                            description: nodePublishSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodePublishVolume
+                              and NodeUnpublishVolume calls. This field is optional,
+                              and  may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secret references
+                              are passed.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          readOnly:
+                            description: readOnly specifies a read-only configuration
+                              for the volume. Defaults to false (read/write).
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            description: volumeAttributes stores driver-specific properties
+                              that are passed to the CSI driver. Consult your driver's
+                              documentation for supported values.
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        description: downwardAPI represents downward API about the
+                          pod that should populate this volume
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a Optional: mode bits used to set
+                              permissions on created files by default. Must be an
+                              octal value between 0000 and 0777 or a decimal value
+                              between 0 and 511. YAML accepts both octal and decimal
+                              values, JSON requires decimal values for mode bits.
+                              Defaults to 0644. Directories within the path are not
+                              affected by this setting. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: Items is a list of downward API volume file
+                            items:
+                              description: DownwardAPIVolumeFile represents information
+                                to create the file containing the pod field
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod:
+                                    only annotations, labels, name and namespace are
+                                    supported.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  description: 'Optional: mode bits used to set permissions
+                                    on this file, must be an octal value between 0000
+                                    and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON
+                                    requires decimal values for mode bits. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: 'Required: Path is  the relative path
+                                    name of the file to be created. Must not be absolute
+                                    or contain the ''..'' path. Must be utf-8 encoded.
+                                    The first item of the relative path must not start
+                                    with ''..'''
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, requests.cpu and requests.memory)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        description: 'emptyDir represents a temporary directory that
+                          shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        properties:
+                          medium:
+                            description: 'medium represents what type of storage medium
+                              should back this directory. The default is "" which
+                              means to use the node''s default medium. Must be an
+                              empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'sizeLimit is the total amount of local storage
+                              required for this EmptyDir volume. The size limit is
+                              also applicable for memory medium. The maximum usage
+                              on memory medium EmptyDir would be the minimum value
+                              between the SizeLimit specified here and the sum of
+                              memory limits of all containers in a pod. The default
+                              is nil which means that the limit is undefined. More
+                              info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        description: |-
+                          ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                          Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                             tracking are needed,
+                          c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                             information on the connection between this volume type
+                             and PersistentVolumeClaim).
+
+                          Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                          A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                        properties:
+                          volumeClaimTemplate:
+                            description: |-
+                              Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                              An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                              This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                              Required, must not be nil.
+                            properties:
+                              metadata:
+                                description: May contain labels and annotations that
+                                  will be copied into the PVC when creating it. No
+                                  other fields are allowed and will be rejected during
+                                  validation.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              spec:
+                                description: The specification for the PersistentVolumeClaim.
+                                  The entire content is copied unchanged into the
+                                  PVC that gets created from this template. The same
+                                  fields as in a PersistentVolumeClaim are also valid
+                                  here.
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the desired
+                                      access modes the volume should have. More info:
+                                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    description: 'dataSource field can be used to
+                                      specify either: * An existing VolumeSnapshot
+                                      object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                      * An existing PVC (PersistentVolumeClaim) If
+                                      the provisioner or an external controller can
+                                      support the specified data source, it will create
+                                      a new volume based on the contents of the specified
+                                      data source. If the AnyVolumeDataSource feature
+                                      gate is enabled, this field will always have
+                                      the same contents as the DataSourceRef field.'
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the
+                                          resource being referenced. If APIGroup is
+                                          not specified, the specified Kind must be
+                                          in the core API group. For any other third-party
+                                          types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource
+                                          being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource
+                                          being referenced
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  dataSourceRef:
+                                    description: |-
+                                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                                      * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                        preserves all values, and generates an error if a disallowed value is
+                                        specified.
+                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the
+                                          resource being referenced. If APIGroup is
+                                          not specified, the specified Kind must be
+                                          in the core API group. For any other third-party
+                                          types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource
+                                          being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource
+                                          being referenced
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    description: 'resources represents the minimum
+                                      resources the volume should have. If RecoverVolumeExpansionFailure
+                                      feature is enabled users are allowed to specify
+                                      resource requirements that are lower than previous
+                                      value but must still be higher than capacity
+                                      recorded in the status field of the claim. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  selector:
+                                    description: selector is a label query over volumes
+                                      to consider for binding.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    description: 'storageClassName is the name of
+                                      the StorageClass required by the claim. More
+                                      info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        description: fc represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          lun:
+                            description: 'lun is Optional: FC target lun number'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'targetWWNs is Optional: FC target worldwide
+                              names (WWNs)'
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            description: 'wwids Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        description: flexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        properties:
+                          driver:
+                            description: driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                              depends on FlexVolume script.
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            description: 'options is Optional: this field holds extra
+                              command options if any.'
+                            type: object
+                          readOnly:
+                            description: 'readOnly is Optional: defaults to false
+                              (read/write). ReadOnly here will force the ReadOnly
+                              setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is Optional: secretRef is reference
+                              to the secret object containing sensitive information
+                              to pass to the plugin scripts. This may be empty if
+                              no secret object is specified. If the secret object
+                              contains more than one secret, all secrets are passed
+                              to the plugin scripts.'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        description: flocker represents a Flocker volume attached
+                          to a kubelet's host machine. This depends on the Flocker
+                          control service being running
+                        properties:
+                          datasetName:
+                            description: datasetName is Name of the dataset stored
+                              as metadata -> name on the dataset for Flocker should
+                              be considered as deprecated
+                            type: string
+                          datasetUUID:
+                            description: datasetUUID is the UUID of the dataset. This
+                              is unique identifier of a Flocker dataset
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        description: 'gcePersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        properties:
+                          fsType:
+                            description: 'fsType is filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume
+                              that you want to mount. If omitted, the default is to
+                              mount by volume name. Examples: For volume /dev/sda1,
+                              you specify the partition as "1". Similarly, the volume
+                              partition for /dev/sda is "0" (or you can leave the
+                              property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            format: int32
+                            type: integer
+                          pdName:
+                            description: 'pdName is unique name of the PD resource
+                              in GCE. Used to identify the disk in GCE. More info:
+                              https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        description: 'gitRepo represents a git repository at a particular
+                          revision. DEPRECATED: GitRepo is deprecated. To provision
+                          a container with a git repo, mount an EmptyDir into an InitContainer
+                          that clones the repo using git, then mount the EmptyDir
+                          into the Pod''s container.'
+                        properties:
+                          directory:
+                            description: directory is the target directory name. Must
+                              not contain or start with '..'.  If '.' is supplied,
+                              the volume directory will be the git repository.  Otherwise,
+                              if specified, the volume will contain the git repository
+                              in the subdirectory with the given name.
+                            type: string
+                          repository:
+                            description: repository is the URL
+                            type: string
+                          revision:
+                            description: revision is the commit hash for the specified
+                              revision.
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        description: 'glusterfs represents a Glusterfs mount on the
+                          host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        properties:
+                          endpoints:
+                            description: 'endpoints is the endpoint name that details
+                              Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'path is the Glusterfs volume path. More
+                              info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        description: 'hostPath represents a pre-existing file or directory
+                          on the host machine that is directly exposed to the container.
+                          This is generally used for system agents or other privileged
+                          things that are allowed to see the host machine. Most containers
+                          will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        properties:
+                          path:
+                            description: 'path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        description: 'iscsi represents an ISCSI Disk resource that
+                          is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                        properties:
+                          chapAuthDiscovery:
+                            description: chapAuthDiscovery defines whether support
+                              iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: chapAuthSession defines whether support iSCSI
+                              Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                            type: string
+                          initiatorName:
+                            description: initiatorName is the custom iSCSI Initiator
+                              Name. If initiatorName is specified with iscsiInterface
+                              simultaneously, new iSCSI interface <target portal>:<volume
+                              name> will be created for the connection.
+                            type: string
+                          iqn:
+                            description: iqn is the target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iscsiInterface is the interface Name that
+                              uses an iSCSI transport. Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: lun represents iSCSI Target Lun number.
+                            format: int32
+                            type: integer
+                          portals:
+                            description: portals is the iSCSI Target Portal List.
+                              The portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            description: readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: secretRef is the CHAP Secret for iSCSI target
+                              and initiator authentication
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          targetPortal:
+                            description: targetPortal is iSCSI Target Portal. The
+                              Portal is either an IP or ip_addr:port if the port is
+                              other than default (typically TCP ports 860 and 3260).
+                            type: string
+                        required:
+                        - targetPortal
+                        - iqn
+                        - lun
+                        type: object
+                      name:
+                        description: 'name of the volume. Must be a DNS_LABEL and
+                          unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      nfs:
+                        description: 'nfs represents an NFS mount on the host that
+                          shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        properties:
+                          path:
+                            description: 'path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                        required:
+                        - server
+                        - path
+                        type: object
+                      persistentVolumeClaim:
+                        description: 'persistentVolumeClaimVolumeSource represents
+                          a reference to a PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          claimName:
+                            description: 'claimName is the name of a PersistentVolumeClaim
+                              in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: string
+                          readOnly:
+                            description: readOnly Will force the ReadOnly setting
+                              in VolumeMounts. Default false.
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        description: photonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: pdID is the ID that identifies Photon Controller
+                              persistent disk
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        description: portworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: volumeID uniquely identifies a Portworx volume
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        description: projected items for all in one resources secrets,
+                          configmaps, and downward API
+                        properties:
+                          defaultMode:
+                            description: defaultMode are the mode bits used to set
+                              permissions on created files by default. Must be an
+                              octal value between 0000 and 0777 or a decimal value
+                              between 0 and 511. YAML accepts both octal and decimal
+                              values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this
+                              setting. This might be in conflict with other options
+                              that affect the file mode, like fsGroup, and the result
+                              can be other mode bits set.
+                            format: int32
+                            type: integer
+                          sources:
+                            description: sources is the list of volume projections
+                            items:
+                              description: Projection that may be projected along
+                                with other supported volume types
+                              properties:
+                                configMap:
+                                  description: configMap information about the configMap
+                                    data to project
+                                  properties:
+                                    items:
+                                      description: items if unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the ConfigMap, the
+                                        volume setup will error unless it is marked
+                                        optional. Paths must be relative and may not
+                                        contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits
+                                              used to set permissions on this file.
+                                              Must be an octal value between 0000
+                                              and 0777 or a decimal value between
+                                              0 and 511. YAML accepts both octal and
+                                              decimal values, JSON requires decimal
+                                              values for mode bits. If not specified,
+                                              the volume defaultMode will be used.
+                                              This might be in conflict with other
+                                              options that affect the file mode, like
+                                              fsGroup, and the result can be other
+                                              mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path
+                                              of the file to map the key to. May not
+                                              be an absolute path. May not contain
+                                              the path element '..'. May not start
+                                              with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap
+                                        or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI
+                                    data to project
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume
+                                        file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name and namespace are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            description: 'Optional: mode bits used
+                                              to set permissions on this file, must
+                                              be an octal value between 0000 and 0777
+                                              or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal
+                                              values, JSON requires decimal values
+                                              for mode bits. If not specified, the
+                                              volume defaultMode will be used. This
+                                              might be in conflict with other options
+                                              that affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.
+                                              Must not be absolute or contain the
+                                              ''..'' path. Must be utf-8 encoded.
+                                              The first item of the relative path
+                                              must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.memory,
+                                              requests.cpu and requests.memory) are
+                                              currently supported.'
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  description: secret information about the secret
+                                    data to project
+                                  properties:
+                                    items:
+                                      description: items if unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the Secret, the volume
+                                        setup will error unless it is marked optional.
+                                        Paths must be relative and may not contain
+                                        the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits
+                                              used to set permissions on this file.
+                                              Must be an octal value between 0000
+                                              and 0777 or a decimal value between
+                                              0 and 511. YAML accepts both octal and
+                                              decimal values, JSON requires decimal
+                                              values for mode bits. If not specified,
+                                              the volume defaultMode will be used.
+                                              This might be in conflict with other
+                                              options that affect the file mode, like
+                                              fsGroup, and the result can be other
+                                              mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path
+                                              of the file to map the key to. May not
+                                              be an absolute path. May not contain
+                                              the path element '..'. May not start
+                                              with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: optional field specify whether
+                                        the Secret or its key must be defined
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  description: serviceAccountToken is information
+                                    about the serviceAccountToken data to project
+                                  properties:
+                                    audience:
+                                      description: audience is the intended audience
+                                        of the token. A recipient of a token must
+                                        identify itself with an identifier specified
+                                        in the audience of the token, and otherwise
+                                        should reject the token. The audience defaults
+                                        to the identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: expirationSeconds is the requested
+                                        duration of validity of the service account
+                                        token. As the token approaches expiration,
+                                        the kubelet volume plugin will proactively
+                                        rotate the service account token. The kubelet
+                                        will start trying to rotate the token if the
+                                        token is older than 80 percent of its time
+                                        to live or if the token is older than 24 hours.Defaults
+                                        to 1 hour and must be at least 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      description: path is the path relative to the
+                                        mount point of the file to project the token
+                                        into.
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        description: quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          group:
+                            description: group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: readOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          tenant:
+                            description: tenant owning the given Quobyte volume in
+                              the Backend Used with dynamically provisioned Quobyte
+                              volumes, value is set by the plugin
+                            type: string
+                          user:
+                            description: user to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        description: 'rbd represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
+                              that you want to mount. Tip: Ensure that the filesystem
+                              type is supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                            type: string
+                          image:
+                            description: 'image is the rados image name. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'monitors is a collection of Ceph monitors.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            description: 'pool is the rados pool name. Default is
+                              rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is the rados user name. Default is
+                              admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                        required:
+                        - monitors
+                        - image
+                        type: object
+                      scaleIO:
+                        description: scaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: gateway is the host address of the ScaleIO
+                              API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: protectionDomain is the name of the ScaleIO
+                              Protection Domain for the configured storage.
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          sslEnabled:
+                            description: sslEnabled Flag enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: storageMode indicates whether the storage
+                              for a volume should be ThickProvisioned or ThinProvisioned.
+                              Default is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: storagePool is the ScaleIO Storage Pool associated
+                              with the protection domain.
+                            type: string
+                          system:
+                            description: system is the name of the storage system
+                              as configured in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: volumeName is the name of a volume already
+                              created in the ScaleIO system that is associated with
+                              this volume source.
+                            type: string
+                        required:
+                        - gateway
+                        - system
+                        - secretRef
+                        type: object
+                      secret:
+                        description: 'secret represents a secret that should populate
+                          this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is Optional: mode bits used
+                              to set permissions on created files by default. Must
+                              be an octal value between 0000 and 0777 or a decimal
+                              value between 0 and 511. YAML accepts both octal and
+                              decimal values, JSON requires decimal values for mode
+                              bits. Defaults to 0644. Directories within the path
+                              are not affected by this setting. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: items If unspecified, each key-value pair
+                              in the Data field of the referenced Secret will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the Secret, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to
+                                    set permissions on this file. Must be an octal
+                                    value between 0000 and 0777 or a decimal value
+                                    between 0 and 511. YAML accepts both octal and
+                                    decimal values, JSON requires decimal values for
+                                    mode bits. If not specified, the volume defaultMode
+                                    will be used. This might be in conflict with other
+                                    options that affect the file mode, like fsGroup,
+                                    and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file
+                                    to map the key to. May not be an absolute path.
+                                    May not contain the path element '..'. May not
+                                    start with the string '..'.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            description: optional field specify whether the Secret
+                              or its keys must be defined
+                            type: boolean
+                          secretName:
+                            description: 'secretName is the name of the secret in
+                              the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: string
+                        type: object
+                      storageos:
+                        description: storageOS represents a StorageOS volume attached
+                          and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          volumeName:
+                            description: volumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: volumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        description: vsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is filesystem type to mount. Must
+                              be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: storagePolicyID is the storage Policy Based
+                              Management (SPBM) profile ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: storagePolicyName is the storage Policy Based
+                              Management (SPBM) profile name.
+                            type: string
+                          volumePath:
+                            description: volumePath is the path that identifies vSphere
+                              volume vmdk
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+              required:
+              - containers
+              type: object
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/kube/exports/namespaced/apiresourceschema-replicasets.apps.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-replicasets.apps.yaml
@@ -1,0 +1,7171 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.replicasets.apps
+spec:
+  group: apps
+  names:
+    categories:
+    - all
+    kind: ReplicaSet
+    listKind: ReplicaSetList
+    plural: replicasets
+    shortNames:
+    - rs
+    singular: replicaset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: ReplicaSet ensures that a specified number of pod replicas are
+        running at any given time.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'Spec defines the specification of the desired behavior of
+            the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            minReadySeconds:
+              description: Minimum number of seconds for which a newly created pod
+                should be ready without any of its container crashing, for it to be
+                considered available. Defaults to 0 (pod will be considered available
+                as soon as it is ready)
+              format: int32
+              type: integer
+            replicas:
+              description: 'Replicas is the number of desired replicas. This is a
+                pointer to distinguish between explicit zero and unspecified. Defaults
+                to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller'
+              format: int32
+              type: integer
+            selector:
+              description: 'Selector is a label query over pods that should match
+                the replica count. Label keys and values that must match in order
+                to be controlled by this replica set. It must match the pod template''s
+                labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            template:
+              description: 'Template is the object that describes the pod that will
+                be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the pod.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
+                    affinity:
+                      description: If specified, the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - preference
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      description: AutomountServiceAccountToken indicates whether
+                        a service account token should be automatically mounted.
+                      type: boolean
+                    containers:
+                      description: List of containers belonging to the pod. Containers
+                        cannot currently be added or removed. There must be at least
+                        one container in a Pod. Cannot be updated.
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    dnsConfig:
+                      description: Specifies the DNS parameters of a pod. Parameters
+                        specified here will be merged to the generated DNS configuration
+                        based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: A list of DNS name server IP addresses. This
+                            will be appended to the base nameservers generated from
+                            DNSPolicy. Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          description: A list of DNS resolver options. This will be
+                            merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options
+                            given in Options will override those that appear in the
+                            base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: Required.
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          description: A list of DNS search domains for host-name
+                            lookup. This will be appended to the base search paths
+                            generated from DNSPolicy. Duplicated search paths will
+                            be removed.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                        Possible enum values:
+                         - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                         - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                      type: string
+                    enableServiceLinks:
+                      description: 'EnableServiceLinks indicates whether information
+                        about services should be injected into pod''s environment
+                        variables, matching the syntax of Docker links. Optional:
+                        Defaults to true.'
+                      type: boolean
+                    ephemeralContainers:
+                      description: List of ephemeral containers run in this pod. Ephemeral
+                        containers may be run in an existing pod to perform user-initiated
+                        actions such as debugging. This list cannot be specified when
+                        creating a pod, and it cannot be modified by updating the
+                        pod spec. In order to add an ephemeral container to an existing
+                        pod, use the pod's ephemeralcontainers subresource.
+                      items:
+                        description: |-
+                          An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The image''s
+                              CMD is used if this is not provided. Variable references
+                              $(VAR_NAME) are expanded using the container''s environment.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The image''s ENTRYPOINT is used if this is not
+                              provided. Variable references $(VAR_NAME) are expanded
+                              using the container''s environment. If a variable cannot
+                              be resolved, the reference in the input string will
+                              be unchanged. Double $$ are reduced to a single $, which
+                              allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                              will produce the string literal "$(VAR_NAME)". Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Cannot be updated. More
+                              info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Lifecycle is not allowed for ephemeral containers.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the ephemeral container specified
+                              as a DNS_LABEL. This name must be unique among all containers,
+                              init containers and ephemeral containers.
+                            type: string
+                          ports:
+                            description: Ports are not allowed for ephemeral containers.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: Resources are not allowed for ephemeral containers.
+                              Ephemeral containers use spare resources already allocated
+                              to the pod.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Optional: SecurityContext defines the security
+                              options the ephemeral container should be run with.
+                              If set, the fields of SecurityContext override the equivalent
+                              fields of PodSecurityContext.'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          targetContainerName:
+                            description: |-
+                              If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                              The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                            type: string
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Subpath mounts are not allowed for ephemeral
+                              containers. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    hostAliases:
+                      description: HostAliases is an optional list of hosts and IPs
+                        that will be injected into the pod's hosts file if specified.
+                        This is only valid for non-hostNetwork pods.
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        required:
+                        - ip
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - ip
+                      x-kubernetes-list-type: map
+                    hostIPC:
+                      description: 'Use the host''s ipc namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace. If this option is set, the ports
+                        that will be used must be specified. Default to false.
+                      type: boolean
+                    hostPID:
+                      description: 'Use the host''s pid namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostUsers:
+                      description: 'Use the host''s user namespace. Optional: Default
+                        to true. If set to true or not present, the pod will be run
+                        in the host user namespace, useful for when the pod needs
+                        a feature only available to the host user namespace, such
+                        as loading a kernel module with CAP_SYS_MODULE. When set to
+                        false, a new userns is created for the pod. Setting false
+                        is useful for mitigating container breakout vulnerabilities
+                        even allowing users to run their containers as root without
+                        actually having root privileges on the host. This field is
+                        alpha-level and is only honored by servers that enable the
+                        UserNamespacesSupport feature.'
+                      type: boolean
+                    hostname:
+                      description: Specifies the hostname of the Pod If not specified,
+                        the pod's hostname will be set to a system-defined value.
+                      type: string
+                    imagePullSecrets:
+                      description: 'ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of
+                        the images used by this PodSpec. If specified, these secrets
+                        will be passed to individual puller implementations for them
+                        to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    initContainers:
+                      description: 'List of initialization containers belonging to
+                        the pod. Init containers are executed in order prior to containers
+                        being started. If any init container fails, the pod is considered
+                        to have failed and is handled according to its restartPolicy.
+                        The name for an init container or normal container must be
+                        unique among all containers. Init containers may not have
+                        Lifecycle actions, Readiness probes, Liveness probes, or Startup
+                        probes. The resourceRequirements of an init container are
+                        taken into account during scheduling by finding the highest
+                        request/limit for each resource type, and then using the max
+                        of of that value or the sum of the normal containers. Limits
+                        are applied to init containers in a similar fashion. Init
+                        containers cannot currently be added or removed. Cannot be
+                        updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    nodeName:
+                      description: NodeName is a request to schedule this pod onto
+                        a specific node. If it is non-empty, the scheduler simply
+                        schedules this pod onto that node, assuming that it fits resource
+                        requirements.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    os:
+                      description: |-
+                        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                      properties:
+                        name:
+                          description: 'Name is the name of the operating system.
+                            The currently supported values are linux and windows.
+                            Additional value may be defined in future and can be one
+                            of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                            Clients should expect to handle additional values and
+                            treat unrecognized values in this field as os: null'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Overhead represents the resource overhead associated
+                        with running a pod for a given RuntimeClass. This field will
+                        be autopopulated at admission time by the RuntimeClass admission
+                        controller. If the RuntimeClass admission controller is enabled,
+                        overhead must not be set in Pod create requests. The RuntimeClass
+                        admission controller will reject Pod create requests which
+                        have the overhead already set. If RuntimeClass is configured
+                        and selected in the PodSpec, Overhead will be set to the value
+                        defined in the corresponding RuntimeClass, otherwise it will
+                        remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                      type: object
+                    preemptionPolicy:
+                      description: PreemptionPolicy is the Policy for preempting pods
+                        with lower priority. One of Never, PreemptLowerPriority. Defaults
+                        to PreemptLowerPriority if unset.
+                      type: string
+                    priority:
+                      description: The priority value. Various system components use
+                        this field to find the priority of the pod. When Priority
+                        Admission Controller is enabled, it prevents users from setting
+                        this field. The admission controller populates this field
+                        from PriorityClassName. The higher the value, the higher the
+                        priority.
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which
+                        indicate the highest priorities with the former being the
+                        highest priority. Any other name must be defined by creating
+                        a PriorityClass object with that name. If not specified, the
+                        pod priority will be default or zero if there is no default.
+                      type: string
+                    readinessGates:
+                      description: 'If specified, all readiness gates will be evaluated
+                        for pod readiness. A pod is ready when all its containers
+                        are ready AND all conditions specified in the readiness gates
+                        have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                      items:
+                        description: PodReadinessGate contains the reference to a
+                          pod condition
+                        properties:
+                          conditionType:
+                            description: ConditionType refers to a condition in the
+                              pod's condition list with matching type.
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      description: |-
+                        Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                        Possible enum values:
+                         - `"Always"`
+                         - `"Never"`
+                         - `"OnFailure"`
+                      type: string
+                    runtimeClassName:
+                      description: 'RuntimeClassName refers to a RuntimeClass object
+                        in the node.k8s.io group, which should be used to run this
+                        pod.  If no RuntimeClass resource matches the named class,
+                        the pod will not be run. If unset or empty, the "legacy" RuntimeClass
+                        will be used, which is an implicit class with an empty definition
+                        that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                      type: string
+                    schedulerName:
+                      description: If specified, the pod will be dispatched by specified
+                        scheduler. If not specified, the pod will be dispatched by
+                        default scheduler.
+                      type: string
+                    securityContext:
+                      description: 'SecurityContext holds pod-level security attributes
+                        and common container settings. Optional: Defaults to empty.  See
+                        type description for default values of each field.'
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                Possible enum values:
+                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: 'DeprecatedServiceAccount is a depreciated alias
+                        for ServiceAccountName. Deprecated: Use serviceAccountName
+                        instead.'
+                      type: string
+                    serviceAccountName:
+                      description: 'ServiceAccountName is the name of the ServiceAccount
+                        to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                      type: string
+                    setHostnameAsFQDN:
+                      description: If true the pod's hostname will be configured as
+                        the pod's FQDN, rather than the leaf name (the default). In
+                        Linux containers, this means setting the FQDN in the hostname
+                        field of the kernel (the nodename field of struct utsname).
+                        In Windows containers, this means setting the registry value
+                        of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                        to FQDN. If a pod does not have FQDN, this has no effect.
+                        Default to false.
+                      type: boolean
+                    shareProcessNamespace:
+                      description: 'Share a single process namespace between all of
+                        the containers in a pod. When this is set containers will
+                        be able to view and signal processes from other containers
+                        in the same pod, and the first process in each container will
+                        not be assigned PID 1. HostPID and ShareProcessNamespace cannot
+                        both be set. Optional: Default to false.'
+                      type: boolean
+                    subdomain:
+                      description: If specified, the fully qualified Pod hostname
+                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                        domain>". If not specified, the pod will not have a domainname
+                        at all.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully. May be decreased in delete request. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). If this
+                        value is nil, the default grace period will be used instead.
+                        The grace period is the duration in seconds after the processes
+                        running in the pod are sent a termination signal and the time
+                        when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your
+                        process. Defaults to 30 seconds.
+                      format: int64
+                      type: integer
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                              Possible enum values:
+                               - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                               - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                               - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                              Possible enum values:
+                               - `"Equal"`
+                               - `"Exists"`
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints describes how a group
+                        of pods ought to spread across topology domains. Scheduler
+                        will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select the pods over which spreading will be calculated.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading
+                              will be calculated for the incoming pod. Keys that don't
+                              exist in the incoming pod labels will be ignored. A
+                              null or empty list means only match against labelSelector.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. The global minimum is the minimum number of
+                              matching pods in an eligible domain or zero if the number
+                              of eligible domains is less than MinDomains. For example,
+                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
+                              the same labelSelector spread as 2/2/1: In this case,
+                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
+                              can only be scheduled to zone3 to become 2/2/2; scheduling
+                              it onto zone1(zone2) would make the ActualSkew(3-1)
+                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
+                              2, incoming pod can be scheduled onto any zone. When
+                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
+                              higher precedence to topologies that satisfy it. It''s
+                              a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. We define a domain
+                              as a particular instance of a topology. Also, we define
+                              an eligible domain as a domain whose nodes meet the
+                              requirements of nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each
+                              Node is a domain of that topology. And, if TopologyKey
+                              is "topology.kubernetes.io/zone", each zone is a domain
+                              of that topology. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                              Possible enum values:
+                               - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                               - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    volumes:
+                      description: 'List of volumes that can be mounted by containers
+                        belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                  disk resource in AWS (Amazon EBS volume). More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a
+                                  collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                  the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is
+                                  reference to the authentication secret for User,
+                                  default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados
+                                  user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Examples: "ext4", "xfs", "ntfs".
+                                  Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to
+                                  OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                  medium should back this directory. The default is
+                                  "" which means to use the node''s default medium.
+                                  Must be an empty string (default) or Memory. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'sizeLimit is the total amount of local
+                                  storage required for this EmptyDir volume. The size
+                                  limit is also applicable for memory medium. The
+                                  maximum usage on memory medium EmptyDir would be
+                                  the minimum value between the SizeLimit specified
+                                  here and the sum of memory limits of all containers
+                                  in a pod. The default is nil which means that the
+                                  limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used
+                                          to specify either: * An existing VolumeSnapshot
+                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name
+                                          of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide
+                                  identifiers (wwids) Either wwids or combination
+                                  of targetWWNs and lun must be set, but not both
+                                  simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". The
+                                  default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is
+                                  reference to the secret object containing sensitive
+                                  information to pass to the plugin scripts. This
+                                  may be empty if no secret object is specified. If
+                                  the secret object contains more than one secret,
+                                  all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                  in GCE. Used to identify the disk in GCE. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is
+                                  supplied, the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name
+                                  that uses an iSCSI transport. Defaults to 'default'
+                                  (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal.
+                                  The Portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                type: string
+                            required:
+                            - targetPortal
+                            - iqn
+                            - lun
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL
+                              and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - server
+                            - path
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to
+                                  set permissions on created files by default. Must
+                                  be an octal value between 0000 and 0777 or a decimal
+                                  value between 0 and 511. YAML accepts both octal
+                                  and decimal values, JSON requires decimal values
+                                  for mode bits. Directories within the path are not
+                                  affected by this setting. This might be in conflict
+                                  with other options that affect the file mode, like
+                                  fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default
+                                  is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default
+                                  is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            - image
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                  is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated
+                                  with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - system
+                            - secretRef
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret
+                                  in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - containers
+                  type: object
+              type: object
+          required:
+          - selector
+          type: object
+        status:
+          description: 'Status is the most recently observed status of the ReplicaSet.
+            This data may be out of date by some window of time. Populated by the
+            system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: The number of available replicas (ready for at least minReadySeconds)
+                for this replica set.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a replica
+                set's current state.
+              items:
+                description: ReplicaSetCondition describes the state of a replica
+                  set at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: The last time the condition transitioned from one
+                      status to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of replica set condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            fullyLabeledReplicas:
+              description: The number of pods that have labels matching the labels
+                of the pod template of the replicaset.
+              format: int32
+              type: integer
+            observedGeneration:
+              description: ObservedGeneration reflects the generation of the most
+                recently observed ReplicaSet.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas is the number of pods targeted by this ReplicaSet
+                with a Ready Condition.
+              format: int32
+              type: integer
+            replicas:
+              description: 'Replicas is the most recently oberved number of replicas.
+                More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller'
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-replicationcontrollers.core.k8s.io.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-replicationcontrollers.core.k8s.io.yaml
@@ -1,0 +1,7132 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.replicationcontrollers.core
+spec:
+  group: ""
+  names:
+    categories:
+    - all
+    kind: ReplicationController
+    listKind: ReplicationControllerList
+    plural: replicationcontrollers
+    shortNames:
+    - rc
+    singular: replicationcontroller
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: ReplicationController represents the configuration of a replication
+        controller.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'Spec defines the specification of the desired behavior of
+            the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            minReadySeconds:
+              description: Minimum number of seconds for which a newly created pod
+                should be ready without any of its container crashing, for it to be
+                considered available. Defaults to 0 (pod will be considered available
+                as soon as it is ready)
+              format: int32
+              type: integer
+            replicas:
+              description: 'Replicas is the number of desired replicas. This is a
+                pointer to distinguish between explicit zero and unspecified. Defaults
+                to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller'
+              format: int32
+              type: integer
+            selector:
+              additionalProperties:
+                type: string
+              description: 'Selector is a label query over pods that should match
+                the Replicas count. If Selector is empty, it is defaulted to the labels
+                present on the Pod template. Label keys and values that must match
+                in order to be controlled by this replication controller, if empty
+                defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              type: object
+            template:
+              description: 'Template is the object that describes the pod that will
+                be created if insufficient replicas are detected. This takes precedence
+                over a TemplateRef. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template'
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the pod.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
+                    affinity:
+                      description: If specified, the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - preference
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      description: AutomountServiceAccountToken indicates whether
+                        a service account token should be automatically mounted.
+                      type: boolean
+                    containers:
+                      description: List of containers belonging to the pod. Containers
+                        cannot currently be added or removed. There must be at least
+                        one container in a Pod. Cannot be updated.
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    dnsConfig:
+                      description: Specifies the DNS parameters of a pod. Parameters
+                        specified here will be merged to the generated DNS configuration
+                        based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: A list of DNS name server IP addresses. This
+                            will be appended to the base nameservers generated from
+                            DNSPolicy. Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          description: A list of DNS resolver options. This will be
+                            merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options
+                            given in Options will override those that appear in the
+                            base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: Required.
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          description: A list of DNS search domains for host-name
+                            lookup. This will be appended to the base search paths
+                            generated from DNSPolicy. Duplicated search paths will
+                            be removed.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                        Possible enum values:
+                         - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                         - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                      type: string
+                    enableServiceLinks:
+                      description: 'EnableServiceLinks indicates whether information
+                        about services should be injected into pod''s environment
+                        variables, matching the syntax of Docker links. Optional:
+                        Defaults to true.'
+                      type: boolean
+                    ephemeralContainers:
+                      description: List of ephemeral containers run in this pod. Ephemeral
+                        containers may be run in an existing pod to perform user-initiated
+                        actions such as debugging. This list cannot be specified when
+                        creating a pod, and it cannot be modified by updating the
+                        pod spec. In order to add an ephemeral container to an existing
+                        pod, use the pod's ephemeralcontainers subresource.
+                      items:
+                        description: |-
+                          An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The image''s
+                              CMD is used if this is not provided. Variable references
+                              $(VAR_NAME) are expanded using the container''s environment.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The image''s ENTRYPOINT is used if this is not
+                              provided. Variable references $(VAR_NAME) are expanded
+                              using the container''s environment. If a variable cannot
+                              be resolved, the reference in the input string will
+                              be unchanged. Double $$ are reduced to a single $, which
+                              allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                              will produce the string literal "$(VAR_NAME)". Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Cannot be updated. More
+                              info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Lifecycle is not allowed for ephemeral containers.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the ephemeral container specified
+                              as a DNS_LABEL. This name must be unique among all containers,
+                              init containers and ephemeral containers.
+                            type: string
+                          ports:
+                            description: Ports are not allowed for ephemeral containers.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: Resources are not allowed for ephemeral containers.
+                              Ephemeral containers use spare resources already allocated
+                              to the pod.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Optional: SecurityContext defines the security
+                              options the ephemeral container should be run with.
+                              If set, the fields of SecurityContext override the equivalent
+                              fields of PodSecurityContext.'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          targetContainerName:
+                            description: |-
+                              If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                              The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                            type: string
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Subpath mounts are not allowed for ephemeral
+                              containers. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    hostAliases:
+                      description: HostAliases is an optional list of hosts and IPs
+                        that will be injected into the pod's hosts file if specified.
+                        This is only valid for non-hostNetwork pods.
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        required:
+                        - ip
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - ip
+                      x-kubernetes-list-type: map
+                    hostIPC:
+                      description: 'Use the host''s ipc namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace. If this option is set, the ports
+                        that will be used must be specified. Default to false.
+                      type: boolean
+                    hostPID:
+                      description: 'Use the host''s pid namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostUsers:
+                      description: 'Use the host''s user namespace. Optional: Default
+                        to true. If set to true or not present, the pod will be run
+                        in the host user namespace, useful for when the pod needs
+                        a feature only available to the host user namespace, such
+                        as loading a kernel module with CAP_SYS_MODULE. When set to
+                        false, a new userns is created for the pod. Setting false
+                        is useful for mitigating container breakout vulnerabilities
+                        even allowing users to run their containers as root without
+                        actually having root privileges on the host. This field is
+                        alpha-level and is only honored by servers that enable the
+                        UserNamespacesSupport feature.'
+                      type: boolean
+                    hostname:
+                      description: Specifies the hostname of the Pod If not specified,
+                        the pod's hostname will be set to a system-defined value.
+                      type: string
+                    imagePullSecrets:
+                      description: 'ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of
+                        the images used by this PodSpec. If specified, these secrets
+                        will be passed to individual puller implementations for them
+                        to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    initContainers:
+                      description: 'List of initialization containers belonging to
+                        the pod. Init containers are executed in order prior to containers
+                        being started. If any init container fails, the pod is considered
+                        to have failed and is handled according to its restartPolicy.
+                        The name for an init container or normal container must be
+                        unique among all containers. Init containers may not have
+                        Lifecycle actions, Readiness probes, Liveness probes, or Startup
+                        probes. The resourceRequirements of an init container are
+                        taken into account during scheduling by finding the highest
+                        request/limit for each resource type, and then using the max
+                        of of that value or the sum of the normal containers. Limits
+                        are applied to init containers in a similar fashion. Init
+                        containers cannot currently be added or removed. Cannot be
+                        updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    nodeName:
+                      description: NodeName is a request to schedule this pod onto
+                        a specific node. If it is non-empty, the scheduler simply
+                        schedules this pod onto that node, assuming that it fits resource
+                        requirements.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    os:
+                      description: |-
+                        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                      properties:
+                        name:
+                          description: 'Name is the name of the operating system.
+                            The currently supported values are linux and windows.
+                            Additional value may be defined in future and can be one
+                            of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                            Clients should expect to handle additional values and
+                            treat unrecognized values in this field as os: null'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Overhead represents the resource overhead associated
+                        with running a pod for a given RuntimeClass. This field will
+                        be autopopulated at admission time by the RuntimeClass admission
+                        controller. If the RuntimeClass admission controller is enabled,
+                        overhead must not be set in Pod create requests. The RuntimeClass
+                        admission controller will reject Pod create requests which
+                        have the overhead already set. If RuntimeClass is configured
+                        and selected in the PodSpec, Overhead will be set to the value
+                        defined in the corresponding RuntimeClass, otherwise it will
+                        remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                      type: object
+                    preemptionPolicy:
+                      description: PreemptionPolicy is the Policy for preempting pods
+                        with lower priority. One of Never, PreemptLowerPriority. Defaults
+                        to PreemptLowerPriority if unset.
+                      type: string
+                    priority:
+                      description: The priority value. Various system components use
+                        this field to find the priority of the pod. When Priority
+                        Admission Controller is enabled, it prevents users from setting
+                        this field. The admission controller populates this field
+                        from PriorityClassName. The higher the value, the higher the
+                        priority.
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which
+                        indicate the highest priorities with the former being the
+                        highest priority. Any other name must be defined by creating
+                        a PriorityClass object with that name. If not specified, the
+                        pod priority will be default or zero if there is no default.
+                      type: string
+                    readinessGates:
+                      description: 'If specified, all readiness gates will be evaluated
+                        for pod readiness. A pod is ready when all its containers
+                        are ready AND all conditions specified in the readiness gates
+                        have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                      items:
+                        description: PodReadinessGate contains the reference to a
+                          pod condition
+                        properties:
+                          conditionType:
+                            description: ConditionType refers to a condition in the
+                              pod's condition list with matching type.
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      description: |-
+                        Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                        Possible enum values:
+                         - `"Always"`
+                         - `"Never"`
+                         - `"OnFailure"`
+                      type: string
+                    runtimeClassName:
+                      description: 'RuntimeClassName refers to a RuntimeClass object
+                        in the node.k8s.io group, which should be used to run this
+                        pod.  If no RuntimeClass resource matches the named class,
+                        the pod will not be run. If unset or empty, the "legacy" RuntimeClass
+                        will be used, which is an implicit class with an empty definition
+                        that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                      type: string
+                    schedulerName:
+                      description: If specified, the pod will be dispatched by specified
+                        scheduler. If not specified, the pod will be dispatched by
+                        default scheduler.
+                      type: string
+                    securityContext:
+                      description: 'SecurityContext holds pod-level security attributes
+                        and common container settings. Optional: Defaults to empty.  See
+                        type description for default values of each field.'
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                Possible enum values:
+                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: 'DeprecatedServiceAccount is a depreciated alias
+                        for ServiceAccountName. Deprecated: Use serviceAccountName
+                        instead.'
+                      type: string
+                    serviceAccountName:
+                      description: 'ServiceAccountName is the name of the ServiceAccount
+                        to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                      type: string
+                    setHostnameAsFQDN:
+                      description: If true the pod's hostname will be configured as
+                        the pod's FQDN, rather than the leaf name (the default). In
+                        Linux containers, this means setting the FQDN in the hostname
+                        field of the kernel (the nodename field of struct utsname).
+                        In Windows containers, this means setting the registry value
+                        of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                        to FQDN. If a pod does not have FQDN, this has no effect.
+                        Default to false.
+                      type: boolean
+                    shareProcessNamespace:
+                      description: 'Share a single process namespace between all of
+                        the containers in a pod. When this is set containers will
+                        be able to view and signal processes from other containers
+                        in the same pod, and the first process in each container will
+                        not be assigned PID 1. HostPID and ShareProcessNamespace cannot
+                        both be set. Optional: Default to false.'
+                      type: boolean
+                    subdomain:
+                      description: If specified, the fully qualified Pod hostname
+                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                        domain>". If not specified, the pod will not have a domainname
+                        at all.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully. May be decreased in delete request. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). If this
+                        value is nil, the default grace period will be used instead.
+                        The grace period is the duration in seconds after the processes
+                        running in the pod are sent a termination signal and the time
+                        when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your
+                        process. Defaults to 30 seconds.
+                      format: int64
+                      type: integer
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                              Possible enum values:
+                               - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                               - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                               - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                              Possible enum values:
+                               - `"Equal"`
+                               - `"Exists"`
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints describes how a group
+                        of pods ought to spread across topology domains. Scheduler
+                        will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select the pods over which spreading will be calculated.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading
+                              will be calculated for the incoming pod. Keys that don't
+                              exist in the incoming pod labels will be ignored. A
+                              null or empty list means only match against labelSelector.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. The global minimum is the minimum number of
+                              matching pods in an eligible domain or zero if the number
+                              of eligible domains is less than MinDomains. For example,
+                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
+                              the same labelSelector spread as 2/2/1: In this case,
+                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
+                              can only be scheduled to zone3 to become 2/2/2; scheduling
+                              it onto zone1(zone2) would make the ActualSkew(3-1)
+                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
+                              2, incoming pod can be scheduled onto any zone. When
+                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
+                              higher precedence to topologies that satisfy it. It''s
+                              a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. We define a domain
+                              as a particular instance of a topology. Also, we define
+                              an eligible domain as a domain whose nodes meet the
+                              requirements of nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each
+                              Node is a domain of that topology. And, if TopologyKey
+                              is "topology.kubernetes.io/zone", each zone is a domain
+                              of that topology. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                              Possible enum values:
+                               - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                               - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    volumes:
+                      description: 'List of volumes that can be mounted by containers
+                        belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                  disk resource in AWS (Amazon EBS volume). More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a
+                                  collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                  the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is
+                                  reference to the authentication secret for User,
+                                  default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados
+                                  user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Examples: "ext4", "xfs", "ntfs".
+                                  Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to
+                                  OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                  medium should back this directory. The default is
+                                  "" which means to use the node''s default medium.
+                                  Must be an empty string (default) or Memory. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'sizeLimit is the total amount of local
+                                  storage required for this EmptyDir volume. The size
+                                  limit is also applicable for memory medium. The
+                                  maximum usage on memory medium EmptyDir would be
+                                  the minimum value between the SizeLimit specified
+                                  here and the sum of memory limits of all containers
+                                  in a pod. The default is nil which means that the
+                                  limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used
+                                          to specify either: * An existing VolumeSnapshot
+                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name
+                                          of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide
+                                  identifiers (wwids) Either wwids or combination
+                                  of targetWWNs and lun must be set, but not both
+                                  simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". The
+                                  default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is
+                                  reference to the secret object containing sensitive
+                                  information to pass to the plugin scripts. This
+                                  may be empty if no secret object is specified. If
+                                  the secret object contains more than one secret,
+                                  all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                  in GCE. Used to identify the disk in GCE. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is
+                                  supplied, the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name
+                                  that uses an iSCSI transport. Defaults to 'default'
+                                  (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal.
+                                  The Portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                type: string
+                            required:
+                            - targetPortal
+                            - iqn
+                            - lun
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL
+                              and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - server
+                            - path
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to
+                                  set permissions on created files by default. Must
+                                  be an octal value between 0000 and 0777 or a decimal
+                                  value between 0 and 511. YAML accepts both octal
+                                  and decimal values, JSON requires decimal values
+                                  for mode bits. Directories within the path are not
+                                  affected by this setting. This might be in conflict
+                                  with other options that affect the file mode, like
+                                  fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default
+                                  is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default
+                                  is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            - image
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                  is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated
+                                  with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - system
+                            - secretRef
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret
+                                  in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - containers
+                  type: object
+              type: object
+          type: object
+        status:
+          description: 'Status is the most recently observed status of the replication
+            controller. This data may be out of date by some window of time. Populated
+            by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          properties:
+            availableReplicas:
+              description: The number of available replicas (ready for at least minReadySeconds)
+                for this replication controller.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a replication
+                controller's current state.
+              items:
+                description: ReplicationControllerCondition describes the state of
+                  a replication controller at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: The last time the condition transitioned from one
+                      status to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of replication controller condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            fullyLabeledReplicas:
+              description: The number of pods that have labels matching the labels
+                of the pod template of the replication controller.
+              format: int32
+              type: integer
+            observedGeneration:
+              description: ObservedGeneration reflects the generation of the most
+                recently observed replication controller.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: The number of ready replicas for this replication controller.
+              format: int32
+              type: integer
+            replicas:
+              description: 'Replicas is the most recently oberved number of replicas.
+                More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller'
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/config/kube/exports/namespaced/apiresourceschema-statefulsets.apps.yaml
+++ b/config/kube/exports/namespaced/apiresourceschema-statefulsets.apps.yaml
@@ -1,0 +1,7567 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: v230615-d48020c8.statefulsets.apps
+spec:
+  group: apps
+  names:
+    categories:
+    - all
+    kind: StatefulSet
+    listKind: StatefulSetList
+    plural: statefulsets
+    shortNames:
+    - sts
+    singular: statefulset
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: |-
+        StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+          - Network: A single stable DNS and hostname.
+          - Storage: As many VolumeClaims as requested.
+
+        The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines the desired identities of pods in this set.
+          properties:
+            minReadySeconds:
+              description: Minimum number of seconds for which a newly created pod
+                should be ready without any of its container crashing for it to be
+                considered available. Defaults to 0 (pod will be considered available
+                as soon as it is ready)
+              format: int32
+              type: integer
+            persistentVolumeClaimRetentionPolicy:
+              description: persistentVolumeClaimRetentionPolicy describes the lifecycle
+                of persistent volume claims created from volumeClaimTemplates. By
+                default, all persistent volume claims are created as needed and retained
+                until manually deleted. This policy allows the lifecycle to be altered,
+                for example by deleting persistent volume claims when their stateful
+                set is deleted, or when their pod is scaled down. This requires the
+                StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.  +optional
+              properties:
+                whenDeleted:
+                  description: WhenDeleted specifies what happens to PVCs created
+                    from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                    deleted. The default policy of `Retain` causes PVCs to not be
+                    affected by StatefulSet deletion. The `Delete` policy causes those
+                    PVCs to be deleted.
+                  type: string
+                whenScaled:
+                  description: WhenScaled specifies what happens to PVCs created from
+                    StatefulSet VolumeClaimTemplates when the StatefulSet is scaled
+                    down. The default policy of `Retain` causes PVCs to not be affected
+                    by a scaledown. The `Delete` policy causes the associated PVCs
+                    for any excess pods above the replica count to be deleted.
+                  type: string
+              type: object
+            podManagementPolicy:
+              description: |-
+                podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+
+                Possible enum values:
+                 - `"OrderedReady"` will create pods in strictly increasing order on scale up and strictly decreasing order on scale down, progressing only when the previous pod is ready or terminated. At most one pod will be changed at any time.
+                 - `"Parallel"` will create and delete pods as soon as the stateful set replica count is changed, and will not wait for pods to be ready or complete termination.
+              type: string
+            replicas:
+              description: replicas is the desired number of replicas of the given
+                Template. These are replicas in the sense that they are instantiations
+                of the same Template, but individual replicas also have a consistent
+                identity. If unspecified, defaults to 1.
+              format: int32
+              type: integer
+            revisionHistoryLimit:
+              description: revisionHistoryLimit is the maximum number of revisions
+                that will be maintained in the StatefulSet's revision history. The
+                revision history consists of all revisions not represented by a currently
+                applied StatefulSetSpec version. The default value is 10.
+              format: int32
+              type: integer
+            selector:
+              description: 'selector is a label query over pods that should match
+                the replica count. It must match the pod template''s labels. More
+                info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+            serviceName:
+              description: 'serviceName is the name of the service that governs this
+                StatefulSet. This service must exist before the StatefulSet, and is
+                responsible for the network identity of the set. Pods get DNS/hostnames
+                that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local
+                where "pod-specific-string" is managed by the StatefulSet controller.'
+              type: string
+            template:
+              description: template is the object that describes the pod that will
+                be created if insufficient replicas are detected. Each pod stamped
+                out by the StatefulSet will fulfill this Template, but have a unique
+                identity from the rest of the StatefulSet.
+              properties:
+                metadata:
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                spec:
+                  description: 'Specification of the desired behavior of the pod.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                  properties:
+                    activeDeadlineSeconds:
+                      description: Optional duration in seconds the pod may be active
+                        on the node relative to StartTime before the system will actively
+                        try to mark it failed and kill associated containers. Value
+                        must be a positive integer.
+                      format: int64
+                      type: integer
+                    affinity:
+                      description: If specified, the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a
+                                  no-op). A null preferred scheduling term matches
+                                  no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - preference
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an
+                                update), the system may or may not try to eventually
+                                evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them
+                                      are ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                                Possible enum values:
+                                                 - `"DoesNotExist"`
+                                                 - `"Exists"`
+                                                 - `"Gt"`
+                                                 - `"In"`
+                                                 - `"Lt"`
+                                                 - `"NotIn"`
+                                              type: string
+                                            values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If
+                                                the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If
+                                                the operator is Gt or Lt, the values
+                                                array must have a single element,
+                                                which will be interpreted as an integer.
+                                                This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the
+                                corresponding podAffinityTerm; the node(s) with the
+                                highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node
+                                that violates one or more of the expressions. The
+                                node that is most preferred is the one with the greatest
+                                sum of weights, i.e. for each node that meets all
+                                of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions,
+                                etc.), compute a sum by iterating through the elements
+                                of this field and adding "weight" to the sum if the
+                                node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - weight
+                                - podAffinityTerm
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the
+                                pod will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a
+                                pod label update), the system may or may not try to
+                                eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all
+                                terms must be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or
+                                  not co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any
+                                  node on which a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces
+                                      field. null selector and null or empty namespaces
+                                      list means "this pod's namespace". An empty
+                                      selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces
+                                      list and null namespaceSelector means "this
+                                      pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    automountServiceAccountToken:
+                      description: AutomountServiceAccountToken indicates whether
+                        a service account token should be automatically mounted.
+                      type: boolean
+                    containers:
+                      description: List of containers belonging to the pod. Containers
+                        cannot currently be added or removed. There must be at least
+                        one container in a Pod. Cannot be updated.
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    dnsConfig:
+                      description: Specifies the DNS parameters of a pod. Parameters
+                        specified here will be merged to the generated DNS configuration
+                        based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: A list of DNS name server IP addresses. This
+                            will be appended to the base nameservers generated from
+                            DNSPolicy. Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                        options:
+                          description: A list of DNS resolver options. This will be
+                            merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options
+                            given in Options will override those that appear in the
+                            base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: Required.
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        searches:
+                          description: A list of DNS search domains for host-name
+                            lookup. This will be appended to the base search paths
+                            generated from DNSPolicy. Duplicated search paths will
+                            be removed.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+
+                        Possible enum values:
+                         - `"ClusterFirst"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"ClusterFirstWithHostNet"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.
+                         - `"Default"` indicates that the pod should use the default (as determined by kubelet) DNS settings.
+                         - `"None"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.
+                      type: string
+                    enableServiceLinks:
+                      description: 'EnableServiceLinks indicates whether information
+                        about services should be injected into pod''s environment
+                        variables, matching the syntax of Docker links. Optional:
+                        Defaults to true.'
+                      type: boolean
+                    ephemeralContainers:
+                      description: List of ephemeral containers run in this pod. Ephemeral
+                        containers may be run in an existing pod to perform user-initiated
+                        actions such as debugging. This list cannot be specified when
+                        creating a pod, and it cannot be modified by updating the
+                        pod spec. In order to add an ephemeral container to an existing
+                        pod, use the pod's ephemeralcontainers subresource.
+                      items:
+                        description: |-
+                          An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The image''s
+                              CMD is used if this is not provided. Variable references
+                              $(VAR_NAME) are expanded using the container''s environment.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The image''s ENTRYPOINT is used if this is not
+                              provided. Variable references $(VAR_NAME) are expanded
+                              using the container''s environment. If a variable cannot
+                              be resolved, the reference in the input string will
+                              be unchanged. Double $$ are reduced to a single $, which
+                              allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                              will produce the string literal "$(VAR_NAME)". Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Cannot be updated. More
+                              info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Lifecycle is not allowed for ephemeral containers.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the ephemeral container specified
+                              as a DNS_LABEL. This name must be unique among all containers,
+                              init containers and ephemeral containers.
+                            type: string
+                          ports:
+                            description: Ports are not allowed for ephemeral containers.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: Resources are not allowed for ephemeral containers.
+                              Ephemeral containers use spare resources already allocated
+                              to the pod.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Optional: SecurityContext defines the security
+                              options the ephemeral container should be run with.
+                              If set, the fields of SecurityContext override the equivalent
+                              fields of PodSecurityContext.'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Probes are not allowed for ephemeral containers.
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          targetContainerName:
+                            description: |-
+                              If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                              The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+                            type: string
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Subpath mounts are not allowed for ephemeral
+                              containers. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    hostAliases:
+                      description: HostAliases is an optional list of hosts and IPs
+                        that will be injected into the pod's hosts file if specified.
+                        This is only valid for non-hostNetwork pods.
+                      items:
+                        description: HostAlias holds the mapping between IP and hostnames
+                          that will be injected as an entry in the pod's hosts file.
+                        properties:
+                          hostnames:
+                            description: Hostnames for the above IP address.
+                            items:
+                              type: string
+                            type: array
+                          ip:
+                            description: IP address of the host file entry.
+                            type: string
+                        required:
+                        - ip
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - ip
+                      x-kubernetes-list-type: map
+                    hostIPC:
+                      description: 'Use the host''s ipc namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace. If this option is set, the ports
+                        that will be used must be specified. Default to false.
+                      type: boolean
+                    hostPID:
+                      description: 'Use the host''s pid namespace. Optional: Default
+                        to false.'
+                      type: boolean
+                    hostUsers:
+                      description: 'Use the host''s user namespace. Optional: Default
+                        to true. If set to true or not present, the pod will be run
+                        in the host user namespace, useful for when the pod needs
+                        a feature only available to the host user namespace, such
+                        as loading a kernel module with CAP_SYS_MODULE. When set to
+                        false, a new userns is created for the pod. Setting false
+                        is useful for mitigating container breakout vulnerabilities
+                        even allowing users to run their containers as root without
+                        actually having root privileges on the host. This field is
+                        alpha-level and is only honored by servers that enable the
+                        UserNamespacesSupport feature.'
+                      type: boolean
+                    hostname:
+                      description: Specifies the hostname of the Pod If not specified,
+                        the pod's hostname will be set to a system-defined value.
+                      type: string
+                    imagePullSecrets:
+                      description: 'ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of
+                        the images used by this PodSpec. If specified, these secrets
+                        will be passed to individual puller implementations for them
+                        to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same
+                          namespace.
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    initContainers:
+                      description: 'List of initialization containers belonging to
+                        the pod. Init containers are executed in order prior to containers
+                        being started. If any init container fails, the pod is considered
+                        to have failed and is handled according to its restartPolicy.
+                        The name for an init container or normal container must be
+                        unique among all containers. Init containers may not have
+                        Lifecycle actions, Readiness probes, Liveness probes, or Startup
+                        probes. The resourceRequirements of an init container are
+                        taken into account during scheduling by finding the highest
+                        request/limit for each resource type, and then using the max
+                        of of that value or the sum of the normal containers. Limits
+                        are applied to init containers in a similar fashion. Init
+                        containers cannot currently be added or removed. Cannot be
+                        updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                      items:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: |-
+                              Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+
+                              Possible enum values:
+                               - `"Always"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.
+                               - `"IfNotPresent"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.
+                               - `"Never"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The Pod''s termination grace period countdown
+                                  begins before the PreStop hook is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period (unless delayed by finalizers). Other
+                                  management of the container blocks until the hook
+                                  completes or until the termination grace period
+                                  is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                          Possible enum values:
+                                           - `"HTTP"` means that the scheme used will be http://
+                                           - `"HTTPS"` means that the scheme used will be https://
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: Deprecated. TCPSocket is NOT supported
+                                      as a LifecycleHandler and kept for the backward
+                                      compatibility. There are no validation of this
+                                      field and lifecycle hooks will fail in runtime
+                                      when tcp handler is specified.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Not specifying a port here DOES NOT prevent that port
+                              from being exposed. Any port which is listening on the
+                              default "0.0.0.0" address inside a container will be
+                              accessible from the network. Modifying this array with
+                              strategic merge patch may corrupt the data. For more
+                              information See https://github.com/kubernetes/kubernetes/issues/108255.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+
+                                    Possible enum values:
+                                     - `"SCTP"` is the SCTP protocol.
+                                     - `"TCP"` is the TCP protocol.
+                                     - `"UDP"` is the UDP protocol.
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'SecurityContext defines the security options
+                              the container should be run with. If set, the fields
+                              of SecurityContext override the equivalent fields of
+                              PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN Note that this field
+                                  cannot be set when spec.os.name is windows.'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false. Note that
+                                  this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled. Note that this field
+                                  cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false. Note that this
+                                  field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name
+                                  is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: The seccomp options to use by this container.
+                                  If seccomp options are provided at both the pod
+                                  & container level, the container options override
+                                  the pod options. Note that this field cannot be
+                                  set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: localhostProfile indicates a profile
+                                      defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node
+                                      to work. Must be a descending path, relative
+                                      to the kubelet's configured seccomp profile
+                                      location. Must only be set if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                      Possible enum values:
+                                       - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                       - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                       - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence. Note
+                                  that this field cannot be set when spec.os.name
+                                  is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: HostProcess determines if a container
+                                      should be run as a 'Host Process' container.
+                                      This field is alpha-level and will only be honored
+                                      by components that enable the WindowsHostProcessContainers
+                                      feature flag. Setting this field without the
+                                      feature flag will result in errors when validating
+                                      the Pod. All of a Pod's containers must have
+                                      the same effective HostProcess value (it is
+                                      not allowed to have a mix of HostProcess containers
+                                      and non-HostProcess containers).  In addition,
+                                      if HostProcess is true then HostNetwork must
+                                      also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies an action involving a
+                                  GRPC port. This is a beta field and requires enabling
+                                  GRPCContainerProbe feature gate.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host. Defaults to HTTP.
+
+                                      Possible enum values:
+                                       - `"HTTP"` means that the scheme used will be http://
+                                       - `"HTTPS"` means that the scheme used will be https://
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies an action involving
+                                  a TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: Optional duration in seconds the pod
+                                  needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after
+                                  the processes running in the pod are sent a termination
+                                  signal and the time when the processes are forcibly
+                                  halted with a kill signal. Set this value longer
+                                  than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds
+                                  will be used. Otherwise, this value overrides the
+                                  value provided by the pod spec. Value must be non-negative
+                                  integer. The value zero indicates stop immediately
+                                  via the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod
+                                  feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                  is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: |-
+                              Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+
+                              Possible enum values:
+                               - `"FallbackToLogsOnError"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.
+                               - `"File"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - devicePath
+                            x-kubernetes-list-type: map
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - mountPath
+                            x-kubernetes-list-type: map
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    nodeName:
+                      description: NodeName is a request to schedule this pod onto
+                        a specific node. If it is non-empty, the scheduler simply
+                        schedules this pod onto that node, assuming that it fits resource
+                        requirements.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: 'NodeSelector is a selector which must be true
+                        for the pod to fit on a node. Selector which must match a
+                        node''s labels for the pod to be scheduled on that node. More
+                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                      type: object
+                    os:
+                      description: |-
+                        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+                        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+                        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+                      properties:
+                        name:
+                          description: 'Name is the name of the operating system.
+                            The currently supported values are linux and windows.
+                            Additional value may be defined in future and can be one
+                            of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                            Clients should expect to handle additional values and
+                            treat unrecognized values in this field as os: null'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    overhead:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Overhead represents the resource overhead associated
+                        with running a pod for a given RuntimeClass. This field will
+                        be autopopulated at admission time by the RuntimeClass admission
+                        controller. If the RuntimeClass admission controller is enabled,
+                        overhead must not be set in Pod create requests. The RuntimeClass
+                        admission controller will reject Pod create requests which
+                        have the overhead already set. If RuntimeClass is configured
+                        and selected in the PodSpec, Overhead will be set to the value
+                        defined in the corresponding RuntimeClass, otherwise it will
+                        remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
+                      type: object
+                    preemptionPolicy:
+                      description: PreemptionPolicy is the Policy for preempting pods
+                        with lower priority. One of Never, PreemptLowerPriority. Defaults
+                        to PreemptLowerPriority if unset.
+                      type: string
+                    priority:
+                      description: The priority value. Various system components use
+                        this field to find the priority of the pod. When Priority
+                        Admission Controller is enabled, it prevents users from setting
+                        this field. The admission controller populates this field
+                        from PriorityClassName. The higher the value, the higher the
+                        priority.
+                      format: int32
+                      type: integer
+                    priorityClassName:
+                      description: If specified, indicates the pod's priority. "system-node-critical"
+                        and "system-cluster-critical" are two special keywords which
+                        indicate the highest priorities with the former being the
+                        highest priority. Any other name must be defined by creating
+                        a PriorityClass object with that name. If not specified, the
+                        pod priority will be default or zero if there is no default.
+                      type: string
+                    readinessGates:
+                      description: 'If specified, all readiness gates will be evaluated
+                        for pod readiness. A pod is ready when all its containers
+                        are ready AND all conditions specified in the readiness gates
+                        have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
+                      items:
+                        description: PodReadinessGate contains the reference to a
+                          pod condition
+                        properties:
+                          conditionType:
+                            description: ConditionType refers to a condition in the
+                              pod's condition list with matching type.
+                            type: string
+                        required:
+                        - conditionType
+                        type: object
+                      type: array
+                    restartPolicy:
+                      description: |-
+                        Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+
+                        Possible enum values:
+                         - `"Always"`
+                         - `"Never"`
+                         - `"OnFailure"`
+                      type: string
+                    runtimeClassName:
+                      description: 'RuntimeClassName refers to a RuntimeClass object
+                        in the node.k8s.io group, which should be used to run this
+                        pod.  If no RuntimeClass resource matches the named class,
+                        the pod will not be run. If unset or empty, the "legacy" RuntimeClass
+                        will be used, which is an implicit class with an empty definition
+                        that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
+                      type: string
+                    schedulerName:
+                      description: If specified, the pod will be dispatched by specified
+                        scheduler. If not specified, the pod will be dispatched by
+                        default scheduler.
+                      type: string
+                    securityContext:
+                      description: 'SecurityContext holds pod-level security attributes
+                        and common container settings. Optional: Defaults to empty.  See
+                        type description for default values of each field.'
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                            ownership and permission of the volume before being exposed
+                            inside Pod. This field will only apply to volume types
+                            which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such
+                            as: secret, configmaps and emptydir. Valid values are
+                            "OnRootMismatch" and "Always". If not specified, "Always"
+                            is used. Note that this field cannot be set when spec.os.name
+                            is windows.'
+                          type: string
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence for
+                            that container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in SecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container. Note that this field
+                            cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod. Note that this field cannot be set when spec.os.name
+                            is windows.
+                          properties:
+                            localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile
+                                must be preconfigured on the node to work. Must be
+                                a descending path, relative to the kubelet's configured
+                                seccomp profile location. Must only be set if type
+                                is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+
+                                Possible enum values:
+                                 - `"Localhost"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.
+                                 - `"RuntimeDefault"` represents the default container runtime seccomp profile.
+                                 - `"Unconfined"` indicates no seccomp profile is applied (A.K.A. unconfined).
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's
+                            primary GID.  If unspecified, no groups will be added
+                            to any container. Note that this field cannot be set when
+                            spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch. Note that this field cannot
+                            be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence. Note that this field cannot be set when
+                            spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container. This field is
+                                alpha-level and will only be honored by components
+                                that enable the WindowsHostProcessContainers feature
+                                flag. Setting this field without the feature flag
+                                will result in errors when validating the Pod. All
+                                of a Pod's containers must have the same effective
+                                HostProcess value (it is not allowed to have a mix
+                                of HostProcess containers and non-HostProcess containers).  In
+                                addition, if HostProcess is true then HostNetwork
+                                must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set
+                                in PodSecurityContext. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: 'DeprecatedServiceAccount is a depreciated alias
+                        for ServiceAccountName. Deprecated: Use serviceAccountName
+                        instead.'
+                      type: string
+                    serviceAccountName:
+                      description: 'ServiceAccountName is the name of the ServiceAccount
+                        to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                      type: string
+                    setHostnameAsFQDN:
+                      description: If true the pod's hostname will be configured as
+                        the pod's FQDN, rather than the leaf name (the default). In
+                        Linux containers, this means setting the FQDN in the hostname
+                        field of the kernel (the nodename field of struct utsname).
+                        In Windows containers, this means setting the registry value
+                        of hostname for the registry key HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
+                        to FQDN. If a pod does not have FQDN, this has no effect.
+                        Default to false.
+                      type: boolean
+                    shareProcessNamespace:
+                      description: 'Share a single process namespace between all of
+                        the containers in a pod. When this is set containers will
+                        be able to view and signal processes from other containers
+                        in the same pod, and the first process in each container will
+                        not be assigned PID 1. HostPID and ShareProcessNamespace cannot
+                        both be set. Optional: Default to false.'
+                      type: boolean
+                    subdomain:
+                      description: If specified, the fully qualified Pod hostname
+                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                        domain>". If not specified, the pod will not have a domainname
+                        at all.
+                      type: string
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully. May be decreased in delete request. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). If this
+                        value is nil, the default grace period will be used instead.
+                        The grace period is the duration in seconds after the processes
+                        running in the pod are sent a termination signal and the time
+                        when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your
+                        process. Defaults to 30 seconds.
+                      format: int64
+                      type: integer
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+                              Possible enum values:
+                               - `"NoExecute"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.
+                               - `"NoSchedule"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.
+                               - `"PreferNoSchedule"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+
+                              Possible enum values:
+                               - `"Equal"`
+                               - `"Exists"`
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: TopologySpreadConstraints describes how a group
+                        of pods ought to spread across topology domains. Scheduler
+                        will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine
+                              the number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          matchLabelKeys:
+                            description: MatchLabelKeys is a set of pod label keys
+                              to select the pods over which spreading will be calculated.
+                              The keys are used to lookup values from the incoming
+                              pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading
+                              will be calculated for the incoming pod. Keys that don't
+                              exist in the incoming pod labels will be ignored. A
+                              null or empty list means only match against labelSelector.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods
+                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                              it is the maximum permitted difference between the number
+                              of matching pods in the target topology and the global
+                              minimum. The global minimum is the minimum number of
+                              matching pods in an eligible domain or zero if the number
+                              of eligible domains is less than MinDomains. For example,
+                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
+                              the same labelSelector spread as 2/2/1: In this case,
+                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
+                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
+                              can only be scheduled to zone3 to become 2/2/2; scheduling
+                              it onto zone1(zone2) would make the ActualSkew(3-1)
+                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
+                              2, incoming pod can be scheduled onto any zone. When
+                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
+                              higher precedence to topologies that satisfy it. It''s
+                              a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes
+                              that have a label with this key and identical values
+                              are considered to be in the same topology. We consider
+                              each <key, value> as a "bucket", and try to put balanced
+                              number of pods into each bucket. We define a domain
+                              as a particular instance of a topology. Also, we define
+                              an eligible domain as a domain whose nodes meet the
+                              requirements of nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each
+                              Node is a domain of that topology. And, if TopologyKey
+                              is "topology.kubernetes.io/zone", each zone is a domain
+                              of that topology. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+
+                              Possible enum values:
+                               - `"DoNotSchedule"` instructs the scheduler not to schedule the pod when constraints are not satisfied.
+                               - `"ScheduleAnyway"` instructs the scheduler to schedule the pod even if constraints are not satisfied.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    volumes:
+                      description: 'List of volumes that can be mounted by containers
+                        belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly
+                                  setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent
+                                  disk resource in AWS (Amazon EBS volume). More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount
+                              on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service
+                              mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a
+                                  collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is
+                                  the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is
+                                  reference to the authentication secret for User,
+                                  default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados
+                                  user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached
+                              and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Examples: "ext4", "xfs", "ntfs".
+                                  Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret
+                                  object containing parameters used to connect to
+                                  OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume
+                                  in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value
+                                  pair in the Data field of the referenced ConfigMap
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver
+                                  that handles this volume. Consult with your admin
+                                  for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the
+                                  associated CSI driver which will determine the default
+                                  filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to
+                                  the secret object containing sensitive information
+                                  to pass to the CSI driver to complete the CSI NodePublishVolume
+                                  and NodeUnpublishVolume calls. This field is optional,
+                                  and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all
+                                  secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration
+                                  for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific
+                                  properties that are passed to the CSI driver. Consult
+                                  your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created
+                                  files by default. Must be a Optional: mode bits
+                                  used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name and namespace
+                                        are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set
+                                        permissions on this file, must be an octal
+                                        value between 0000 and 0777 or a decimal value
+                                        between 0 and 511. YAML accepts both octal
+                                        and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, requests.cpu and requests.memory)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory
+                              that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage
+                                  medium should back this directory. The default is
+                                  "" which means to use the node''s default medium.
+                                  Must be an empty string (default) or Memory. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'sizeLimit is the total amount of local
+                                  storage required for this EmptyDir volume. The size
+                                  limit is also applicable for memory medium. The
+                                  maximum usage on memory medium EmptyDir would be
+                                  the minimum value between the SizeLimit specified
+                                  here and the sum of memory limits of all containers
+                                  in a pod. The default is nil which means that the
+                                  limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations
+                                      that will be copied into the PVC when creating
+                                      it. No other fields are allowed and will be
+                                      rejected during validation.
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim.
+                                      The entire content is copied unchanged into
+                                      the PVC that gets created from this template.
+                                      The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired
+                                          access modes the volume should have. More
+                                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used
+                                          to specify either: * An existing VolumeSnapshot
+                                          object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller
+                                          can support the specified data source, it
+                                          will create a new volume based on the contents
+                                          of the specified data source. If the AnyVolumeDataSource
+                                          feature gate is enabled, this field will
+                                          always have the same contents as the DataSourceRef
+                                          field.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for
+                                              the resource being referenced. If APIGroup
+                                              is not specified, the specified Kind
+                                              must be in the core API group. For any
+                                              other third-party types, APIGroup is
+                                              required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum
+                                          resources the volume should have. If RecoverVolumeExpansionFailure
+                                          feature is enabled users are allowed to
+                                          specify resource requirements that are lower
+                                          than previous value but must still be higher
+                                          than capacity recorded in the status field
+                                          of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Limits describes the maximum
+                                              amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: 'Requests describes the minimum
+                                              amount of compute resources required.
+                                              If Requests is omitted for a container,
+                                              it defaults to Limits if that is explicitly
+                                              specified, otherwise to an implementation-defined
+                                              value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name
+                                          of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type
+                                          of volume is required by the claim. Value
+                                          of Filesystem is implied when not included
+                                          in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide
+                                  identifiers (wwids) Either wwids or combination
+                                  of targetWWNs and lun must be set, but not both
+                                  simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource
+                              that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". The
+                                  default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false
+                                  (read/write). ReadOnly here will force the ReadOnly
+                                  setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is
+                                  reference to the secret object containing sensitive
+                                  information to pass to the plugin scripts. This
+                                  may be empty if no secret object is specified. If
+                                  the secret object contains more than one secret,
+                                  all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached
+                              to a kubelet's host machine. This depends on the Flocker
+                              control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored
+                                  as metadata -> name on the dataset for Flocker should
+                                  be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk
+                              resource that is attached to a kubelet''s host machine
+                              and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume
+                                  that you want to mount. Tip: Ensure that the filesystem
+                                  type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume
+                                  that you want to mount. If omitted, the default
+                                  is to mount by volume name. Examples: For volume
+                                  /dev/sda1, you specify the partition as "1". Similarly,
+                                  the volume partition for /dev/sda is "0" (or you
+                                  can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource
+                                  in GCE. Used to identify the disk in GCE. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a
+                              particular revision. DEPRECATED: GitRepo is deprecated.
+                              To provision a container with a git repo, mount an EmptyDir
+                              into an InitContainer that clones the repo using git,
+                              then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is
+                                  supplied, the volume directory will be the git repository.  Otherwise,
+                                  if specified, the volume will contain the git repository
+                                  in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on
+                              the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that
+                                  details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More
+                                  info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file
+                              or directory on the host machine that is directly exposed
+                              to the container. This is generally used for system
+                              agents or other privileged things that are allowed to
+                              see the host machine. Most containers will NOT need
+                              this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If
+                                  the path is a symlink, it will follow the link to
+                                  the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to
+                                  "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource
+                              that is attached to a kubelet''s host machine and then
+                              exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator
+                                  Name. If initiatorName is specified with iscsiInterface
+                                  simultaneously, new iSCSI interface <target portal>:<volume
+                                  name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name
+                                  that uses an iSCSI transport. Defaults to 'default'
+                                  (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List.
+                                  The portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal.
+                                  The Portal is either an IP or ip_addr:port if the
+                                  port is other than default (typically TCP ports
+                                  860 and 3260).
+                                type: string
+                            required:
+                            - targetPortal
+                            - iqn
+                            - lun
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL
+                              and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host
+                              that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export
+                                  to be mounted with read-only permissions. Defaults
+                                  to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address
+                                  of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                            - server
+                            - path
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents
+                              a reference to a PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim
+                                  in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting
+                                  in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController
+                              persistent disk attached and mounted on kubelets host
+                              machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type
+                                  to mount Must be a filesystem type supported by
+                                  the host operating system. Ex. "ext4", "xfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to
+                                  set permissions on created files by default. Must
+                                  be an octal value between 0000 and 0777 or a decimal
+                                  value between 0 and 511. YAML accepts both octal
+                                  and decimal values, JSON requires decimal values
+                                  for mode bits. Directories within the path are not
+                                  affected by this setting. This might be in conflict
+                                  with other options that affect the file mode, like
+                                  fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along
+                                    with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits
+                                                  used to set permissions on this
+                                                  file, must be an octal value between
+                                                  0000 and 0777 or a decimal value
+                                                  between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of
+                                                  the container: only resources limits
+                                                  and requests (limits.cpu, limits.memory,
+                                                  requests.cpu and requests.memory)
+                                                  are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience
+                                            of the token. A recipient of a token must
+                                            identify itself with an identifier specified
+                                            in the audience of the token, and otherwise
+                                            should reject the token. The audience
+                                            defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested
+                                            duration of validity of the service account
+                                            token. As the token approaches expiration,
+                                            the kubelet volume plugin will proactively
+                                            rotate the service account token. The
+                                            kubelet will start trying to rotate the
+                                            token if the token is older than 80 percent
+                                            of its time to live or if the token is
+                                            older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to
+                                            the mount point of the file to project
+                                            the token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the
+                              host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default
+                                  is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte
+                                  volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple
+                                  Quobyte Registry services specified as a string
+                                  as host:port pair (multiple entries are separated
+                                  with commas) which acts as the central registry
+                                  for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume
+                                  in the Backend Used with dynamically provisioned
+                                  Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults
+                                  to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount
+                              on the host that shares a pod''s lifetime. More info:
+                              https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the
+                                  volume that you want to mount. Tip: Ensure that
+                                  the filesystem type is supported by the host operating
+                                  system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified. More info:
+                                  https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for
+                                  RBDUser. Default is /etc/ceph/keyring. More info:
+                                  https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default
+                                  is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly
+                                  setting in VolumeMounts. Defaults to false. More
+                                  info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication
+                                  secret for RBDUser. If provided overrides keyring.
+                                  Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default
+                                  is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                            - monitors
+                            - image
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume
+                              attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                  is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for
+                                  ScaleIO user and other sensitive information. If
+                                  this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage
+                                  for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already
+                                  created in the ScaleIO system that is associated
+                                  with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - system
+                            - secretRef
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate
+                              this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used
+                                  to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or
+                                  a decimal value between 0 and 511. YAML accepts
+                                  both octal and decimal values, JSON requires decimal
+                                  values for mode bits. Defaults to 0644. Directories
+                                  within the path are not affected by this setting.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value
+                                  pair in the Data field of the referenced Secret
+                                  will be projected into the volume as a file whose
+                                  name is the key and content is the value. If specified,
+                                  the listed keys will be projected into the specified
+                                  paths, and unlisted keys will not be present. If
+                                  a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked
+                                  optional. Paths must be relative and may not contain
+                                  the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used
+                                        to set permissions on this file. Must be an
+                                        octal value between 0000 and 0777 or a decimal
+                                        value between 0 and 511. YAML accepts both
+                                        octal and decimal values, JSON requires decimal
+                                        values for mode bits. If not specified, the
+                                        volume defaultMode will be used. This might
+                                        be in conflict with other options that affect
+                                        the file mode, like fsGroup, and the result
+                                        can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the
+                                        file to map the key to. May not be an absolute
+                                        path. May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret
+                                  in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached
+                              and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host
+                                  operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write).
+                                  ReadOnly here will force the ReadOnly setting in
+                                  VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use
+                                  for obtaining the StorageOS API credentials.  If
+                                  not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name
+                                  of the StorageOS volume.  Volume names are only
+                                  unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of
+                                  the volume within StorageOS.  If no namespace is
+                                  specified then the Pod's namespace will be used.  This
+                                  allows the Kubernetes name scoping to be mirrored
+                                  within StorageOS for tighter integration. Set VolumeName
+                                  to any name to override the default behaviour. Set
+                                  to "default" if you are not using namespaces within
+                                  StorageOS. Namespaces that do not pre-exist within
+                                  StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume
+                              attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must
+                                  be a filesystem type supported by the host operating
+                                  system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                  to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - containers
+                  type: object
+              type: object
+            updateStrategy:
+              description: updateStrategy indicates the StatefulSetUpdateStrategy
+                that will be employed to update Pods in the StatefulSet when a revision
+                is made to Template.
+              properties:
+                rollingUpdate:
+                  description: RollingUpdate is used to communicate parameters when
+                    Type is RollingUpdateStatefulSetStrategyType.
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'The maximum number of pods that can be unavailable
+                        during the update. Value can be an absolute number (ex: 5)
+                        or a percentage of desired pods (ex: 10%). Absolute number
+                        is calculated from percentage by rounding up. This can not
+                        be 0. Defaults to 1. This field is alpha-level and is only
+                        honored by servers that enable the MaxUnavailableStatefulSet
+                        feature. The field applies to all pods in the range 0 to Replicas-1.
+                        That means if there is any unavailable pod in the range 0
+                        to Replicas-1, it will be counted towards MaxUnavailable.'
+                      x-kubernetes-int-or-string: true
+                    partition:
+                      description: Partition indicates the ordinal at which the StatefulSet
+                        should be partitioned for updates. During a rolling update,
+                        all pods from ordinal Replicas-1 to Partition are updated.
+                        All pods from ordinal Partition-1 to 0 remain untouched. This
+                        is helpful in being able to do a canary based deployment.
+                        The default value is 0.
+                      format: int32
+                      type: integer
+                  type: object
+                type:
+                  description: |-
+                    Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+
+                    Possible enum values:
+                     - `"OnDelete"` triggers the legacy behavior. Version tracking and ordered rolling restarts are disabled. Pods are recreated from the StatefulSetSpec when they are manually deleted. When a scale operation is performed with this strategy,specification version indicated by the StatefulSet's currentRevision.
+                     - `"RollingUpdate"` indicates that update will be applied to all Pods in the StatefulSet with respect to the StatefulSet ordering constraints. When a scale operation is performed with this strategy, new Pods will be created from the specification version indicated by the StatefulSet's updateRevision.
+                  type: string
+              type: object
+            volumeClaimTemplates:
+              description: volumeClaimTemplates is a list of claims that pods are
+                allowed to reference. The StatefulSet controller is responsible for
+                mapping network identities to claims in a way that maintains the identity
+                of a pod. Every claim in this list must have at least one matching
+                (by name) volumeMount in one container in the template. A claim in
+                this list takes precedence over any volumes in the template, with
+                the same name.
+              items:
+                description: PersistentVolumeClaim is a user's request for and claim
+                  to a persistent volume
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  spec:
+                    description: 'spec defines the desired characteristics of a volume
+                      requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      accessModes:
+                        description: 'accessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim) If the provisioner
+                          or an external controller can support the specified data
+                          source, it will create a new volume based on the contents
+                          of the specified data source. If the AnyVolumeDataSource
+                          feature gate is enabled, this field will always have the
+                          same contents as the DataSourceRef field.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'resources represents the minimum resources the
+                          volume should have. If RecoverVolumeExpansionFailure feature
+                          is enabled users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher
+                          than capacity recorded in the status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'storageClassName is the name of the StorageClass
+                          required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  status:
+                    description: 'status represents the current information/status
+                      of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    properties:
+                      accessModes:
+                        description: 'accessModes contains the actual access modes
+                          the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      allocatedResources:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: allocatedResources is the storage resource within
+                          AllocatedResources tracks the capacity allocated to a PVC.
+                          It may be larger than the actual capacity when a volume
+                          expansion operation is requested. For storage quota, the
+                          larger value from allocatedResources and PVC.spec.resources
+                          is used. If allocatedResources is not set, PVC.spec.resources
+                          alone is used for quota calculation. If a volume expansion
+                          capacity request is lowered, allocatedResources is only
+                          lowered if there are no expansion operations in progress
+                          and if the actual volume capacity is equal or lower than
+                          the requested capacity. This is an alpha field and requires
+                          enabling RecoverVolumeExpansionFailure feature.
+                        type: object
+                      capacity:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: capacity represents the actual resources of the
+                          underlying volume.
+                        type: object
+                      conditions:
+                        description: conditions is the current Condition of persistent
+                          volume claim. If underlying persistent volume is being resized
+                          then the Condition will be set to 'ResizeStarted'.
+                        items:
+                          description: PersistentVolumeClaimCondition contails details
+                            about state of pvc
+                          properties:
+                            lastProbeTime:
+                              description: lastProbeTime is the time we probed the
+                                condition.
+                              format: date-time
+                              type: string
+                            lastTransitionTime:
+                              description: lastTransitionTime is the time the condition
+                                transitioned from one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is the human-readable message indicating
+                                details about last transition.
+                              type: string
+                            reason:
+                              description: reason is a unique, this should be a short,
+                                machine understandable string that gives the reason
+                                for condition's last transition. If it reports "ResizeStarted"
+                                that means the underlying persistent volume is being
+                                resized.
+                              type: string
+                            status:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
+                      phase:
+                        description: |-
+                          phase represents the current phase of PersistentVolumeClaim.
+
+                          Possible enum values:
+                           - `"Bound"` used for PersistentVolumeClaims that are bound
+                           - `"Lost"` used for PersistentVolumeClaims that lost their underlying PersistentVolume. The claim was bound to a PersistentVolume and this volume does not exist any longer and all data on it was lost.
+                           - `"Pending"` used for PersistentVolumeClaims that are not yet bound
+                        type: string
+                      resizeStatus:
+                        description: resizeStatus stores status of resize operation.
+                          ResizeStatus is not set by default but when expansion is
+                          complete resizeStatus is set to empty string by resize controller
+                          or kubelet. This is an alpha field and requires enabling
+                          RecoverVolumeExpansionFailure feature.
+                        type: string
+                    type: object
+                type: object
+              type: array
+          required:
+          - selector
+          - template
+          - serviceName
+          type: object
+        status:
+          description: Status is the current status of Pods in this StatefulSet. This
+            data may be out of date by some window of time.
+          properties:
+            availableReplicas:
+              description: Total number of available pods (ready for at least minReadySeconds)
+                targeted by this statefulset.
+              format: int32
+              type: integer
+            collisionCount:
+              description: collisionCount is the count of hash collisions for the
+                StatefulSet. The StatefulSet controller uses this field as a collision
+                avoidance mechanism when it needs to create the name for the newest
+                ControllerRevision.
+              format: int32
+              type: integer
+            conditions:
+              description: Represents the latest available observations of a statefulset's
+                current state.
+              items:
+                description: StatefulSetCondition describes the state of a statefulset
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of statefulset condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+              - type
+              x-kubernetes-list-type: map
+            currentReplicas:
+              description: currentReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by currentRevision.
+              format: int32
+              type: integer
+            currentRevision:
+              description: currentRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+              type: string
+            observedGeneration:
+              description: observedGeneration is the most recent generation observed
+                for this StatefulSet. It corresponds to the StatefulSet's generation,
+                which is updated on mutation by the API Server.
+              format: int64
+              type: integer
+            readyReplicas:
+              description: readyReplicas is the number of pods created for this StatefulSet
+                with a Ready Condition.
+              format: int32
+              type: integer
+            replicas:
+              description: replicas is the number of Pods created by the StatefulSet
+                controller.
+              format: int32
+              type: integer
+            updateRevision:
+              description: updateRevision, if not empty, indicates the version of
+                the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+              type: string
+            updatedReplicas:
+              description: updatedReplicas is the number of Pods created by the StatefulSet
+                controller from the StatefulSet version indicated by updateRevision.
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-post-kcp.md
@@ -90,12 +90,20 @@ spec:
 That script also deletes the Location named `default`, which is not
 used in this PoC, if it shows up.
 
-### Create the edge service provider workspace
+### Initialize the KubeStellar platform
 
-Use the following commands.
+In this step KubeStellar creates and populates the Edge Service
+Provider Workspace (ESPW), which exports the KubeStellar API, and also
+augments the `root:compute` workspace from kcp TMC as needed here.
+Those augmentation consists of adding authorization to update the
+relevant `/status` and `/scale` subresources (missing in kcp TMC) and
+extending the supported subset of the Kubernetes API for managing
+containerized workloads from the four resources built into kcp TMC
+(`Deployment`, `Pod`, `Service`, and `Ingress`) to the other ones that
+are namespaced and are meaningful in KubeStellar.
 
 ```shell
-kubectl ws root
-kubectl ws create espw --enter
+kubestellar init
 ```
+
 <!--example1-post-kcp-end-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -1,15 +1,4 @@
 <!--example1-stage-1a-start-->
-### Populate the edge service provider workspace
-
-This puts the definition and export of the KubeStellar API in the edge
-service provider workspace.
-
-Use the following command.
-
-```shell
-kubectl apply -f config/exports
-```
-
 ### The mailbox controller
 
 Running the mailbox controller will be conveniently automated.

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-2.md
@@ -98,7 +98,7 @@ replacements:
   value: '"env is %(env)"'
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: ReplicaSet
 metadata:
   namespace: commonstuff
   name: commond
@@ -155,7 +155,7 @@ spec:
   nonNamespacedObjects:
   - apiGroup: apis.kcp.io
     resources: [ "apibindings" ]
-    resourceNames: [ "bind-kube" ]
+    resourceNames: [ "bind-kubernetes", "bind-apps" ]
   upsync:
   - apiGroup: "group1.test"
     resources: ["sprockets", "flanges"]
@@ -276,7 +276,7 @@ spec:
   nonNamespacedObjects:
   - apiGroup: apis.kcp.io
     resources: [ "apibindings" ]
-    resourceNames: [ "bind-kube" ]
+    resourceNames: [ "bind-kubernetes" ]
   upsync:
   - apiGroup: "group1.test"
     resources: ["sprockets", "flanges"]

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-3.md
@@ -62,41 +62,83 @@ spec:
     - commonstuff
     resources:
     - apiVersion: v1
-      group: networking.k8s.io
-      resource: ingresses
-    - apiVersion: v1
-      group: rbac.authorization.k8s.io
-      resource: roles
-    - apiVersion: v1
-      group: ""
-      resource: configmaps
-    - apiVersion: v1
-      group: ""
-      resource: limitranges
-    - apiVersion: v1
       group: ""
       resource: secrets
     - apiVersion: v1
       group: rbac.authorization.k8s.io
-      resource: rolebindings
+      resource: roles
     - apiVersion: v1
-      group: apps
-      resource: deployments
-    - apiVersion: v1
-      group: ""
-      resource: pods
+      group: batch
+      resource: jobs
     - apiVersion: v1
       group: ""
       resource: serviceaccounts
     - apiVersion: v1
       group: ""
-      resource: services
+      resource: limitranges
+    - apiVersion: v1
+      group: apps
+      resource: daemonsets
+    - apiVersion: v1
+      group: storage.k8s.io
+      resource: csistoragecapacities
+    - apiVersion: v1
+      group: rbac.authorization.k8s.io
+      resource: rolebindings
+    - apiVersion: v1
+      group: ""
+      resource: pods
     - apiVersion: v1
       group: ""
       resource: resourcequotas
     - apiVersion: v1
+      group: discovery.k8s.io
+      resource: endpointslices
+    - apiVersion: v1
+      group: ""
+      resource: replicationcontrollers
+    - apiVersion: v1
+      group: networking.k8s.io
+      resource: ingresses
+    - apiVersion: v1
+      group: ""
+      resource: services
+    - apiVersion: v1
+      group: apps
+      resource: deployments
+    - apiVersion: v1
+      group: ""
+      resource: persistentvolumeclaims
+    - apiVersion: v1
       group: coordination.k8s.io
       resource: leases
+    - apiVersion: v1
+      group: policy
+      resource: poddisruptionbudgets
+    - apiVersion: v1
+      group: apps
+      resource: statefulsets
+    - apiVersion: v1
+      group: networking.k8s.io
+      resource: networkpolicies
+    - apiVersion: v1
+      group: batch
+      resource: cronjobs
+    - apiVersion: v1
+      group: ""
+      resource: endpoints
+    - apiVersion: v2
+      group: autoscaling
+      resource: horizontalpodautoscalers
+    - apiVersion: v1
+      group: apps
+      resource: replicasets
+    - apiVersion: v1
+      group: ""
+      resource: configmaps
+    - apiVersion: v1
+      group: ""
+      resource: podtemplates
   upsync:
   - apiGroup: group1.test
     names:
@@ -127,11 +169,11 @@ default       Active   32m
 ```
 
 ```shell
-kubectl get deployments -A
+kubectl get replicasets -A
 ```
 ``` { .bash .no-copy }
-NAMESPACE     NAME      READY   UP-TO-DATE   AVAILABLE   AGE
-commonstuff   commond   0/0     0            0           6m44s
+NAMESPACE     NAME      DESIRED   CURRENT   READY   AGE
+commonstuff   commond   0         1         1       10m
 ```
 
 The guilder cluster gets both the common and special workloads.
@@ -173,41 +215,83 @@ spec:
     - specialstuff
     resources:
     - apiVersion: v1
+      group: apps
+      resource: replicasets
+    - apiVersion: v1
+      group: storage.k8s.io
+      resource: csistoragecapacities
+    - apiVersion: v1
+      group: networking.k8s.io
+      resource: networkpolicies
+    - apiVersion: v1
+      group: apps
+      resource: daemonsets
+    - apiVersion: v1
       group: ""
       resource: services
     - apiVersion: v1
-      group: apps
-      resource: deployments
-    - apiVersion: v1
       group: ""
-      resource: pods
-    - apiVersion: v1
-      group: coordination.k8s.io
-      resource: leases
+      resource: replicationcontrollers
     - apiVersion: v1
       group: networking.k8s.io
       resource: ingresses
+    - apiVersion: v2
+      group: autoscaling
+      resource: horizontalpodautoscalers
     - apiVersion: v1
-      group: ""
-      resource: limitranges
-    - apiVersion: v1
-      group: ""
-      resource: serviceaccounts
-    - apiVersion: v1
-      group: rbac.authorization.k8s.io
-      resource: rolebindings
-    - apiVersion: v1
-      group: ""
-      resource: configmaps
-    - apiVersion: v1
-      group: ""
-      resource: secrets
+      group: policy
+      resource: poddisruptionbudgets
     - apiVersion: v1
       group: rbac.authorization.k8s.io
       resource: roles
     - apiVersion: v1
       group: ""
+      resource: serviceaccounts
+    - apiVersion: v1
+      group: batch
+      resource: jobs
+    - apiVersion: v1
+      group: batch
+      resource: cronjobs
+    - apiVersion: v1
+      group: ""
+      resource: persistentvolumeclaims
+    - apiVersion: v1
+      group: apps
+      resource: deployments
+    - apiVersion: v1
+      group: rbac.authorization.k8s.io
+      resource: rolebindings
+    - apiVersion: v1
+      group: apps
+      resource: statefulsets
+    - apiVersion: v1
+      group: ""
+      resource: configmaps
+    - apiVersion: v1
+      group: ""
+      resource: podtemplates
+    - apiVersion: v1
+      group: ""
       resource: resourcequotas
+    - apiVersion: v1
+      group: coordination.k8s.io
+      resource: leases
+    - apiVersion: v1
+      group: ""
+      resource: endpoints
+    - apiVersion: v1
+      group: discovery.k8s.io
+      resource: endpointslices
+    - apiVersion: v1
+      group: ""
+      resource: secrets
+    - apiVersion: v1
+      group: ""
+      resource: limitranges
+    - apiVersion: v1
+      group: ""
+      resource: pods
   upsync:
   - apiGroup: group3.test
     names:
@@ -232,11 +316,13 @@ status: {}
 ```
 
 ```shell
-kubectl get deployments -A
+kubectl get deployments,replicasets -A
 ```
 ``` { .bash .no-copy }
-NAMESPACE      NAME       READY   UP-TO-DATE   AVAILABLE   AGE
-commonstuff    commond    0/0     0            0           6m1s
-specialstuff   speciald   0/0     0            0           5m58s
+NAMESPACE      NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+specialstuff   deployment.apps/speciald   0/0     1            0           12m
+
+NAMESPACE     NAME                      DESIRED   CURRENT   READY   AGE
+commonstuff   replicaset.apps/commond   0         1         1       7m4s
 ```
 <!--example1-stage-3-stop-->

--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-4.md
@@ -36,11 +36,12 @@ local-path-storage                   Active   57m
 ```
 
 ```shell
-KUBECONFIG=~/.kube/config kubectl --context kind-florin get deploy -A | egrep 'NAME|stuff'
+KUBECONFIG=~/.kube/config kubectl --context kind-florin get deploy,rs -A | egrep 'NAME|stuff'
 ```
 ``` { .bash .no-copy }
-NAMESPACE                         NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
-commonstuff                       commond                           1/1     1            1           7m59s
+NAMESPACE                            NAME                                                 READY   UP-TO-DATE   AVAILABLE   AGE
+NAMESPACE                            NAME                                                            DESIRED   CURRENT   READY   AGE
+commonstuff                          replicaset.apps/commond                                         1         1         1       13m
 ```
 
 Examine the guilder cluster.  Find both workload namespaces and both
@@ -56,19 +57,21 @@ specialstuff                       Active   8m33s
 ```
 
 ```shell
-KUBECONFIG=~/.kube/config kubectl --context kind-guilder get deploy -A | egrep NAME\|stuff
+KUBECONFIG=~/.kube/config kubectl --context kind-guilder get deploy,rs -A | egrep NAME\|stuff
 ```
 ``` { .bash .no-copy }
-NAMESPACE                          NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
-commonstuff                        commond                            1/1     1            1           8m37s
-specialstuff                       speciald                           1/1     1            1           8m55s
+NAMESPACE                             NAME                                                  READY   UP-TO-DATE   AVAILABLE   AGE
+specialstuff                          deployment.apps/speciald                              1/1     1            1           23m
+NAMESPACE                             NAME                                                            DESIRED   CURRENT   READY   AGE
+commonstuff                           replicaset.apps/commond                                         1         1         1       23m
+specialstuff                          replicaset.apps/speciald-76cdbb69b5                             1         1         1       14s
 ```
 
 Examining the common workload in the guilder cluster, for example,
 will show that the replacement-style customization happened.
 
 ```shell
-KUBECONFIG=~/.kube/config kubectl --context kind-guilder get deploy -n commonstuff commond -o yaml
+KUBECONFIG=~/.kube/config kubectl --context kind-guilder get rs -n commonstuff commond -o yaml
 ```
 ``` { .bash .no-copy }
 ...

--- a/scripts/kubectl-kubestellar-ensure-wmw
+++ b/scripts/kubectl-kubestellar-ensure-wmw
@@ -100,18 +100,32 @@ spec:
 EOF
 fi
 
-if [ "$want_kube" == true ] && ! kubectl "${kubectl_flags[@]}" get APIBinding bind-kube &> /dev/null; then
+function bind_iff_wanted() { # usage: export_name
+    export_name=$1
+    binding_name=bind-$export_name
+    if [ "$want_kube" == true ] && ! kubectl "${kubectl_flags[@]}" get APIBinding ${binding_name} &> /dev/null; then
 kubectl "${kubectl_flags[@]}" apply -f - <<EOF
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIBinding
 metadata:
-  name: bind-kube
+  name: ${binding_name}
 spec:
   reference:
     export:
       path: root:compute
-      name: kubernetes
+      name: ${export_name}
 EOF
-elif [ "$want_kube" == false ] && kubectl "${kubectl_flags[@]}" get APIBinding bind-kube &> /dev/null; then
-     kubectl "${kubectl_flags[@]}" delete APIBinding bind-kube
+elif [ "$want_kube" == false ] && kubectl "${kubectl_flags[@]}" get APIBinding ${binding_name} &> /dev/null; then
+     kubectl "${kubectl_flags[@]}" delete APIBinding ${binding_name}
 fi
+}
+
+bind_iff_wanted kubernetes
+bind_iff_wanted apps
+bind_iff_wanted autoscaling
+bind_iff_wanted batch
+bind_iff_wanted core.k8s.io
+bind_iff_wanted discovery.k8s.io
+bind_iff_wanted networking.k8s.io
+bind_iff_wanted policy
+bind_iff_wanted storage.k8s.io

--- a/scripts/kubestellar
+++ b/scripts/kubestellar
@@ -88,10 +88,50 @@ then
     exit 1
 fi
 
+function create_or_replace() { # usage: filename
+    filename="$1"
+    kind=$(grep kind: "$filename" | head -1 | awk '{ print $2 }')
+    name=$(grep name: "$filename" | head -1 | awk '{ print $2 }')
+    if kubectl get "$kind" "$name" &> /dev/null
+    then eval kubectl replace -f "$filename" $verbdir
+    else eval kubectl create -f "$filename" $verbdir
+    fi
+}
+    
 # current ws at start does not matter, is root:compute on return
-function ensure_compute_status_updateable() {
+function ensure_root_compute_configd() {
     kubectl ws root:compute &> /dev/null
-    kubectl apply -f - &> /dev/null <<EOF
+    ( cd ${SCRIPT_DIR}/../config/kube/exports/namespaced
+      # Some are too big to `kubectl apply`
+      for rsfn in apiresourceschema-*.yaml; do
+	  create_or_replace $rsfn
+      done
+      for refn in apiexport-*.yaml; do
+	  eval kubectl apply -f "$refn" $verbdir
+      done
+    )
+    eval kubectl apply -f - $verbdir <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute:apiexport:kubernetes-extended:bind
+rules:
+- apiGroups:
+  - apis.kcp.io
+  resourceNames:
+  - apps
+  - autoscaling
+  - batch
+  - core.k8s.io
+  - discovery.k8s.io
+  - networking.k8s.io
+  - policy
+  - storage.k8s.io
+  resources:
+  - apiexports
+  verbs:
+  - bind
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -101,17 +141,89 @@ rules:
   - ""
   - apps
   - networking.k8s.io
+
+  - autoscaling
+  - batch
+  - discovery.k8s.io
+  - policy
+  - storage.k8s.io
+  resources:
+  - services
+  - pods
+  - ingresses
+  - deployments
+
+  - cronjobs
+  - csistoragecapacities
+  - daemonsets
+  - endpoints
+  - endpointslices
+  - horizontalpodautoscalers
+  - jobs
+  - networkpolicies
+  - persistentvolumeclaims
+  - poddisruptionbudgets
+  - podtemplates
+  - replicasets
+  - replicationcontrollers
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  - apps
+  - networking.k8s.io
+
+  - autoscaling
+  - batch
+  - discovery.k8s.io
+  - policy
+  - storage.k8s.io
   resources:
   - services/status
   - pods/status
   - ingresses/status
   - deployments/status
   - deployments/scale
+
+  - cronjobs/status
+  - csistoragecapacities/status
+  - daemonsets/status
+  - endpoints/status
+  - endpointslices/status
+  - horizontalpodautoscalers/status
+  - jobs/status
+  - networkpolicies/status
+  - persistentvolumeclaims/status
+  - poddisruptionbudgets/status
+  - podtemplates/status
+  - replicasets/scale
+  - replicasets/status
+  - replicationcontrollers/scale
+  - replicationcontrollers/status
+  - statefulsets/scale
+  - statefulsets/status
   verbs:
+  - get
+  - list
+  - watch
   - update
   - patch
 EOF
     kubectl apply -f - &> /dev/null <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute:apiexport:kubernetes-extended:bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute:apiexport:kubernetes-extended:bind
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: apis.kcp.io:binding:system:authenticated
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -125,6 +237,7 @@ subjects:
   kind: Group
   name: apis.kcp.io:binding:system:authenticated
 EOF
+    echo "Finished augmenting root:compute for KubeStellar"
 }
 
 # current ws at start does not matter, is ESPW on return
@@ -141,7 +254,7 @@ function ensure_espw() {
 }
 
 if [ "$subcommand" == init ]; then
-    ensure_compute_status_updateable
+    ensure_root_compute_configd
     ensure_espw
     exit
 fi
@@ -172,7 +285,7 @@ if [ $subcommand == stop ]; then
    exit 0
 fi
 
-ensure_compute_status_updateable
+ensure_root_compute_configd
 ensure_espw
 
 wait_for_process(){


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR does the following.
1. Makes `kubestellar init` extend the `root:compute` workspace with additional APIExports that cover the namespaced resources not already exported by kcp-dev/kcp and additional RBAC contents to make those additional APIExports usable.
3. Makes `kubectl kubestellar ensure wmw --with-kube` install corresponding APIBinding objects.

This PR also updates example1 to exercise the new functionality, using a ReplicaSet object instead of a Deployment object in the common workload.  This PR also updates example1 to use `kubestellar init` because that now does a lot more than just create one workspace and do one `kubectl apply`.

Not exporting the cluster-scoped part yet, not sure about ability to support it in the future.

The CRDs and APIExports were produced as follows.

The resources were pulled from a `kind` cluster running Kubernetes release 1.25.2.

These were produced by the following bashery.

The following function converts a `kubectl api-resources` listing into a listing of arguments to the kcp crd-puller.

```bash
function rejigger() {
    if [[ $# -eq 4 ]]
    then gv="$2"
    else gv="$3"
    fi

    case "$gv" in
	(*/*) group=.$(echo "$gv" | cut -f1 -d/) ;;
	(*)   group=""
    esac

    echo "${1}$group"
}
```

With `kubectl` configured to manipulate a kcp workspace, the following command captures the listing of resources built into that kcp workspace.

```bash
kubectl api-resources | grep -v APIVERSION | while read line; do rejigger $line; done > /tmp/kcp-rgs.txt
```

With `kubectl` configured to manipulate a kind cluster, the following commands capture the resource listing split into namespaced and cluster-scoped.

```bash
kubectl api-resources | grep -v APIVERSION | grep -w true | while read line; do rejigger $line; done > /tmp/kind-ns-rgs.txt
kubectl api-resources | grep -v APIVERSION | grep -w false | while read line; do rejigger $line; done > /tmp/kind-cs-rgs.txt
```

With CWD=config/kube/exports/namespaced,

```bash
crd-puller --kubeconfig $KUBECONFIG $(grep -v -f /tmp/kcp-rgs.txt /tmp/kind-ns-rgs.txt)
```

With CWD=config/kube/exports/cluster-scoped,

```bash
crd-puller --kubeconfig $KUBECONFIG $(grep -v -f /tmp/kcp-rgs.txt /tmp/kind-cs-rgs.txt)
```

I manually deleted the four CRDs from https://github.com/kcp-dev/kcp/tree/v0.11.0/config/rootcompute/kube-1.24 .

Sadly, https://github.com/kubernetes/kubernetes/issues/118698 is a thing.
So I manually hacked the CRD for jobs.

Sadly, the filenames produced by the crd-puller are not loved by apigen.  The following function renames one file as needed.

```bash
function fixname() {
    rg=${1%%.yaml}
    case $rg in
	(*.*)
	    g=$(echo $rg | cut -d. -f2-)
	    r=$(echo $rg | cut -d. -f1);;
	(*)
	    g=core.k8s.io
	    r=$rg;;
    esac
    mv ${rg}.yaml ${g}_${r}.yaml
}
```

In each of those CRD directories,

```bash
for fn in *.yaml; do fixname $fn; done
```

Penultimately, with CWD=config/kube,

```bash
../../hack/tools/apigen --input-dir crds/namespaced --output-dir exports/namespaced
../../hack/tools/apigen --input-dir crds/cluster-scoped --output-dir exports/cluster-scoped
```
Finally, https://github.com/kubernetes/enhancements/pull/1111 applies
to APIExport/APIBinding as well as to CRDs.  And the CRD puller does
not know anything about this (not that it would help?).  I manually
hacked the namespaced APIResource files that needed it to have an
`api-approved.kubernetes.io` annotation.  It turns out that the
checking in the apiserver only requires that the annotation's value
parse as a URL (any URL will do).

## Related issue(s)

This addresses part of #522 --- the part for namespaced resources, but not cluster-scoped ones.

/cc @waltforme 
/cc @ezrasilvera 
