### PR TITLE
📖 Fix typo in example1

### DIFF
--- a/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
+++ b/docs/content/Coding Milestones/PoC2023q1/example1-subs/example1-stage-1a.md
@@ -7,7 +7,7 @@ service provider workspace.
 Use the following command.
 
 ```shell
-kubectl create -f config/exports
+kubectl apply -f config/exports
 ```
 
 ### The mailbox controller


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR fixes a typo in the example1 recipe.  It should say `kubectl apply` rather than `kubectl create`.

## Related issue(s)

Fixes #
