### PR TITLE
:bug: Fix to set correct UID and resource version when syncing updated objects and do not downsync upsynced objects

### DIFF
--- a/pkg/syncer/syncers/common.go
+++ b/pkg/syncer/syncers/common.go
@@ -178,13 +178,15 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 	for _, srcResource := range srcResourceList.Items {
 		destResource, ok := findWithObject(srcResource, destResourceList)
 		if ok {
-			srcResource.SetResourceVersion("")
-			srcResource.SetUID("")
+			srcResource.SetResourceVersion(destResource.GetResourceVersion())
+			srcResource.SetUID(destResource.GetUID())
 			srcResource.SetManagedFields(nil)
 			if hasAnnotation(destResource) {
 				setAnnotation(&srcResource)
+				updatedResources = append(updatedResources, srcResource)
+			} else {
+				logger.V(2).Info(fmt.Sprintf("  ignore adding %s to updatedResources since annotation is not set.", destResource.GetName()))
 			}
-			updatedResources = append(updatedResources, srcResource)
 		} else {
 			srcResource.SetResourceVersion("")
 			srcResource.SetUID("")
@@ -199,7 +201,7 @@ func diff(logger klog.Logger, srcResourceList *unstructured.UnstructuredList, de
 				logger.V(3).Info(fmt.Sprintf("  %s is added to deletedResources since annotation is set.", destResource.GetName()))
 				deletedResources = append(deletedResources, destResource)
 			} else {
-				logger.V(3).Info(fmt.Sprintf("  %s is not added to deletedResources since annotation is not set.", destResource.GetName()))
+				logger.V(2).Info(fmt.Sprintf("  ignore adding %s to deletedResources since annotation is not set.", destResource.GetName()))
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

As reported in #625, there is a bug that upsynced objects are not updated. I fixed the bug and made sure that it addressed the issue with the issue opener (Tayebeh).   

What 's the changes
- Fix to set UID and Resource Version of the target k8s cluster's one when downsyncer/upsyncer push updated objects from upstream/downstream 
- Fix not to downsync upsynced objects (exactly saying not downsync objects having `edge.kcp.io/upsynced` annotation) and similarly not to upsync downsynced objects (`edge.kcp.io/downsynced` annotation) 
- Update tests

## Related issue(s)

Fixes #625
